### PR TITLE
fix(ci): publish a check run actually named build-test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,32 @@ jobs:
           node packages/cli/dist/cli.js doctor --json > /tmp/doctor.json
           node -e 'const j=JSON.parse(require("node:fs").readFileSync("/tmp/doctor.json","utf8")); if(!Array.isArray(j.harnesses)) { console.error("doctor --json did not produce a harnesses array"); process.exit(1); }'
 
+  # Branch protection on main requires a check context literally named
+  # `build-test`. The job above never publishes one: a matrix job's check runs
+  # are named from its `name:` template, so it reports as "Node 20.19.0" and
+  # "Node 24.16.0" and the required context stays pending forever (every PR
+  # sits at BLOCKED). This aggregate exists only to publish that name.
+  # `if: always()` is load-bearing — without it the job is skipped when the
+  # matrix fails or is cancelled, and a skipped required check never reports.
+  build-test-gate:
+    name: build-test
+    needs: build-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every Node matrix leg to succeed
+        # `needs.<job>.result` collapses the whole matrix: it is `success` only
+        # when every leg succeeded (fail-fast: false means all of them ran).
+        env:
+          MATRIX_RESULT: ${{ needs.build-test.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$MATRIX_RESULT" != "success" ]; then
+            echo "::error::Node matrix result is '$MATRIX_RESULT' (expected 'success')."
+            exit 1
+          fi
+
   swift:
     runs-on: macos-26
     steps:


### PR DESCRIPTION
## What & why

Branch protection on main requires a status check named `build-test`, and no such check has ever been published. The job with that id carries `name: Node ${{ matrix.node-version }}`, and a matrix job's check runs are named from the `name:` template, so what actually reports is "Node 20.19.0" and "Node 24.16.0". The required context therefore stays pending forever and every pull request sits at BLOCKED, which is why merges have been going through an admin bypass rather than through the gate.

This adds an aggregate job whose check-run name is exactly `build-test` and whose only job is to publish that name. It fails unless the whole matrix succeeded. `if: always()` is load bearing: without it the job is skipped when the matrix fails or is cancelled, and a skipped required check never reports at all, which would recreate the same stuck state on exactly the runs that matter.

The matrix job itself is untouched, byte for byte. The matrix result is passed through `env:` rather than interpolated into the `run:` block because `scripts/release-workflow-check.mjs` rejects an expression on or inside a `run:` line.

## Checks

- [x] `pnpm release:workflow:check` passes; `prettier --check` clean on the changed file; job graph parsed and verified
- [x] Docs updated in the SAME PR where behavior they describe changed (none describe this)
- [x] `CLAUDEXOR_BIBLE.md` not changed
- [x] No secrets, tokens, or machine-local paths in the diff
