### PR TITLE
feat(doctor): diagnose broken installs behind "not found on PATH"

### DIFF
--- a/.changeset/broken-install-advisory.md
+++ b/.changeset/broken-install-advisory.md
@@ -1,0 +1,6 @@
+---
+"@claudexor/core": patch
+"@claudexor/harness-codex": patch
+---
+
+Doctor and discover now explain WHY a vendor CLI failed to resolve when the filesystem still holds evidence of an install: a dangling Homebrew symlink, a stripped exec bit, a directory shadowing the name, or a Caskroom/Cellar registration whose payload vanished — each with the exact `brew reinstall [--cask]` remediation. Diagnostic only: never gates a run, never executes a package manager. The codex doctor probes and diagnoses in the same scoped environment.

--- a/.changeset/broken-install-advisory.md
+++ b/.changeset/broken-install-advisory.md
@@ -3,4 +3,4 @@
 "@claudexor/harness-codex": patch
 ---
 
-Doctor and discover now explain WHY a vendor CLI failed to resolve when the filesystem still holds evidence of an install: a dangling Homebrew symlink, a stripped exec bit, a directory shadowing the name, or a Caskroom/Cellar registration whose payload vanished — each with the exact `brew reinstall [--cask]` remediation. Diagnostic only: never gates a run, never executes a package manager. The codex doctor probes and diagnoses in the same scoped environment.
+Doctor and discover now explain WHY the codex CLI failed to resolve when the filesystem still holds evidence of an install: a dangling Homebrew symlink, a stripped exec bit, a directory shadowing the name, or a Caskroom/Cellar registration whose payload vanished — each with the exact `brew reinstall [--cask]` remediation. Diagnostic only: never gates a run, never executes a package manager. The codex doctor probes and diagnoses in the same scoped environment.

