### PR TITLE
fix(routing): infer primary from explicit singleton pool

### DIFF
--- a/.changeset/calm-singletons-route.md
+++ b/.changeset/calm-singletons-route.md
@@ -1,0 +1,7 @@
+---
+"claudexor": patch
+---
+
+Treat one explicitly selected harness as the effective primary when no
+`--primary-harness` is supplied, so configured routing defaults cannot override
+an explicit singleton pool.

--- a/README.md
+++ b/README.md
@@ -375,7 +375,9 @@ access profile changes. The full semantics live in
 Routing is `Pool + Primary + Routing Goal`: selected harnesses are the
 eligible pool, `--primary-harness <id>` biases single-route modes, and
 `--routing-goal auto|quality|economy` picks the pacing. In chat this is sticky
-per thread — the thread remembers its primary, pool, and (since 2.1) its
+per thread. An explicit one-harness pool infers that harness as primary unless
+`--primary-harness` is supplied; an explicit primary must belong to the pool.
+The thread remembers its primary, pool, and (since 2.1) its
 credential profile; the engine owns routing, surfaces only send the choice.
 Reviewer panels are explicit when needed (`--reviewer-panel
 "claude=claude-opus-4-8:max,cursor=gemini-3.5-flash"`); a clean verified

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,6 +157,8 @@ Routing is `Pool + Primary + Routing Goal`:
 
 - selected harness ids are the eligible pool;
 - `primaryHarness` is a bias/ordering hint, not a privileged semantic role;
+- one explicitly selected harness becomes the effective primary when no explicit
+  primary is supplied; an explicit primary must belong to the selected pool;
 - `routingGoal` is recorded as `TaskContract.budget.routing_goal`, default
   `auto`; the other goals are `quality` and `economy`. The v1 portfolio ids
   have no aliases and fail at every boundary.

--- a/packages/canary/src/golden.story.ts
+++ b/packages/canary/src/golden.story.ts
@@ -119,6 +119,35 @@ describe("canary golden stories", () => {
     }
   });
 
