### PR TITLE
fix(cli): stabilize typed JSON failure projection

### DIFF
--- a/packages/cli/src/retry-command.test.ts
+++ b/packages/cli/src/retry-command.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  ensureDaemon: vi.fn(),
+  controlApiFetch: vi.fn(),
+  print: vi.fn(),
+  printJson: vi.fn(),
+  printUsageError: vi.fn(() => 2),
+}));
+
+vi.mock("./daemon-run.js", () => ({ ensureDaemon: mocks.ensureDaemon }));
+vi.mock("./live.js", () => ({ controlApiFetch: mocks.controlApiFetch }));
+vi.mock("./cli-io.js", async () => {
+  const real = await vi.importActual<typeof import("./cli-io.js")>("./cli-io.js");
+  return {
+    ...real,
+    print: mocks.print,
+    printJson: mocks.printJson,
+    printUsageError: mocks.printUsageError,
+  };
+});
+
+import { parseArgs } from "./args.js";
+import { retryCommand, runAgainCommand } from "./retry-command.js";
+
+/** The daemon re-projects every `>= 400` reply into a strict ControlProblem. */
+function problem(status: number, body: Record<string, unknown>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/problem+json" },
+  });
+}
+
+describe("retryCommand surfaces a typed refusal's message, not just its status", () => {
+  let stderrText = "";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stderrText = "";
+    mocks.ensureDaemon.mockResolvedValue({
+      addr: { baseUrl: "http://127.0.0.1:1234", token: "test" },
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+      stderrText += String(chunk);
+      return true;
+    });
+  });
+
+  it("prints the pre-start refusal text in text mode instead of a bare HTTP 403", async () => {
+    // Exactly what the control API answers when a replayed job dies before it
+    // binds a run: the trust gate's typed 403. The actionable sentence rides in
+    // `message`; there is no `error` key on the wire.
+    mocks.controlApiFetch.mockResolvedValue(
+      problem(403, {
+        code: "trust_full_access_required",
+        message: "full access is required for this project",
+        retryable: false,
+        fieldErrors: {},
+        requiredActions: [],
+        evidenceRefs: [],
+        context: { jobId: "job-retry-refused", state: "failed", retryOf: "run-d1" },
+      }),
+    );
+
+    expect(await retryCommand(parseArgs(["retry", "run-d1"]), false)).toBe(1);
+    expect(stderrText).toContain("full access is required for this project");
+    expect(stderrText).not.toContain("HTTP 403");
+  });
+
+  it("keeps the typed problem fields in the JSON envelope", async () => {
+    mocks.controlApiFetch.mockResolvedValue(
+      problem(403, {
+        code: "trust_full_access_required",
+        message: "full access is required for this project",
+        retryable: false,
+        fieldErrors: {},
+        requiredActions: ["grant full access to this project"],
+        evidenceRefs: [],
+        context: { retryOf: "run-d1" },
+      }),
+    );
+
+    expect(await retryCommand(parseArgs(["retry", "run-d1"]), true)).toBe(1);
+    expect(mocks.printJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ok: false,
+        code: "trust_full_access_required",
+        message: "claudexor retry: full access is required for this project",
+        // Legacy alias: consumers that read `error` off the CLI envelope keep working.
+        error: "claudexor retry: full access is required for this project",
+        retryable: false,
+        requiredActions: ["grant full access to this project"],
+        context: { retryOf: "run-d1" },
+      }),
+    );
+  });
+
+  it("still reads a legacy `error`-only body, so an old sender does not regress", async () => {
+    mocks.controlApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: "no such run" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(await retryCommand(parseArgs(["retry", "run-gone"]), false)).toBe(1);
+    expect(stderrText).toContain("no such run");
+  });
+
+  it("leaves an accepted retry reporting its handle", async () => {
+    mocks.controlApiFetch.mockResolvedValue(
+      new Response(JSON.stringify({ state: "queued", jobId: "job-9" }), {
+        status: 202,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    expect(await retryCommand(parseArgs(["retry", "run-d1"]), false)).toBe(0);
+    expect(mocks.print).toHaveBeenCalledWith("retry run-d1: queued (job-9)");
+  });
+
+  it("run-again reports its refusal the same way", async () => {
+    mocks.controlApiFetch.mockResolvedValue(
+      problem(409, {
+        code: "run_busy",
+        message: "run is still running",
+        retryable: true,
+        fieldErrors: {},
+        requiredActions: [],
+        evidenceRefs: [],
+        context: {},
+      }),
+    );
+
+    expect(await runAgainCommand(parseArgs(["run-again", "run-d1"]), false)).toBe(1);
+    expect(stderrText).toContain("run is still running");
+    expect(stderrText).not.toContain("HTTP 409");
+  });
+});

--- a/packages/cli/src/retry-command.ts
+++ b/packages/cli/src/retry-command.ts
@@ -1,5 +1,21 @@
+/**
+ * `claudexor retry` / `claudexor run-again`.
+ *
+ * Both refusals go through the SAME projector the rest of the CLI uses
+ * (`controlProblemError` → `renderCliFailure`), because the daemon does not
+ * serve the field these commands used to read. Every `>= 400` reply from the
+ * control API is re-projected into a strict `ControlProblem` before it reaches
+ * the wire, so the human text arrives in `message` and there is no `error` key
+ * at all — reading `data["error"]` therefore always fell through to a bare
+ * `HTTP <status>` and threw away the actionable refusal. The projector reads
+ * `message` first and still salvages a legacy `error` body, so a sender that
+ * has not moved to problem+json does not regress, and the typed fields
+ * (`code`/`retryable`/`requiredActions`/`context`) survive instead of being
+ * flattened into one string.
+ */
 import type { ParsedArgs } from "./args.js";
 import { print, printJson, printUsageError } from "./cli-io.js";
+import { controlProblemError, renderCliFailure } from "./cli-error.js";
 import { ensureDaemon } from "./daemon-run.js";
 import { controlApiFetch } from "./live.js";
 
@@ -14,16 +30,15 @@ export async function retryCommand(args: ParsedArgs, json: boolean): Promise<num
       body: "{}",
     });
     const data = (await response.json()) as Record<string, unknown>;
