### PR TITLE
fix(telemetry): preserve truthful producer outcomes

### DIFF
--- a/.changeset/honest-producer-facts.md
+++ b/.changeset/honest-producer-facts.md
@@ -1,0 +1,7 @@
+---
+"claudexor": patch
+---
+
+Record truthful planner deliverable outcomes, report the actual council member
+count, and preserve independent check and review facts when a terminal decision
+is blocked.

--- a/packages/delivery/src/delivery.test.ts
+++ b/packages/delivery/src/delivery.test.ts
@@ -14,7 +14,13 @@ import { describe, expect, it } from "vitest";
 import { runCapture } from "@claudexor/core";
 import { sha256 } from "@claudexor/util";
 import { DecisionRecord, makeOutcomeFacts } from "@claudexor/schema";
-import { checkPatch, deliver, validateApplyGate, verifyAndDeliver } from "./index.js";
+import {
+  blockedDecisionOverride,
+  checkPatch,
+  deliver,
+  validateApplyGate,
+  verifyAndDeliver,
+} from "./index.js";
 
 async function git(repo: string, args: string[]) {
   return runCapture("git", ["-C", repo, ...args], { timeoutMs: 30_000 });
@@ -467,5 +473,43 @@ describe("final_verify apply-gate consumer (INV-115)", () => {
       operatorDecision: { action: "accept_risk", patch_sha256: sha256(patch) },
     });
     expect(overridden).toBeNull();
+  });
+});
+
+describe("blocked decision fact overrides", () => {
+  it("preserves passed checks when a review block overrides the review axis", () => {
+    const result = blockedDecisionOverride(
+      [],
+      makeOutcomeFacts("succeeded", { checks: "passed" }),
+      null,
+    );
+
+    expect(result.facts).toMatchObject({
+      checks: "passed",
+      review: "blocked",
+      reason: "review_blocked",
+    });
+  });
+
+  it("preserves an approved review when final verify overrides the checks axis", () => {
+    const result = blockedDecisionOverride(
+      [],
+      makeOutcomeFacts("succeeded", { review: "approved" }),
+      {
+        attempted: true,
+        applied_cleanly: true,
+        gates_passed: false,
+        gates: [],
+        base_sha: null,
+        duration_ms: null,
+        reason: "configured gate failed",
+      },
+    );
+
+    expect(result.facts).toMatchObject({
+      checks: "failed",
+      review: "approved",
+      reason: "checks_failed",
+    });
   });
 });