+  it("[INV-013:explicit-singleton-primary] every run verb routes an explicit singleton ahead of a conflicting configured primary", () => {
+    writeFileSync(join(sb.configDir, "config.yaml"), "routing:\n  primary_harness: codex\n");
+    const commands: Array<{ args: string[]; mode: string; harness: string }> = [
+      { args: ["ask", "answer"], mode: "ask", harness: "fake-success" },
+      { args: ["plan", "plan"], mode: "plan", harness: "fake-success" },
+      { args: ["agent", "change"], mode: "agent", harness: "fake-success" },
+      { args: ["create", "scaffold"], mode: "agent", harness: "fake-implement" },
+    ];
+    for (const command of commands) {
+      const result = cli(sb, [
+        ...command.args,
+        "--harness",
+        command.harness,
+        "--model",
+        "fake-model",
+        "--json",
+      ]);
+      expect(result.code, `${command.args[0]}: ${result.stdout}${result.stderr}`).toBe(0);
+      const output = result.json() as { mode?: string; runDir: string };
+      expect(output.mode).toBe(command.mode);
+      expect(output.runDir).toBeTruthy();
+      const startedHarnesses = readEvents(output.runDir)
+        .filter((event) => event["type"] === "harness.started")
+        .map((event) => (event["payload"] as Record<string, unknown>)["harness_id"]);
+      expect(startedHarnesses).toContain(command.harness);
+      expect(startedHarnesses).not.toContain("codex");
+    }
+  });
+
   it("[INV-062:prompt-secret-block] a secret-like value in the prompt is hard-blocked before any run starts (no bypass)", () => {
     const secret = "sk-" + "z".repeat(24);
     const r = cli(sb, [

--- a/packages/cli/src/command-flags.ts
+++ b/packages/cli/src/command-flags.ts
@@ -81,7 +81,11 @@ const FROZEN_REVIEW_FLAGS: readonly CliFlagSpec[] = [
 export const FROZEN_REVIEW_FLAG_NAMES = FROZEN_REVIEW_FLAGS.map((flag) => flag.name);
 
 export const CLI_FLAGS: readonly CliFlagSpec[] = [
-  valueFlag("harness", "<id[,id...]>", "Force harness(es)"),
+  valueFlag(
+    "harness",
+    "<id[,id...]>",
+    "Force the eligible pool; one explicit harness also becomes the effective primary",
+  ),
   valueFlag(
     "route",
     "<local_session|api_key>",
@@ -159,7 +163,11 @@ export const CLI_FLAGS: readonly CliFlagSpec[] = [
   valueFlag("web", "<mode>", "External web/search policy: off|auto|cached|live"),
   valueFlag("model", "<id>", "Model hint forwarded to the selected harness route"),
   valueFlag("effort", "<level>", "Reasoning effort hint: low|medium|high|xhigh|max"),
-  valueFlag("primary-harness", "<id>", "Bias single-route modes and first candidate choice"),
+  valueFlag(
+    "primary-harness",
+    "<id>",
+    "Explicitly bias single-route modes and first candidate choice; must belong to the pool",
+  ),
   valueFlag("portfolio", "<id>", "Removed in v2; always errors (use --routing-goal)"),
   valueFlag("routing-goal", "<goal>", "Routing goal: auto|quality|economy"),
   valueFlag(

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -882,6 +882,39 @@ describe("Orchestrator", () => {
     expect(taskYaml).toContain("claude: model-x");
   });
 
+  it("infers an explicit singleton pool as primary ahead of a conflicting configured primary", async () => {
+    const repo = await initRepo();
+    const seen: { id: string; model: string | null }[] = [];
+    const observedAdapter = (id: string, family: ProviderFamily): HarnessAdapter => ({
+      ...realLikeAdapter(id, family),
+      async *run(spec) {
+        seen.push({ id, model: spec.model_hint });
+        yield { type: "completed", session_id: spec.session_id, ts: new Date().toISOString() };
+      },
+    });
+    const registry = new Map<string, HarnessAdapter>([
+      ["codex", observedAdapter("codex", "openai")],
+      ["claude", observedAdapter("claude", "anthropic")],
+    ]);
+    const res = await withScopedConfigDir(async () => {
+      writeFileSync(
+        join(process.env.CLAUDEXOR_CONFIG_DIR!, "config.yaml"),
+        "routing:\n  primary_harness: codex\n",
+      );
+      const orch = new Orchestrator({ registry, reviewers: [] });
+      return orch.run({
+        repoRoot: repo,
+        prompt: "x",
+        mode: "agent",
+        harnesses: ["claude"],
+        model: "model-x",
+        n: 1,
+      });
+    });
+    expect(res.lifecycle).toBe("succeeded");
+    expect(seen).toEqual([{ id: "claude", model: "model-x" }]);
+  });
+
   it("REFUSES a run whose resolved model fails the harness truth source (typed preflight, no CLI spawn)", async () => {
     const repo = await initRepo();
     let spawned = false;
@@ -1331,16 +1364,35 @@ describe("Orchestrator", () => {
 
   it("fails loudly when no available harness can perform the intent", async () => {
     const repo = await initRepo();
-    const registry = new Map<string, HarnessAdapter>([["raw-ish", noImplementAdapter("raw-ish")]]);
-    const orch = new Orchestrator({ registry, reviewers: [] });
-    const res = await orch.run({
-      repoRoot: repo,
-      prompt: "x",
-      mode: "agent",
-      harnesses: ["raw-ish"],
-      n: 1,
+    let configuredPrimaryRan = false;
+    const configuredPrimary: HarnessAdapter = {
+      ...realLikeAdapter("codex"),
+      async *run(spec) {
+        configuredPrimaryRan = true;
+        yield { type: "completed", session_id: spec.session_id, ts: new Date().toISOString() };
+      },
+    };
+    const registry = new Map<string, HarnessAdapter>([
+      ["raw-ish", noImplementAdapter("raw-ish")],
+      ["codex", configuredPrimary],
+    ]);
+    const res = await withScopedConfigDir(async () => {
+      writeFileSync(
+        join(process.env.CLAUDEXOR_CONFIG_DIR!, "config.yaml"),
+        "routing:\n  primary_harness: codex\n",
+      );
+      const orch = new Orchestrator({ registry, reviewers: [] });
+      return orch.run({
+        repoRoot: repo,
+        prompt: "x",
+        mode: "agent",
+        harnesses: ["raw-ish"],
+        n: 1,
+      });
     });
     expect(legacyOutcome(res)).toBe("failed");
+    expect(res.candidates).toEqual([]);
+    expect(configuredPrimaryRan).toBe(false);
     expect(res.summary).toMatch(/perform 'implement'/);
     expect(readFileSync(join(res.runDir, "context", "context_error.md"), "utf8")).toMatch(
       /perform 'implement'/,

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -964,7 +964,11 @@ export class Orchestrator {
     const configuredPool = cfg?.global.routing.eligible_harnesses;
     const harnesses =
       input.harnesses ?? (configuredPool && configuredPool.length > 0 ? configuredPool : undefined);
-    const primaryHarness = input.primaryHarness ?? cfg?.global.routing.primary_harness ?? undefined;
+    const primaryHarness =
+      input.primaryHarness ??
+      (input.harnesses?.length === 1 ? input.harnesses[0] : undefined) ??
+      cfg?.global.routing.primary_harness ??
+      undefined;
     if (
       primaryHarness &&
       harnesses &&
@@ -981,14 +985,8 @@ export class Orchestrator {
       );
     }
     const web = input.web ?? input.externalContextPolicy ?? "auto";
-    // INV-103: model choice is harness-scoped end-to-end. The scalar
-    // `model` is a convenience that expands to the RESOLVED PRIMARY only —
-    // never the whole pool (the old global fallback poisoned every pool
-    // member with one vendor's model id). Specific beats general: an explicit
-    // per-harness map entry wins over the scalar.
-    //
-    // Map KEYS fail loudly (INV-021): a typo'd harness id ("claud") must
-    // never silently no-op into "the run used defaults and nothing said why".
+    // INV-103: scalar `model` expands only to the resolved primary, never the pool;
+    // an explicit per-harness map wins. Unknown map keys fail loudly (INV-021).
     const knownHarnessIds = new Set(this.deps.registry.keys());
     for (const key of Object.keys(input.models ?? {})) {
       if (!knownHarnessIds.has(key)) {


### PR DESCRIPTION
## Summary

- infer the effective primary from an explicitly supplied one-harness pool before consulting the configured primary;
- keep an explicit `--primary-harness` authoritative and reject it when it is outside the selected pool;
- preserve fail-closed capability routing: an explicitly selected incapable harness never falls back to the configured primary;
- document the precedence in CLI help, README, and architecture docs.

## Expected vs actual

| Scenario | Expected | Actual after this change |
| --- | --- | --- |
| configured primary `codex`, explicit `--harness claude` | route Claude without duplicating `--primary-harness claude` | Claude is the effective primary and receives the scalar model |
| explicit `--harness codex --primary-harness claude` | reject before invocation | existing membership rejection remains intact |
| configured capable primary, explicit incapable singleton | fail closed | run fails with no candidates; configured primary is never invoked |
| `ask`, `plan`, `agent`, and `create` | same singleton precedence | public CLI canary observes only the explicitly selected harness |

## Scope

This intentionally implements the independently mergeable singleton-precedence slice only.

**Partially addresses #25.**

The multi-harness ambiguity contract and requested/effective routing telemetry remain open because they overlap the shared error/terminal-receipt work in #28 and #29.

## Verification

- build: 30/30 tasks passed
- typecheck: 59/59 tasks passed
- test TypeScript project: passed
- orchestrator: 158/158 tests passed
- focused precedence/fail-closed/explicit-primary matrix: 3/3 passed
- CLI command registry: 9/9 tests passed
- full canary: 27/27 tests passed
- focused four-verb singleton canary with event-log harness assertions: passed
- docs truth, staged-field, retired-key, invariant links, sensitive ownership, MCP/CLI parity, release workflow, Knip, Prettier, complexity ratchet, and `git diff --check`: passed