-    if (!response.ok) throw new Error(String(data["error"] ?? `HTTP ${response.status}`));
+    // A pre-start terminal (the trust gate's typed 403, a requirements refusal)
+    // answers here — its message is what the operator has to act on.
+    if (!response.ok) throw controlProblemError(response.status, data, `HTTP ${response.status}`);
     if (json) printJson(data);
     else
       print(`retry ${runId}: ${String(data["state"])} (${String(data["runId"] ?? data["jobId"])})`);
     return 0;
   } catch (error) {
-    return printUsageError(
-      json,
-      `claudexor retry: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    return renderCliFailure(json, error, { messagePrefix: "claudexor retry:" });
   }
 }
 
@@ -36,7 +51,7 @@ export async function runAgainCommand(args: ParsedArgs, json: boolean): Promise<
       headers: { Authorization: `Bearer ${addr.token}` },
     });
     const data = (await response.json()) as Record<string, unknown>;
-    if (!response.ok) throw new Error(String(data["error"] ?? `HTTP ${response.status}`));
+    if (!response.ok) throw controlProblemError(response.status, data, `HTTP ${response.status}`);
     if (json) printJson(data);
     else {
       print(`editable Run Again draft from ${runId}:`);
@@ -49,9 +64,6 @@ export async function runAgainCommand(args: ParsedArgs, json: boolean): Promise<
     }
     return 0;
   } catch (error) {
-    return printUsageError(
-      json,
-      `claudexor run-again: ${error instanceof Error ? error.message : String(error)}`,
-    );
+    return renderCliFailure(json, error, { messagePrefix: "claudexor run-again:" });
   }
 }

--- a/packages/control-api/src/control-api.test.ts
+++ b/packages/control-api/src/control-api.test.ts
@@ -6957,6 +6957,45 @@ describe("DaemonControlApiServer", () => {
     });
   });
 
+  it("Exact Retry projects a pre-start terminal as its typed refusal, not a 202 handle", async () => {
+    const { daemon, record } = fakeDaemon();
+    // The replay is queued, but the job dies BEFORE it binds a run: the trust
+    // gate refuses with a typed 403. A 202 durable handle here would promise a
+    // run that never appears (and `claudexor retry` would exit 0 on it).
+    const refusing: DaemonFacadeClient = {
+      ...daemon,
+      async enqueue() {
+        return { id: "job-retry-refused", state: "queued" };
+      },
+      async status(id: string) {
+        if (id === record.id) return record;
+        return {
+          id: "job-retry-refused",
+          state: "failed",
+          error: "full access is required for this project",
+          errorCode: "trust_full_access_required",
+          errorStatus: 403,
+        };
+      },
+    };
+    await withDaemonServer(refusing, async (base) => {
+      const response = await apiFetch(`${base}/runs/run-d1/retry`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "Idempotency-Key": "refused-retry" },
+        body: "{}",
+      });
+      expect(response.status).toBe(403);
+      expect(await response.json()).toMatchObject({
+        code: "trust_full_access_required",
+        message: "full access is required for this project",
+        retryable: false,
+        // The retry's own identity rides as bounded context, so a client knows
+        // WHICH replay was refused.
+        context: { jobId: "job-retry-refused", state: "failed", retryOf: "run-d1" },
+      });
+    });
+  });
+
   it("QA-035: Exact Retry replays the model+effort frozen in the source contract despite a settings change", async () => {
     const { daemon, record } = fakeDaemon();
     // The source run FROZE its config-derived route into the immutable contract.

--- a/packages/control-api/src/control-api.test.ts
+++ b/packages/control-api/src/control-api.test.ts
@@ -6996,6 +6996,104 @@ describe("DaemonControlApiServer", () => {
     });
   });
 
+  it("Exact Retry fails an UNTYPED pre-start terminal as 500, not a 202 handle", async () => {
+    const { daemon, record } = fakeDaemon();
+    // No errorCode and no errorStatus: an infra terminal (cancelled/killed
+    // before a run bound) that proves nothing about retryability. It still
+    // never binds a run, so a 202 durable handle would be a lie; without a
+    // typed refusal to key a status on, it is the generic 500 that POST /runs
+    // already returns for the same record.
+    const untyped: DaemonFacadeClient = {
+      ...daemon,
+      async enqueue() {
+        return { id: "job-retry-untyped", state: "queued" };
+      },
+      async status(id: string) {
+        if (id === record.id) return record;
+        return {
+          id: "job-retry-untyped",
+          state: "cancelled",
+          error: "job was cancelled before it bound a run",
+        };
+      },
+    };
+    await withDaemonServer(untyped, async (base) => {
+      const response = await apiFetch(`${base}/runs/run-d1/retry`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "Idempotency-Key": "untyped-retry" },
+        body: "{}",
+      });
+      expect(response.status).toBe(500);
+      const body = (await response.json()) as Record<string, unknown>;
+      expect(body).toMatchObject({
+        // No typed refusal code to serve, so the problem projection's generic
+        // status code stands in — the retry never claims a product taxonomy it
+        // was not given.
+        code: "http_500",
+        message: "job was cancelled before it bound a run",
+        context: { jobId: "job-retry-untyped", state: "cancelled", retryOf: "run-d1" },
+      });
+      // The 202 shape carried `runId: null` as a durable handle. A refusal has
+      // no handle at all.
+      expect(body).not.toHaveProperty("runId");
+    });
+  });
+
+  it("Exact Retry of a THREAD turn carries the new turnId into the refusal context", async () => {
+    const { daemon, record } = fakeDaemon();
+    record.params = {
+      ...(record.params as Record<string, unknown>),
+      threadId: "th-source",
+      turnId: "tn-source",
+    };
+    // The thread-scoped retry pre-creates its replacement turn BEFORE the
+    // enqueue, so the refusal must disclose WHICH turn is now stranded —
+    // otherwise the client cannot bind the failure to the turn it just made.
+    const refusing: DaemonFacadeClient = {
+      ...daemon,
+      async enqueue() {
+        return { id: "job-retry-thread", state: "queued" };
+      },
+      async status(id: string) {
+        if (id === record.id) return record;
+        return {
+          id: "job-retry-thread",
+          state: "failed",
+          error: "journal recovery is required for this project",
+          errorCode: "journal_recovery_required",
+          errorStatus: 409,
+        };
+      },
+    };
+    const services: DaemonControlApiOptions["services"] = {
+      createThreadTurn: async () => ({ id: "tn-retry" }),
+    };
+    await withDaemonServer(
+      refusing,
+      async (base) => {
+        const response = await apiFetch(`${base}/runs/run-d1/retry`, {
+          method: "POST",
+          headers: { authorization: `Bearer ${token}`, "Idempotency-Key": "thread-retry-refused" },
+          body: "{}",
+        });
+        expect(response.status).toBe(409);
+        expect(await response.json()).toMatchObject({
+          code: "journal_recovery_required",
+          message: "journal recovery is required for this project",
+          retryable: false,
+          context: {
+            jobId: "job-retry-thread",
+            state: "failed",
+            retryOf: "run-d1",
+            turnId: "tn-retry",
+          },
+        });
+      },
+      undefined,
+      services,
+    );
+  });
+
   it("QA-035: Exact Retry replays the model+effort frozen in the source contract despite a settings change", async () => {
     const { daemon, record } = fakeDaemon();
     // The source run FROZE its config-derived route into the immutable contract.

--- a/packages/control-api/src/run-retry-routes.ts
+++ b/packages/control-api/src/run-retry-routes.ts
@@ -134,6 +134,14 @@ async function exactRetry(
     // will never exist, and `claudexor retry` would exit 0 on a refusal. POST
     // /runs and POST /threads/:id/turns already project a pre-start terminal
     // as its typed failure; Exact Retry was the one surface that did not.
+    //
+    // The status mapping deliberately follows POST /runs
+    // (`runStart.unboundRunStartResponse`): the persisted `errorStatus`
+    // verbatim, otherwise 500. The sibling turn surface
+    // (`preStartRefusalStatus` in thread-turn-routes.ts) additionally maps a
+    // status-less `trust_full_access_required` to 403, so a trust refusal
+    // recorded WITHOUT an errorStatus is mapped differently by the two
+    // surfaces. Unifying them is out of scope here.
     const { status, body } = runStart.unboundRunStartResponse(accepted, true);
     return ctx.json(res, status, {
       ...body,

--- a/packages/control-api/src/run-retry-routes.ts
+++ b/packages/control-api/src/run-retry-routes.ts
@@ -15,6 +15,7 @@ import type {
   DaemonRunRecord,
 } from "./daemon-server.js";
 import { recordTurnEnqueueFailure } from "./thread-turn-routes.js";
+import { TERMINAL_STATES } from "./sse-shared.js";
 import * as runStart from "./run-start.js";
 
 type RetryServices = Pick<
@@ -127,6 +128,19 @@ async function exactRetry(
     return ctx.requestError(res, error);
   }
   const accepted = await ctx.waitForRunStart(job.id);
+  if (!accepted.runId && TERMINAL_STATES.has(accepted.state)) {
+    // The replayed job died BEFORE it bound a run (e.g. the trust gate's typed
+    // 403). A 202 here would hand the caller a durable handle for a run that
+    // will never exist, and `claudexor retry` would exit 0 on a refusal. POST
+    // /runs and POST /threads/:id/turns already project a pre-start terminal
+    // as its typed failure; Exact Retry was the one surface that did not.
+    const { status, body } = runStart.unboundRunStartResponse(accepted, true);
+    return ctx.json(res, status, {
+      ...body,
+      retryOf: sourceRunId,
+      ...(retryTurnId ? { turnId: retryTurnId } : {}),
+    });
+  }
   ctx.json(
     res,
     accepted.runId ? 200 : 202,


### PR DESCRIPTION
## Summary

- centralize non-streaming CLI `--json` failures behind one safe typed projector across parser, command validation, preflight, daemon bootstrap, control API, lifecycle, and unexpected-error paths
- make usage/validation failures exit 2 and operational/unexpected failures exit 1 while preserving safe `code`, `status`, `retryable`, `fieldErrors`, `requiredActions`, `evidenceRefs`, and `context`
- project Zod issues into concise field errors, preserve typed daemon/API problems across durable boundaries, and harden serialization against secrets, hostile values, cycles, collisions, and truncation-boundary leaks
- add built-CLI contract coverage for synthetic `EPERM/fchmod`, `best-of --n 0`, inline-secret rejection, daemon/lifecycle failures, parser/bootstrap fallbacks, and exact one-object stdout purity
- keep the historical multi-frame `--json-stream`/NDJSON wire contract unchanged

## Verification

- `turbo run build`: 30/30
- `turbo run typecheck`: 59/59
- test TypeScript project: passed
- Vitest: 163 files, 1823 tests passed
- built-CLI canary: 3 files, 36 tests passed
- generated schemas, docs truth, staged/retired/invariant/sensitive ownership, complexity, concept, MCP/CLI parity, Swift fixtures, release workflow, Knip, and Prettier gates: passed
- model-hints and fixture-freshness non-strict gates passed with the existing local CLI-version drift warnings (Codex 0.144.6 vs 0.144.1; Claude 2.1.218 vs 2.1.165)

Base verified at `756b40d1`; no open upstream PRs at publication time.

Closes #28