### PR TITLE
docs: improve npm discovery

### DIFF
--- a/.changeset/warm-searches-find.md
+++ b/.changeset/warm-searches-find.md
@@ -1,0 +1,5 @@
+---
+"claudexor": patch
+---
+
+Lead npm search metadata and the package README with quota-aware rotation across multiple Claude Code and Codex subscriptions, multi-harness workflows, and the product landing page.

--- a/packages/claudexor/README.md
+++ b/packages/claudexor/README.md
@@ -1,18 +1,32 @@
 # claudexor
 
-Harness-agnostic AI coding control plane: one CLI that drives Codex CLI,
-Claude Code, Cursor CLI, and OpenCode with cross-family review, best-of-N
-candidate runs, typed apply gates, and honest run artifacts.
+Local-first control plane for Claude Code, Codex, Cursor, and OpenCode. It keeps
+one Claudexor coding thread moving across harnesses and can track quota and
+rotate across multiple user-owned Claude Code and Codex subscriptions.
+
+- Route planning, implementation, and review through different coding agents.
+- Run Best-of-N candidates and cross-model reviews in isolated workspaces.
+- Continue across harness or account lanes with bounded context packets.
+- Inspect evidence, checks, review state, and typed apply gates before delivery.
+- Expose the same control plane to existing agents through a local MCP server.
+
+Quota telemetry and automatic subscription rotation apply to Claude Code and
+Codex. Cursor and OpenCode participate in the multi-harness pool. Claudexor does
+not migrate native vendor sessions between credential profiles.
 
 ```bash
 npm install -g claudexor
 claudexor doctor
-claudexor ask "what does this repo do?"
-claudexor agent "fix the failing test" --harness codex
-claudexor best-of "fix add()" --harness codex,claude --n 2
+
+claudexor ask "map this repository"
+claudexor agent "implement the approved plan" --harness codex
+claudexor best-of "review this patch" --harness codex,claude --n 2
+claudexor mcp serve
 ```
 
 This package is the bin wrapper over
-[`@claudexor/cli`](https://www.npmjs.com/package/@claudexor/cli). Full
-documentation lives in the
-[Claudexor repository](https://github.com/razzant/claudexor#readme).
+[`@claudexor/cli`](https://www.npmjs.com/package/@claudexor/cli).
+
+[Product overview](https://razzant.github.io/claudexor/) ·
+[documentation and source](https://github.com/razzant/claudexor#readme) ·
+[releases](https://github.com/razzant/claudexor/releases/latest)

--- a/packages/claudexor/package.json
+++ b/packages/claudexor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claudexor",
   "version": "3.0.4",
-  "description": "Harness-agnostic AI coding control plane — one CLI over Codex, Claude Code, Cursor, and OpenCode with cross-family review, best-of-N runs, and typed apply gates.",
+  "description": "Local-first multi-harness control plane for Claude Code, Codex, Cursor, and OpenCode with quota-aware rotation across multiple Claude Code and Codex subscriptions.",
   "type": "module",
   "bin": {
     "claudexor": "./bin/claudexor.js",
@@ -15,20 +15,32 @@
   },
   "keywords": [
     "ai",
-    "agents",
+    "ai-agents",
+    "ai-coding",
+    "ai-coding-assistant",
+    "agent-orchestration",
+    "best-of-n",
+    "claude-code",
     "cli",
+    "code-review",
     "codex",
-    "claude",
+    "codex-cli",
     "cursor",
+    "developer-tools",
     "mcp",
-    "orchestration"
+    "mcp-server",
+    "multi-account",
+    "multi-agent",
+    "opencode",
+    "quota-management",
+    "subscription-management"
   ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/razzant/claudexor.git",
     "directory": "packages/claudexor"
   },
-  "homepage": "https://github.com/razzant/claudexor#readme",
+  "homepage": "https://razzant.github.io/claudexor/",
   "bugs": {
     "url": "https://github.com/razzant/claudexor/issues"
   },


### PR DESCRIPTION
Improves the public claudexor package metadata and the README rendered on npm. The package now leads with multi-subscription quota rotation and multi-harness support, uses twenty targeted search keywords, links to the GitHub Pages product overview, documents the local MCP entrypoint, and states the exact quota and context boundaries.

This changes no runtime behavior and does not publish a package by itself. The included changeset carries the metadata into the next reviewed release, which already has a minor bump pending through the fixed workspace group.

Validated the JSON metadata, unique keyword count, description length, selected-file formatting, changeset status, and the actual packed tarball contents and rendered README.