--- a/packages/delivery/src/final-verifier.ts
+++ b/packages/delivery/src/final-verifier.ts
@@ -2,7 +2,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { FinalVerifyRecord, makeOutcomeFacts, type RunOutcomeFacts } from "@claudexor/schema";
+import { FinalVerifyRecord, type RunOutcomeFacts } from "@claudexor/schema";
 import { type GateSpec, gatesPassed, runGates } from "@claudexor/review";
 import {
   applyPatchProtected,
@@ -36,6 +36,7 @@ export function finalVerifyBlocks(finalVerify: FinalVerifyRecord | null): boolea
  * succeeded — the process finished; a human decision is what is pending. */
 export function blockedDecisionOverride(
   evidenceFacts: string[],
+  facts: RunOutcomeFacts,
   finalVerify: FinalVerifyRecord | null,
 ): {
   facts: RunOutcomeFacts;
@@ -51,8 +52,8 @@ export function blockedDecisionOverride(
     : "reviewer escalated blocking NEEDS_HUMAN findings; a typed operator decision is required";
   return {
     facts: verifyBlocked
-      ? makeOutcomeFacts("succeeded", { checks: "failed", reason: "checks_failed" })
-      : makeOutcomeFacts("succeeded", { review: "blocked", reason: "review_blocked" }),
+      ? { ...facts, checks: "failed", reason: "checks_failed" }
+      : { ...facts, review: "blocked", reason: "review_blocked" },
     apply_recommendation: "human_review",
     verification_basis: "none",
     evidence_facts: [...evidenceFacts, fact],

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -999,6 +999,11 @@ describe("Orchestrator", () => {
     expect(review).toContain("level: critical");
     expect(review).toContain("candidate changed protected path");
     expect(review).toContain("severity: BLOCK");
+    const decision = readFileSync(join(res.runDir, "arbitration", "decision.yaml"), "utf8");
+    expect(decision).toContain("lifecycle: succeeded");
+    expect(decision).toContain("checks: passed");
+    expect(decision).toContain("review: blocked");
+    expect(decision).toContain("reason: review_blocked");
   });
 
   it("allows explicitly approved existing protected gate path changes", async () => {
@@ -4736,6 +4741,17 @@ describe("Orchestrator", () => {
     const summary = readFileSync(join(res.runDir, "final", "summary.md"), "utf8");
     expect(summary).toContain("Open questions: 2");
     expect(summary).toContain("Goal: make a racing game");
+    const telemetry = new ArtifactStore(repo).readYaml<{
+      final_attempt_id: string | null;
+      attempts: Array<{
+        attempt_id: string;
+        outcome: { deliverable_present: boolean; status: string };
+      }>;
+    }>(join(res.runDir, "final", "telemetry.yaml"));
+    expect(telemetry).toMatchObject({
+      final_attempt_id: "p01",
+      attempts: [{ attempt_id: "p01", outcome: { deliverable_present: true, status: "success" } }],
+    });
   });
 
   it("an untagged plan is DISCLOSED as unverified, never silently ready", async () => {
@@ -4803,6 +4819,26 @@ describe("Orchestrator", () => {
     expect(eventTypes).toContain("route.fallback.started");
     expect(eventTypes).toContain("route.fallback.completed");
     expect(res.candidates.map((c) => c.status)).toEqual(["failed", "success"]);
+    const telemetry = new ArtifactStore(repo).readYaml<{
+      final_attempt_id: string | null;
+      attempts: Array<{
+        attempt_id: string;
+        outcome: { deliverable_present: boolean; harness_errored: boolean; status: string };
+      }>;
+    }>(join(res.runDir, "final", "telemetry.yaml"));
+    expect(telemetry).toMatchObject({
+      final_attempt_id: "p02",
+      attempts: [
+        {
+          attempt_id: "p01",
+          outcome: { deliverable_present: false, harness_errored: true, status: "failed" },
+        },
+        {
+          attempt_id: "p02",
+          outcome: { deliverable_present: true, harness_errored: false, status: "success" },
+        },
+      ],
+    });
   });
 
   // Council (INV-031): a planner that emits DRAFT questions on intent=plan and
@@ -4895,6 +4931,24 @@ describe("Orchestrator", () => {
     expect(eventTypes).toContain("council.started");
     expect(eventTypes).toContain("council.draft");
     expect(eventTypes).toContain("council.merged");
+    const telemetry = new ArtifactStore(repo).readYaml<{
+      final_attempt_id: string | null;
+      attempts: Array<{
+        attempt_id: string;
+        outcome: { deliverable_present: boolean; status: string };
+      }>;
+    }>(join(res.runDir, "final", "telemetry.yaml"));
+    expect(telemetry?.final_attempt_id).toBe("p03");
+    expect(telemetry?.attempts.map((attempt) => attempt.attempt_id)).toEqual(["p01", "p02", "p03"]);
+    expect(
+      telemetry?.attempts.every(
+        (attempt) => attempt.outcome.deliverable_present && attempt.outcome.status === "success",
+      ),
+    ).toBe(true);
+    const workProduct = new ArtifactStore(repo).readYaml<{ meta: { planners: number } }>(
+      join(res.runDir, "final", "work_product.yaml"),
+    );
+    expect(workProduct?.meta.planners).toBe(2);
   });
 
   it("council degrades honestly when a member fails but the merge still runs", async () => {
@@ -4935,6 +4989,10 @@ describe("Orchestrator", () => {
     expect(readFileSync(join(res.runDir, "final", "plan.md"), "utf8")).toContain("# Merged plan");
     const summary = readFileSync(join(res.runDir, "final", "summary.md"), "utf8");
     expect(summary).toContain("council degraded");
+    const workProduct = new ArtifactStore(repo).readYaml<{ meta: { planners: number } }>(
+      join(res.runDir, "final", "work_product.yaml"),
+    );
+    expect(workProduct?.meta.planners).toBe(2);
   });
 
   it("council records a native session per member lane on a thread turn", async () => {
@@ -6005,6 +6063,20 @@ describe("Orchestrator", () => {
     expect(plannerStarted).toBe(true);
     expect(legacyOutcome(res)).toBe("cancelled");
     expect(existsSync(join(res.runDir, "final", "plan.md"))).toBe(false);
+    const telemetry = new ArtifactStore(repo).readYaml<{
+      final_attempt_id: string | null;
+      attempts: Array<{
+        outcome: { deliverable_present: boolean; harness_errored: boolean; status: string };
+      }>;
+    }>(join(res.runDir, "final", "telemetry.yaml"));
+    expect(telemetry).toMatchObject({
+      final_attempt_id: null,
+      attempts: [
+        {
+          outcome: { deliverable_present: false, harness_errored: false, status: "failed" },
+        },
+      ],
+    });
   });
 
   it("cancels agent mode after a reviewer-panel abort instead of continuing to arbitration", async () => {

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -3404,7 +3404,7 @@ export class Orchestrator {
     store.writeYaml(join(paths.arbitrationDir, "decision.yaml"), {
       ...result.decision,
       ...(needsDec
-        ? blockedDecisionOverride(result.decision.evidence_facts, finalVerify)
+        ? blockedDecisionOverride(result.decision.evidence_facts, facts, finalVerify)
         : { facts }),
       review_verified: actualReviewVerified,
       final_verify: finalVerify,
@@ -4713,7 +4713,7 @@ export class Orchestrator {
       decision = {
         ...decision,
         ...(convNeedsDecision
-          ? blockedDecisionOverride(decision.evidence_facts, convFinalVerify)
+          ? blockedDecisionOverride(decision.evidence_facts, facts, convFinalVerify)
           : { facts }),
         final_verify: convFinalVerify,
       };
@@ -4927,15 +4927,7 @@ export class Orchestrator {
     ].join("\n");
   }
 
-  /**
-   * Run ONE planner spawn (native plan mode, read-only) end to end: budget
-   * lease, spec build, continuity hydration, event streaming, telemetry, and
-   * settle. Shared by the solo plan loop (each pool member is a sequential
-   * fallback) and the Council strategy (each member is a parallel draft, then
-   * one merge iteration on the primary — same machinery, different prompt +
-   * intent). The caller owns bookkeeping that differs per path: which artifact
-   * a success writes to, fallback disclosure, and accumulation.
-   */
+  /** One read-only planner spawn shared by solo fallback, Council drafts, and merge. */
   async runPlannerAttempt(args: PlannerAttemptArgs): Promise<PlannerAttemptOutcome> {
     const { input, contract, taskId, runId, log, store, paths, ledger, routed, attemptId } = args;
     const adapter = routed.adapter;
@@ -5122,19 +5114,26 @@ export class Orchestrator {
       const first = unrecovered[0] as ToolErrorRecord;
       harnessError = `${first.tool} failed without recovery: ${first.summary}`;
     }
-    if (harnessError) {
+    const attemptError = harnessError ?? (input.signal?.aborted ? "planner cancelled" : null);
+    setAttemptOutcome(telemetry, {
+      deliverablePresent: attemptError === null,
+      gatesPassed: null,
+      harnessErrored: harnessError !== null && !webBlocked,
+      webRequiredUnsatisfied: webBlocked,
+    });
+    if (attemptError) {
       log.emit("harness.completed", {
         harness_id: adapter.id,
         attempt_id: attemptId,
         status: webBlocked ? "blocked" : "failed",
-        error: harnessError,
+        error: attemptError,
         ...telemetrySummary(telemetry),
       });
       return {
         attemptId,
         harnessId: adapter.id,
         status: webBlocked ? "blocked" : "failed",
-        error: harnessError,
+        error: attemptError,
         text: null,
         telemetry,
         budgetDenied: false,
@@ -5364,7 +5363,7 @@ export class Orchestrator {
               attempt_id: attemptId,
               reason: "planner_failed",
             });
-          } else if (fallbackFrom || next === undefined) {
+          } else if (!input.signal?.aborted && (fallbackFrom || next === undefined)) {
             log.emit("route.fallback.exhausted", {
               harness_id: outcome.harnessId,
               attempt_id: attemptId,

--- a/packages/orchestrator/src/planRun.ts
+++ b/packages/orchestrator/src/planRun.ts
@@ -388,7 +388,7 @@ export function finalizePlanRun(
     meta: {
       mode: "plan",
       result_kind: "plan",
-      planners: plans.length,
+      planners: council?.members.length ?? plans.length,
       diffstat: { files: 0, additions: 0, deletions: 0 },
       blockers: 0,
       adopted: null,

--- a/packages/orchestrator/src/runSupport.ts
+++ b/packages/orchestrator/src/runSupport.ts
@@ -71,7 +71,7 @@ export function writeRaceDeliveryDecision(
     ...(input.deliveryFailureReason
       ? deliveryRefusalDecisionFields(input.decision.evidence_facts, input.deliveryFailureReason)
       : needsDecision
-        ? blockedDecisionOverride(input.decision.evidence_facts, input.finalVerify)
+        ? blockedDecisionOverride(input.decision.evidence_facts, input.facts, input.finalVerify)
         : { facts: input.facts }),
     review_verified: input.reviewVerified,
     final_verify: input.finalVerify,


### PR DESCRIPTION
## Summary

- record planner attempt outcomes through the existing `setAttemptOutcome` owner;
- report the actual selected council member count instead of the one merged plan document;
- preserve orthogonal `checks` and `review` facts when a blocked decision is persisted;
- keep cancellation honest: no final plan means no successful/deliverable planner attempt.

## Expected vs actual

| Scenario | Expected | Actual after this change |
| --- | --- | --- |
| successful solo plan writes `final/plan.md` | final attempt is a successful deliverable | `p01.deliverable_present=true`, `status=success`, `final_attempt_id=p01` |
| first planner fails, second succeeds | failed lane is false/failed; final lane is true/success | `p01` and `p02` now retain those distinct outcomes |
| planner is cancelled mid-stream | no canonical plan and no success claim | `final_attempt_id=null`, deliverable false, harness error false, status failed |
| two-member council, including one failed draft | planner count reflects selected members, not successful drafts or merge documents | `work_product.meta.planners=2` in healthy and degraded councils |
| passing checks plus blocking review | preserve both independent axes | persisted decision keeps `checks=passed`, `review=blocked` |
| approved review plus failed final verify | preserve review while changing checks | `review=approved`, `checks=failed` |

## Scope

This is the independently mergeable producer-correctness slice only.

**Partially addresses #29.**

It intentionally does not add a new terminal receipt, CLI/inspect projection, `requiredActions` vocabulary, invariant validator, or schema fields. Those broader requirements overlap #28 and the remaining #29/#31 work.

## Verification

- build: 30/30 tasks passed
- typecheck: 59/59 tasks passed
- test TypeScript project: passed
- final orchestrator suite: 157/157 tests passed
- delivery suite: 23/23 tests passed
- focused producer/council/fact-axis/cancellation matrix: 6/6 passed
- final canary: 26/26 tests passed
- full Node suite checkpoint: 157 files, 1726 tests passed
- docs truth, staged-field, retired-key, invariant links, sensitive ownership, MCP/CLI parity, release workflow, Knip, Prettier, complexity ratchet, and `git diff --check`: passed