--- a/packages/core/src/runtime-env.test.ts
+++ b/packages/core/src/runtime-env.test.ts
@@ -1,8 +1,12 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { normalizedHarnessPath, resolveHarnessBinary } from "./runtime-env.js";
+import {
+  brokenInstallAdvisory,
+  normalizedHarnessPath,
+  resolveHarnessBinary,
+} from "./runtime-env.js";
 
 describe("resolveHarnessBinary", () => {
   let root: string;
@@ -65,6 +69,73 @@ describe("resolveHarnessBinary", () => {
     mkdirSync(a, { recursive: true });
     const env = { HOME: home, PATH: [a, b].join(delimiter) } as NodeJS.ProcessEnv;
     expect(resolveHarnessBinary("tool-b", env)).toBe(target);
+  });
+
+  it("brokenInstallAdvisory returns null when the binary resolves or nothing is on disk", () => {
+    const home = join(root, "adv-home");
+    const binDir = join(root, "adv-bin");
+    fakeBin(binDir, "tool-ok");
+    const env = { HOME: home, PATH: binDir } as NodeJS.ProcessEnv;
+    expect(brokenInstallAdvisory("tool-ok", env, [])).toBeNull();
+    expect(brokenInstallAdvisory("tool-never-installed", env, [])).toBeNull();
+  });
+
+  it("brokenInstallAdvisory names a dangling Caskroom symlink and prescribes brew reinstall --cask", () => {
+    if (process.platform === "win32") return;
+    // The live incident: Caskroom payload purged, /opt/homebrew/bin symlink left dangling.
+    const home = join(root, "adv-home2");
+    const prefix = join(root, "adv-brew");
+    const binDir = join(prefix, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const link = join(binDir, "tool-e");
+    symlinkSync(join(prefix, "Caskroom", "tool-e", "1.0", "tool-e"), link);
+    const env = { HOME: home, PATH: binDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory("tool-e", env, [prefix]);
+    expect(advisory).toContain(link);
+    expect(advisory).toContain("its target is missing");
+    expect(advisory).toContain("brew reinstall --cask tool-e");
+  });
+
+  it("brokenInstallAdvisory reports a registered-but-empty Caskroom when PATH has no entry at all", () => {
+    // The other half of the live incident: brew still lists the cask as
+    // installed while no bin link exists anywhere on the harness PATH.
+    const home = join(root, "adv-home3");
+    const prefix = join(root, "adv-brew2");
+    const caskDir = join(prefix, "Caskroom", "tool-f");
+    mkdirSync(join(caskDir, "0.106.0"), { recursive: true });
+    const emptyDir = join(root, "adv-empty");
+    mkdirSync(emptyDir, { recursive: true });
+    const env = { HOME: home, PATH: emptyDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory("tool-f", env, [prefix]);
+    expect(advisory).toContain(caskDir);
+    expect(advisory).toContain("brew reinstall --cask tool-f");
+  });
+
+  it("brokenInstallAdvisory distinguishes a Cellar formula (no --cask flag)", () => {
+    const home = join(root, "adv-home4");
+    const prefix = join(root, "adv-brew3");
+    mkdirSync(join(prefix, "Cellar", "tool-g", "2.0"), { recursive: true });
+    const emptyDir = join(root, "adv-empty2");
+    mkdirSync(emptyDir, { recursive: true });
+    const env = { HOME: home, PATH: emptyDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory("tool-g", env, [prefix]);
+    expect(advisory).toContain("brew reinstall tool-g");
+    expect(advisory).not.toContain("--cask");
+  });
+
+  it("brokenInstallAdvisory explains a non-executable file outside Homebrew generically", () => {
+    if (process.platform === "win32") return;
+    const home = join(root, "adv-home5");
+    const binDir = join(root, "adv-bin5");
+    mkdirSync(binDir, { recursive: true });
+    const stripped = join(binDir, "tool-h");
+    writeFileSync(stripped, "#!/bin/sh\nexit 0\n");
+    chmodSync(stripped, 0o644);
+    const env = { HOME: home, PATH: binDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory("tool-h", env, []);
+    expect(advisory).toContain(stripped);
+    expect(advisory).toContain("it is not executable");
+    expect(advisory).toContain("reinstall tool-h");
   });
 
   it("skips non-executable files and directories shadowing the name (spawn-faithful)", () => {

--- a/packages/core/src/runtime-env.test.ts
+++ b/packages/core/src/runtime-env.test.ts
@@ -138,6 +138,38 @@ describe("resolveHarnessBinary", () => {
     expect(advisory).toContain("reinstall tool-h");
   });
 
+  it("brokenInstallAdvisory never emits a brew command for a shell-unsafe basename", () => {
+    if (process.platform === "win32") return;
+    // A configured override like CLAUDEXOR_CODEX_BIN with metacharacters in
+    // its basename must not turn into a pasteable `brew reinstall $(...)`.
+    const home = join(root, "adv-home6");
+    const prefix = join(root, "adv-brew6");
+    const binDir = join(prefix, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const evil = "tool-i;$(rm x)";
+    symlinkSync(join(prefix, "Caskroom", evil, "1.0", evil), join(binDir, evil));
+    const env = { HOME: home, PATH: binDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory(evil, env, [prefix]);
+    expect(advisory).toContain("its target is missing");
+    expect(advisory).not.toContain("brew reinstall");
+    expect(advisory).toContain("point the binary override at a working install");
+  });
+
+  it("brokenInstallAdvisory names the missing absolute override instead of claiming a PATH sweep", () => {
+    const home = join(root, "adv-home7");
+    const prefix = join(root, "adv-brew7");
+    mkdirSync(join(prefix, "Caskroom", "tool-j", "2.0"), { recursive: true });
+    const emptyDir = join(root, "adv-empty7");
+    mkdirSync(emptyDir, { recursive: true });
+    const override = join(root, "adv-missing", "tool-j");
+    const env = { HOME: home, PATH: emptyDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory(override, env, [prefix]);
+    expect(advisory).toContain(`the configured override ${override} does not exist`);
+    expect(advisory).not.toContain("no runnable binary is on the harness PATH");
+    expect(advisory).toContain("brew reinstall --cask tool-j");
+    expect(advisory).toContain("or fix the binary override");
+  });
+
   it("skips non-executable files and directories shadowing the name (spawn-faithful)", () => {
     const home = join(root, "home4");
     const shadowDir = join(root, "shadow");

--- a/packages/core/src/runtime-env.test.ts
+++ b/packages/core/src/runtime-env.test.ts
@@ -155,6 +155,24 @@ describe("resolveHarnessBinary", () => {
     expect(advisory).toContain("point the binary override at a working install");
   });
 
+  it("brokenInstallAdvisory recommends the brew PACKAGE token, not the binary basename", () => {
+    if (process.platform === "win32") return;
+    // A package can ship a binary under a different name; `brew reinstall`
+    // must name the package (the Caskroom/Cellar path segment).
+    const home = join(root, "adv-home8");
+    const prefix = join(root, "adv-brew8");
+    const binDir = join(prefix, "bin");
+    mkdirSync(binDir, { recursive: true });
+    symlinkSync(
+      join(prefix, "Caskroom", "vendor-package", "1.0", "tool-k"),
+      join(binDir, "tool-k"),
+    );
+    const env = { HOME: home, PATH: binDir } as NodeJS.ProcessEnv;
+    const advisory = brokenInstallAdvisory("tool-k", env, [prefix]);
+    expect(advisory).toContain("brew reinstall --cask vendor-package");
+    expect(advisory).not.toContain("--cask tool-k");
+  });
+
   it("brokenInstallAdvisory names the missing absolute override instead of claiming a PATH sweep", () => {
     const home = join(root, "adv-home7");
     const prefix = join(root, "adv-brew7");

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -123,7 +123,7 @@ export function brokenInstallAdvisory(
           ? "it is a directory, not a binary"
           : "it is not executable";
     const fix =
-      brewRemediation(target ?? candidate, name) ??
+      brewRemediation(target ?? candidate) ??
       `reinstall ${name} or point the binary override at a working install`;
     return `${where} exists but ${how} — ${fix}`;
   }
@@ -169,11 +169,23 @@ function readlinkOrNull(path: string): string | null {
  *  quotes, or shell metacharacters must never become a pasteable command. */
 const SAFE_BREW_NAME = /^[A-Za-z0-9][A-Za-z0-9@+._-]*$/;
 
+/** The brew package token is the path segment AFTER Caskroom/Cellar — a
+ *  binary's name can differ from the package that ships it, and the
+ *  remediation must name the package. */
+function brewToken(pathish: string, room: "Caskroom" | "Cellar"): string | null {
+  const marker = `/${room}/`;
+  const idx = pathish.indexOf(marker);
+  if (idx === -1) return null;
+  const token = pathish.slice(idx + marker.length).split("/")[0] ?? "";
+  return SAFE_BREW_NAME.test(token) ? token : null;
+}
+
 /** Attribute a broken entry to Homebrew via its canonical payload dirs. */
-function brewRemediation(pathish: string, name: string): string | null {
-  if (!SAFE_BREW_NAME.test(name)) return null;
-  if (pathish.includes("/Caskroom/")) return `run \`brew reinstall --cask ${name}\``;
-  if (pathish.includes("/Cellar/")) return `run \`brew reinstall ${name}\``;
+function brewRemediation(pathish: string): string | null {
+  const cask = brewToken(pathish, "Caskroom");
+  if (cask) return `run \`brew reinstall --cask ${cask}\``;
+  const formula = brewToken(pathish, "Cellar");
+  if (formula) return `run \`brew reinstall ${formula}\``;
   return null;
 }
 

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -1,5 +1,6 @@
+import { existsSync, lstatSync, readlinkSync } from "node:fs";
 import { homedir } from "node:os";
-import { delimiter, isAbsolute, join } from "node:path";
+import { basename, delimiter, isAbsolute, join } from "node:path";
 import { isLaunchableExecutable } from "./executable-inspection.js";
 
 /**
@@ -74,6 +75,94 @@ function binaryNameCandidates(bin: string, source: NodeJS.ProcessEnv): string[] 
   const lower = bin.toLowerCase();
   if (exts.some((e) => lower.endsWith(e.toLowerCase()))) return [bin];
   return [bin, ...exts.map((e) => bin + e)];
+}
+
+const HOMEBREW_PREFIXES = ["/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew"];
+
+/**
+ * Advisory explaining WHY a harness binary failed to resolve when the
+ * filesystem still holds evidence of an install. The live incident this
+ * guards: Homebrew's codex cask stayed registered (Caskroom dir present,
+ * version pinned) while its payload and bin link had vanished, so every
+ * surface dead-ended at "not found on PATH"/ENOENT with no path to repair.
+ * Two evidence classes, checked in order:
+ *
+ *  1. an entry named like the binary exists on the harness PATH (or at the
+ *     configured absolute override) but is not spawnable — dangling symlink,
+ *     exec bit stripped, or a directory shadowing the name;
+ *  2. nothing is on PATH at all, but a Homebrew Caskroom/Cellar dir still
+ *     lists the binary as installed.
+ *
+ * Diagnostic only (doctor/discover append it); never gates a run and never
+ * executes a package manager. Returns null when the binary resolves or when
+ * there is nothing better to say than "not installed".
+ */
+export function brokenInstallAdvisory(
+  bin: string,
+  source: NodeJS.ProcessEnv = process.env,
+  brewPrefixes: readonly string[] = HOMEBREW_PREFIXES,
+): string | null {
+  if (resolveHarnessBinary(bin, source) !== null) return null;
+  const name = basename(bin);
+  const names = binaryNameCandidates(bin, source);
+  const candidates = isAbsolute(bin)
+    ? names
+    : normalizedHarnessPath(source)
+        .split(delimiter)
+        .filter(Boolean)
+        .flatMap((dir) => names.map((n) => join(dir, n)));
+  for (const candidate of candidates) {
+    const kind = lstatKind(candidate);
+    if (kind === null) continue;
+    const target = kind === "symlink" ? readlinkOrNull(candidate) : null;
+    const where = target === null ? candidate : `${candidate} (symlink to ${target})`;
+    const how =
+      kind === "symlink" && !existsSync(candidate)
+        ? "its target is missing"
+        : kind === "dir"
+          ? "it is a directory, not a binary"
+          : "it is not executable";
+    const fix =
+      brewRemediation(target ?? candidate, name) ??
+      `reinstall ${name} or point the binary override at a working install`;
+    return `${where} exists but ${how} — ${fix}`;
+  }
+  for (const prefix of brewPrefixes) {
+    for (const [room, flag] of [
+      ["Caskroom", " --cask"],
+      ["Cellar", ""],
+    ] as const) {
+      const dir = join(prefix, room, name);
+      if (lstatKind(dir) === "dir") {
+        return `Homebrew still lists ${name} as installed (${dir}) but no runnable binary is on the harness PATH — broken install; run \`brew reinstall${flag} ${name}\``;
+      }
+    }
+  }
+  return null;
+}
+
+function lstatKind(path: string): "symlink" | "dir" | "file" | null {
+  try {
+    const s = lstatSync(path);
+    return s.isSymbolicLink() ? "symlink" : s.isDirectory() ? "dir" : "file";
+  } catch {
+    return null;
+  }
+}
+
+function readlinkOrNull(path: string): string | null {
+  try {
+    return readlinkSync(path);
+  } catch {
+    return null;
+  }
+}
+
+/** Attribute a broken entry to Homebrew via its canonical payload dirs. */
+function brewRemediation(pathish: string, name: string): string | null {
+  if (pathish.includes("/Caskroom/")) return `run \`brew reinstall --cask ${name}\``;
+  if (pathish.includes("/Cellar/")) return `run \`brew reinstall ${name}\``;
+  return null;
 }
 
 /**

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -127,6 +127,7 @@ export function brokenInstallAdvisory(
       `reinstall ${name} or point the binary override at a working install`;
     return `${where} exists but ${how} — ${fix}`;
   }
+  if (!SAFE_BREW_NAME.test(name)) return null;
   for (const prefix of brewPrefixes) {
     for (const [room, flag] of [
       ["Caskroom", " --cask"],
@@ -134,7 +135,12 @@ export function brokenInstallAdvisory(
     ] as const) {
       const dir = join(prefix, room, name);
       if (lstatKind(dir) === "dir") {
-        return `Homebrew still lists ${name} as installed (${dir}) but no runnable binary is on the harness PATH — broken install; run \`brew reinstall${flag} ${name}\``;
+        // An absolute override never scanned PATH, so say what was actually
+        // checked instead of claiming a PATH sweep that did not happen.
+        const evidence = isAbsolute(bin)
+          ? `the configured override ${bin} does not exist`
+          : `no runnable binary is on the harness PATH`;
+        return `Homebrew still lists ${name} as installed (${dir}) but ${evidence} — broken install; run \`brew reinstall${flag} ${name}\`${isAbsolute(bin) ? " or fix the binary override" : ""}`;
       }
     }
   }
@@ -158,8 +164,14 @@ function readlinkOrNull(path: string): string | null {
   }
 }
 
+/** A copyable `brew` command is emitted only for names shaped like real
+ *  Homebrew tokens: a configured override whose basename carries whitespace,
+ *  quotes, or shell metacharacters must never become a pasteable command. */
+const SAFE_BREW_NAME = /^[A-Za-z0-9][A-Za-z0-9@+._-]*$/;
+
 /** Attribute a broken entry to Homebrew via its canonical payload dirs. */
 function brewRemediation(pathish: string, name: string): string | null {
+  if (!SAFE_BREW_NAME.test(name)) return null;
   if (pathish.includes("/Caskroom/")) return `run \`brew reinstall --cask ${name}\``;
   if (pathish.includes("/Cellar/")) return `run \`brew reinstall ${name}\``;
   return null;

--- a/packages/harness-codex/src/auth.test.ts
+++ b/packages/harness-codex/src/auth.test.ts
@@ -23,6 +23,7 @@ import {
   probeLogin,
   selectCodexRunAuthRoute,
 } from "./index.js";
+import { missingCliError, missingCliReport } from "./missing-cli.js";
 
 describe("Codex strict runtime auth routing", () => {
   it("defaults native subscription state under Claudexor, never ordinary ~/.codex", () => {
@@ -622,5 +623,19 @@ describe("Codex missing-CLI diagnosis", () => {
     // the probe that failed.
     expect(probeEnvs).toEqual([{ PATH: "/scoped/bin" }]);
     expect(advisoryPaths).toEqual(["/scoped/bin"]);
+  });
+
+  it("an absolute override is described as a broken override, never as a PATH miss", () => {
+    const report = missingCliReport(null, "/custom/codex");
+    expect(report.checks[0]?.detail).toBe("codex override /custom/codex is not runnable");
+    expect(report.reasons).toEqual([
+      "codex CLI override /custom/codex is not runnable (fix CLAUDEXOR_CODEX_BIN)",
+    ]);
+    expect(JSON.stringify(report)).not.toContain("not found on PATH");
+
+    const error = missingCliError("advisory detail", "/custom/codex");
+    expect(error.message).toBe(
+      "codex CLI override /custom/codex is not runnable (fix CLAUDEXOR_CODEX_BIN) — advisory detail",
+    );
   });
 });

--- a/packages/harness-codex/src/auth.test.ts
+++ b/packages/harness-codex/src/auth.test.ts
@@ -601,4 +601,26 @@ describe("Codex missing-CLI diagnosis", () => {
     });
     await expect(adapter.discover()).rejects.toThrow(ADVISORY);
   });
+
+  it("doctor probes AND diagnoses in the scoped spec env (INV-067 same-env doctrine)", async () => {
+    const probeEnvs: Array<Record<string, string | null | undefined> | undefined> = [];
+    const advisoryPaths: Array<string | undefined> = [];
+    const adapter = createCodexAdapter({
+      detectVersion: async (_signal, env) => {
+        probeEnvs.push(env);
+        return null;
+      },
+      brokenInstallAdvisory: (_bin, source) => {
+        advisoryPaths.push(source?.PATH);
+        return null;
+      },
+    });
+    await adapter.doctor({ cwd: "/repo", env: { PATH: "/scoped/bin" }, fresh: true });
+    // The version probe receives the raw spec patch (runCapture merges it);
+    // the advisory receives the MERGED effective env — both name the same
+    // scoped PATH, so the diagnosis can never describe a different env than
+    // the probe that failed.
+    expect(probeEnvs).toEqual([{ PATH: "/scoped/bin" }]);
+    expect(advisoryPaths).toEqual(["/scoped/bin"]);
+  });
 });

--- a/packages/harness-codex/src/auth.test.ts
+++ b/packages/harness-codex/src/auth.test.ts
@@ -559,3 +559,46 @@ describe("Codex transport-aware native doctor", () => {
     expect(cliOptions?.env?.OPENAI_API_KEY).toBeNull();
   });
 });
+
+describe("Codex missing-CLI diagnosis", () => {
+  const ADVISORY =
+    "Homebrew still lists codex as installed (/opt/homebrew/Caskroom/codex) but no runnable binary is on the harness PATH — broken install; run `brew reinstall --cask codex`";
+
+  it("doctor surfaces the broken-install advisory in the installed check and reasons", async () => {
+    const adapter = createCodexAdapter({
+      detectVersion: async () => null,
+      brokenInstallAdvisory: () => ADVISORY,
+    });
+    const report = await adapter.doctor({ cwd: "/repo", env: {}, fresh: true });
+    expect(report.status).toBe("unavailable");
+    expect(report.checks).toEqual([
+      { id: "installed", status: "fail", detail: `codex not found on PATH — ${ADVISORY}` },
+    ]);
+    expect(report.reasons).toEqual([
+      "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
+      ADVISORY,
+    ]);
+  });
+
+  it("doctor keeps the plain dead-end wording when there is no advisory evidence", async () => {
+    const adapter = createCodexAdapter({
+      detectVersion: async () => null,
+      brokenInstallAdvisory: () => null,
+    });
+    const report = await adapter.doctor({ cwd: "/repo", env: {}, fresh: true });
+    expect(report.checks).toEqual([
+      { id: "installed", status: "fail", detail: "codex not found on PATH" },
+    ]);
+    expect(report.reasons).toEqual([
+      "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
+    ]);
+  });
+
+  it("discover appends the advisory to the unavailable error", async () => {
+    const adapter = createCodexAdapter({
+      detectVersion: async () => null,
+      brokenInstallAdvisory: () => ADVISORY,
+    });
+    await expect(adapter.discover()).rejects.toThrow(ADVISORY);
+  });
+});

--- a/packages/harness-codex/src/index.ts
+++ b/packages/harness-codex/src/index.ts
@@ -23,11 +23,9 @@ import {
   abortSignalFromSpec,
   brokenInstallAdvisory,
   browserMcpCommand,
-  HarnessUnavailableError,
   normalizeEffort,
   providerScrubEnv,
   resolveHarnessBinary,
-  runCapture,
   runCliHarness,
   selectStrictAuthRoute,
   selectedAuthAvailable,
@@ -42,7 +40,8 @@ export { canonicalCodexProfileHome, codexAccountIdentity } from "./profile.js";
 import { estimateCodexCostUsd } from "./pricing.js";
 import { codexImageArgs } from "./attachments.js";
 
-export const BIN = process.env.CLAUDEXOR_CODEX_BIN || "codex";
+import { BIN, detectVersion, missingCliError, missingCliReport, probeEnv } from "./missing-cli.js";
+export { BIN } from "./missing-cli.js";
 
 /**
  * Ordered (weakest→strongest) reasoning-effort levels codex's
@@ -112,20 +111,6 @@ function sandboxArgs(access: AccessProfile): string[] {
       return ["--sandbox", "danger-full-access"];
     case "inherit_native":
       return [];
-  }
-}
-
-async function detectVersion(abortSignal?: AbortSignal): Promise<string | null> {
-  try {
-    const r = await runCapture(BIN, ["--version"], {
-      timeoutMs: 10_000,
-      abortSignal,
-      cancelSignal: "SIGTERM",
-      cancelKillDelayMs: 0,
-    });
-    return r.stdout.trim() || `${BIN} (version unknown)`;
-  } catch {
-    return null;
   }
 }
 
@@ -397,12 +382,7 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
 
     async discover(): Promise<HarnessManifest> {
       const version = await runtime.detectVersion();
-      if (version === null) {
-        const advisory = runtime.brokenInstallAdvisory(BIN);
-        throw new HarnessUnavailableError(
-          `codex CLI not found on PATH (set CLAUDEXOR_CODEX_BIN to override)${advisory ? ` — ${advisory}` : ""}`,
-        );
-      }
+      if (version === null) throw missingCliError(runtime.brokenInstallAdvisory(BIN));
       const apiKey = runtime.hasApiKey();
       const login = await runtime.probeLogin(BIN, { env: codexNativeEnv() });
       const nativeSessionAvailable = login.method === "chatgpt";
@@ -485,26 +465,11 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
     },
 
     async doctor(_spec: DoctorSpec): Promise<ConformanceReport> {
-      const version = await runtime.detectVersion(_spec.abortSignal);
+      // The scoped env drives BOTH the version probe and the advisory, so the
+      // diagnosis always describes the exact env the probe failed in.
+      const version = await runtime.detectVersion(_spec.abortSignal, _spec.env);
       if (version === null) {
-        const advisory = runtime.brokenInstallAdvisory(BIN);
-        return ConformanceReportSchema.parse({
-          harness_id: "codex",
-          status: "unavailable",
-          checks: [
-            {
-              id: "installed",
-              status: "fail",
-              detail: advisory
-                ? `codex not found on PATH — ${advisory}`
-                : "codex not found on PATH",
-            },
-          ],
-          reasons: [
-            "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
-            ...(advisory ? [advisory] : []),
-          ],
-        });
+        return missingCliReport(runtime.brokenInstallAdvisory(BIN, probeEnv(_spec.env)));
       }
       const requestedSource = _spec.authSource;
       const probeNative = requestedSource === undefined || requestedSource === "native_session";

--- a/packages/harness-codex/src/index.ts
+++ b/packages/harness-codex/src/index.ts
@@ -382,7 +382,10 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
 
     async discover(): Promise<HarnessManifest> {
       const version = await runtime.detectVersion();
-      if (version === null) throw missingCliError(runtime.brokenInstallAdvisory(BIN));
+      if (version === null) {
+        const advisory = runtime.brokenInstallAdvisory(BIN);
+        throw missingCliError(advisory && redactCodexDoctorDetail(advisory));
+      }
       const apiKey = runtime.hasApiKey();
       const login = await runtime.probeLogin(BIN, { env: codexNativeEnv() });
       const nativeSessionAvailable = login.method === "chatgpt";
@@ -469,7 +472,8 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
       // diagnosis always describes the exact env the probe failed in.
       const version = await runtime.detectVersion(_spec.abortSignal, _spec.env);
       if (version === null) {
-        return missingCliReport(runtime.brokenInstallAdvisory(BIN, probeEnv(_spec.env)));
+        const advisory = runtime.brokenInstallAdvisory(BIN, probeEnv(_spec.env));
+        return missingCliReport(advisory && redactCodexDoctorDetail(advisory));
       }
       const requestedSource = _spec.authSource;
       const probeNative = requestedSource === undefined || requestedSource === "native_session";
@@ -518,7 +522,7 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
         "explain",
         "audit",
       ];
-      const binPath = resolveHarnessBinary(BIN);
+      const binPath = resolveHarnessBinary(BIN, probeEnv(_spec.env));
       const apiSource: AuthSourceReadiness = {
         source: "provider_auth_file",
         availability: apiKey ? "available" : "unavailable",

--- a/packages/harness-codex/src/index.ts
+++ b/packages/harness-codex/src/index.ts
@@ -21,6 +21,7 @@ import {
 import type { DoctorSpec, HarnessAdapter } from "@claudexor/core";
 import {
   abortSignalFromSpec,
+  brokenInstallAdvisory,
   browserMcpCommand,
   HarnessUnavailableError,
   normalizeEffort,
@@ -368,6 +369,7 @@ export type CodexProfileRuntimeDeps = Pick<CodexRuntimeDeps, "probeLogin" | "res
 
 type CodexRuntimeDeps = {
   detectVersion: typeof detectVersion;
+  brokenInstallAdvisory: typeof brokenInstallAdvisory;
   probeLogin: typeof probeLogin;
   hasApiKey: typeof hasApiKey;
   codexApiKey: typeof codexApiKey;
@@ -381,6 +383,7 @@ type CodexRuntimeDeps = {
 export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): HarnessAdapter {
   const runtime: CodexRuntimeDeps = {
     detectVersion,
+    brokenInstallAdvisory,
     probeLogin,
     hasApiKey,
     codexApiKey,
@@ -395,8 +398,9 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
     async discover(): Promise<HarnessManifest> {
       const version = await runtime.detectVersion();
       if (version === null) {
+        const advisory = runtime.brokenInstallAdvisory(BIN);
         throw new HarnessUnavailableError(
-          "codex CLI not found on PATH (set CLAUDEXOR_CODEX_BIN to override)",
+          `codex CLI not found on PATH (set CLAUDEXOR_CODEX_BIN to override)${advisory ? ` — ${advisory}` : ""}`,
         );
       }
       const apiKey = runtime.hasApiKey();
@@ -483,11 +487,23 @@ export function createCodexAdapter(deps: Partial<CodexRuntimeDeps> = {}): Harnes
     async doctor(_spec: DoctorSpec): Promise<ConformanceReport> {
       const version = await runtime.detectVersion(_spec.abortSignal);
       if (version === null) {
+        const advisory = runtime.brokenInstallAdvisory(BIN);
         return ConformanceReportSchema.parse({
           harness_id: "codex",
           status: "unavailable",
-          checks: [{ id: "installed", status: "fail", detail: "codex not found on PATH" }],
-          reasons: ["codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)"],
+          checks: [
+            {
+              id: "installed",
+              status: "fail",
+              detail: advisory
+                ? `codex not found on PATH — ${advisory}`
+                : "codex not found on PATH",
+            },
+          ],
+          reasons: [
+            "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
+            ...(advisory ? [advisory] : []),
+          ],
         });
       }
       const requestedSource = _spec.authSource;

--- a/packages/harness-codex/src/missing-cli.ts
+++ b/packages/harness-codex/src/missing-cli.ts
@@ -1,3 +1,4 @@
+import { isAbsolute } from "node:path";
 import { runCapture } from "@claudexor/core";
 import { HarnessUnavailableError } from "@claudexor/core";
 import { ConformanceReport as ConformanceReportSchema } from "@claudexor/schema";
@@ -38,17 +39,26 @@ export async function detectVersion(
   }
 }
 
+/** An absolute override was never a PATH lookup — say what actually failed. */
+function deadEnd(bin: string): string {
+  return isAbsolute(bin) ? `codex override ${bin} is not runnable` : "codex not found on PATH";
+}
+
 /** The discover() dead-end for a missing CLI, advisory-enriched when the
  *  filesystem still holds evidence of a broken install. */
-export function missingCliError(advisory: string | null): HarnessUnavailableError {
-  return new HarnessUnavailableError(
-    `codex CLI not found on PATH (set CLAUDEXOR_CODEX_BIN to override)${advisory ? ` — ${advisory}` : ""}`,
-  );
+export function missingCliError(
+  advisory: string | null,
+  bin: string = BIN,
+): HarnessUnavailableError {
+  const summary = isAbsolute(bin)
+    ? `codex CLI override ${bin} is not runnable (fix CLAUDEXOR_CODEX_BIN)`
+    : "codex CLI not found on PATH (set CLAUDEXOR_CODEX_BIN to override)";
+  return new HarnessUnavailableError(`${summary}${advisory ? ` — ${advisory}` : ""}`);
 }
 
 /** The doctor() unavailable report for a missing CLI; wording is unchanged
  *  when there is no advisory evidence. */
-export function missingCliReport(advisory: string | null): ConformanceReport {
+export function missingCliReport(advisory: string | null, bin: string = BIN): ConformanceReport {
   return ConformanceReportSchema.parse({
     harness_id: "codex",
     status: "unavailable",
@@ -56,11 +66,13 @@ export function missingCliReport(advisory: string | null): ConformanceReport {
       {
         id: "installed",
         status: "fail",
-        detail: advisory ? `codex not found on PATH — ${advisory}` : "codex not found on PATH",
+        detail: advisory ? `${deadEnd(bin)} — ${advisory}` : deadEnd(bin),
       },
     ],
     reasons: [
-      "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
+      isAbsolute(bin)
+        ? `codex CLI override ${bin} is not runnable (fix CLAUDEXOR_CODEX_BIN)`
+        : "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
       ...(advisory ? [advisory] : []),
     ],
   });

--- a/packages/harness-codex/src/missing-cli.ts
+++ b/packages/harness-codex/src/missing-cli.ts
@@ -1,0 +1,67 @@
+import { runCapture } from "@claudexor/core";
+import { HarnessUnavailableError } from "@claudexor/core";
+import { ConformanceReport as ConformanceReportSchema } from "@claudexor/schema";
+import type { ConformanceReport } from "@claudexor/schema";
+
+export const BIN = process.env.CLAUDEXOR_CODEX_BIN || "codex";
+
+/**
+ * Effective environment for a doctor probe: the scoped DoctorSpec.env is a
+ * PATCH over the inherited process env with the same semantics runCapture
+ * applies when spawning (null/undefined deletes) — so the broken-install
+ * advisory diagnoses exactly the env the version probe spawned in (INV-067).
+ */
+export function probeEnv(patch?: Record<string, string | null | undefined>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(patch ?? {})) {
+    if (value === undefined || value === null) delete env[key];
+    else env[key] = value;
+  }
+  return env;
+}
+
+export async function detectVersion(
+  abortSignal?: AbortSignal,
+  env?: Record<string, string | null | undefined>,
+): Promise<string | null> {
+  try {
+    const r = await runCapture(BIN, ["--version"], {
+      timeoutMs: 10_000,
+      abortSignal,
+      cancelSignal: "SIGTERM",
+      cancelKillDelayMs: 0,
+      ...(env ? { env } : {}),
+    });
+    return r.stdout.trim() || `${BIN} (version unknown)`;
+  } catch {
+    return null;
+  }
+}
+
+/** The discover() dead-end for a missing CLI, advisory-enriched when the
+ *  filesystem still holds evidence of a broken install. */
+export function missingCliError(advisory: string | null): HarnessUnavailableError {
+  return new HarnessUnavailableError(
+    `codex CLI not found on PATH (set CLAUDEXOR_CODEX_BIN to override)${advisory ? ` — ${advisory}` : ""}`,
+  );
+}
+
+/** The doctor() unavailable report for a missing CLI; wording is unchanged
+ *  when there is no advisory evidence. */
+export function missingCliReport(advisory: string | null): ConformanceReport {
+  return ConformanceReportSchema.parse({
+    harness_id: "codex",
+    status: "unavailable",
+    checks: [
+      {
+        id: "installed",
+        status: "fail",
+        detail: advisory ? `codex not found on PATH — ${advisory}` : "codex not found on PATH",
+      },
+    ],
+    reasons: [
+      "codex CLI not found (install Codex or set CLAUDEXOR_CODEX_BIN)",
+      ...(advisory ? [advisory] : []),
+    ],
+  });
+}


### PR DESCRIPTION
## Problem

When a vendor CLI fails to resolve, every surface dead-ends at `codex not found on PATH` / `spawn codex ENOENT` with no path to repair — even when the filesystem plainly shows **why**.

Live incident that motivated this: Homebrew's `codex` cask stayed registered (Caskroom dir present, version pinned at 0.106.0) while its payload and bin link had vanished. The Codex Auth sheet showed only `Not ready: unavailable / codex not found on PATH`, the account row showed `spawn codex ENOENT`, and the setup job refused with `install the vendor CLI first` — none of them could say "your brew install is broken; run `brew reinstall --cask codex`". (A plain `brew install` would not have helped either — brew considered the package installed.)

## Change

**`@claudexor/core`: new `brokenInstallAdvisory(bin, env?, brewPrefixes?)`** in `runtime-env.ts`, modeled on the existing `atRiskNodeAdvisory` contract: returns a remediation string or `null`, purely diagnostic — never gates a run, never executes a package manager. Two evidence classes, checked in order:

1. **An entry named like the binary exists on the harness PATH (or at the configured absolute override) but is not spawnable** — dangling symlink (target named), stripped exec bit, or a directory shadowing the name. If the entry or its symlink target sits under `Caskroom`/`Cellar`, the advisory prescribes the exact `brew reinstall [--cask] <name>`.
2. **Nothing on PATH at all, but a Homebrew `Caskroom`/`Cellar` dir still lists the binary as installed** — the orphaned-registration case from the live incident.

Resolution reuses the same `resolveHarnessBinary` / `normalizedHarnessPath` the spawn layer composes, so the advisory can never disagree with what doctor already reports.

**`@claudexor/harness-codex`: wired into both dead-ends** via the existing `CodexRuntimeDeps` injection seam:
- `discover()` appends the advisory to the `HarnessUnavailableError` message;
- `doctor()` appends it to the `installed` check detail and adds it as a `reasons` entry.

Wording is unchanged when there is no evidence (advisory `null`), so existing consumers/tests see identical output. Other harness adapters (claude, cursor, opencode) have the same dead-end shape and can adopt the same one-liner in follow-ups.

## Testing

- 5 new unit tests for `brokenInstallAdvisory` (real temp-dir fs, house style): resolves→null, dangling Caskroom symlink→`--cask` recipe, orphaned Caskroom→recipe, Cellar formula→no `--cask`, non-brew stripped exec bit→generic wording.
- 3 new adapter tests: doctor surfaces advisory in check+reasons, doctor unchanged without advisory, discover error carries advisory.
- Full `packages/core` + `packages/harness-codex` suites: **199/199 pass**; `typecheck` clean on both.
- Live check against the built dist: healthy machine → `null`; reproduced incident layout (registered-but-empty Caskroom, empty PATH) → exact remediation string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)