### PR TITLE
fix(budget): the auto ranking pass reads one pinned clock, not one Date.now() per candidate

### DIFF
--- a/packages/budget/src/budget.test.ts
+++ b/packages/budget/src/budget.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { BudgetLedger, promptFingerprint, routeCostEvidence } from "./ledger.js";
 import { observationsFromEvent } from "./observe.js";
 import {
@@ -1040,6 +1040,43 @@ describe("routing telemetry", () => {
       expect(r.reason).toBe("declared_order");
       // Equal slacks: the stable sort preserves the declared input order.
       expect(r.order).toEqual(["claude", "codex"]);
+    });
+
+    // The above used to be a coin flip on a busy machine: the ranking pass read
+    // Date.now() once per candidate, so a millisecond crossing between the two
+    // reads made two IDENTICAL quota states differ by ~5.6e-11 of pace slack,
+    // the comparator returned a non-zero order, and the rationale claimed
+    // expiring_quota_slack. This pins the clock to advance on EVERY read, which
+    // turns that race into a certainty; the pass must still see equal slacks
+    // because it evaluates them at one instant.
+    it("holds declared_order when the clock ticks between reads (one pinned instant per pass)", () => {
+      const led = new BudgetLedger();
+      const base = Date.now();
+      const reset = new Date(base + 9_000_000).toISOString();
+      for (const harness_id of ["codex", "claude"] as const) {
+        led.observe({
+          harness_id,
+          ts: new Date(base).toISOString(),
+          quality: "native",
+          kind: "quota_constraint",
+          constraint_id: "five-hour",
+          used_ratio: 0.3,
+          window_seconds: 18_000,
+          resets_at: reset,
+        });
+      }
+      let tick = 0;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => base + tick++);
+      try {
+        const r = explainRanking([cand("claude"), cand("codex")], routeContext(led, "auto"));
+        expect(r.reason).toBe("declared_order");
+        expect(r.order).toEqual(["claude", "codex"]);
+        // One pinned instant for the whole pass: the sort and the reason walk
+        // may not each pin their own, or they could explain different orders.
+        expect(tick).toBe(1);
+      } finally {
+        clock.mockRestore();
+      }
     });
   });
 

--- a/packages/budget/src/router.ts
+++ b/packages/budget/src/router.ts
@@ -67,6 +67,13 @@ export interface RouteContext {
   intent: Intent;
   qualityTiers: QualityTierSet;
   ledger: BudgetLedger;
+  /**
+   * The instant EVERY clock-dependent axis is evaluated at (cooldown expiry and
+   * quota pace slack). Optional: each entry point pins one `Date.now()` for the
+   * whole call when it is absent. A caller that ranks a pool and then explains
+   * the SAME pool must pass a pinned instant so both passes read one clock.
+   */
+  now?: number;
 }
 
 export class RoutingPreflightError extends Error {
@@ -97,6 +104,18 @@ function isIncrementalPaid(candidate: RouterCandidate): boolean {
   return !["proven_zero", "subscription_entitlement"].includes(effectiveBilling(candidate));
 }
 
+/**
+ * Pin ONE evaluation instant for a whole ranking pass. Reading the clock again
+ * per candidate makes the comparator time-varying: two candidates carrying
+ * IDENTICAL quota observations get slacks that differ by whatever milliseconds
+ * elapsed between the two reads, so a pool nothing actually separates is
+ * ordered by scheduler jitter and reports `expiring_quota_slack` instead of the
+ * honest `declared_order`. The pin is what makes equal inputs compare equal.
+ */
+function pinInstant(ctx: RouteContext): RouteContext {
+  return ctx.now === undefined ? { ...ctx, now: Date.now() } : ctx;
+}
+
 function eligible(candidates: RouterCandidate[], ctx: RouteContext): RouterCandidate[] {
   const ready = candidates.filter(
     (candidate) =>
@@ -105,6 +124,7 @@ function eligible(candidates: RouterCandidate[], ctx: RouteContext): RouterCandi
         candidate.harnessId,
         candidate.credentialRoute,
         candidate.credentialSubjectId,
+        ctx.now,
       ),
   );
   const free = ready.filter((candidate) => !isIncrementalPaid(candidate));
@@ -119,12 +139,15 @@ function tierValueOf(candidate: RouterCandidate, ctx: RouteContext): number {
   return tierIndex(candidate, ctx) ?? Number.MAX_SAFE_INTEGER;
 }
 
-/** Binding pace slack the `auto` comparator orders by; null = none observed. */
+/** Binding pace slack the `auto` comparator orders by; null = none observed.
+ * Evaluated at the pass-wide pinned instant (`ctx.now`) — never at a freshly
+ * read clock, which would make two identical quota states differ. */
 function autoSlack(candidate: RouterCandidate, ctx: RouteContext): number | null {
   return ctx.ledger.bindingPaceSlack(
     candidate.harnessId,
     candidate.credentialRoute,
     candidate.credentialSubjectId,
+    ctx.now,
   );
 }
 
@@ -148,6 +171,11 @@ type AutoRankAxis = "expiring_quota_slack" | "quality_tier";
  * two EQUAL non-null slacks yield order 0 and a null axis (declared order, and
  * the sort does NOT fall through to tiers). Only when BOTH slacks are absent
  * does the comparator compare tier indices.
+ *
+ * Both slacks are read at the pass-wide pinned instant (`ctx.now`), so the
+ * subtraction compares two quota states and nothing else. Re-reading the clock
+ * per candidate made the comparator time-varying and broke exactly the
+ * guarantee above: equal quota states produced a non-zero order.
  */
 function compareAutoTraced(
   a: RouterCandidate,
@@ -165,7 +193,11 @@ function compareAutoTraced(
 }
 
 /** Order candidates transparently; lower tuple values win. Unknown quota remains eligible. */
-export function rankHarnesses(candidates: RouterCandidate[], ctx: RouteContext): RouterCandidate[] {
+export function rankHarnesses(
+  candidates: RouterCandidate[],
+  context: RouteContext,
+): RouterCandidate[] {
+  const ctx = pinInstant(context);
   const routes = eligible(candidates, ctx);
   if (ctx.goal === "quality" && routes.every((candidate) => tierIndex(candidate, ctx) === null)) {
     throw new RoutingPreflightError(
@@ -207,8 +239,11 @@ export function selectHarness(
  */
 export function explainRanking(
   candidates: RouterCandidate[],
-  ctx: RouteContext,
+  context: RouteContext,
 ): RouteRankingRationale {
+  // ONE instant for both passes: the sort and the reason walk must read the same
+  // clock, or the recorded rationale can disagree with the order it explains.
+  const ctx = pinInstant(context);
   const rankedCandidates = rankHarnesses(candidates, ctx);
   const order = rankedCandidates.map((c) => c.harnessId);
   const eligibleIds = new Set(order);

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1657,13 +1657,13 @@ export class Orchestrator {
         intent,
         qualityTiers: config.routing.quality_tiers,
         ledger: routeLedger,
+        now: Date.now(), // ONE instant for the sort AND the rationale below
       };
       const ranked = rankHarnesses(remaining, routeCtx)
         .map((candidate) => byId.get(candidate.harnessId))
         .filter((candidate): candidate is RoutedAdapter => Boolean(candidate));
-      // QA-034: record the typed rationale ONCE at pool ordering (run evidence,
-      // not an event). Axis-aligned with rankHarnesses above so the persisted
-      // reason can never disagree with the order actually taken.
+      // QA-034: the rationale is run evidence recorded ONCE at pool ordering,
+      // pinned to routeCtx.now so it cannot disagree with the order just taken.
       if (runId) this.routingRationaleByRun.set(runId, explainRanking(remaining, routeCtx));
       ordered = ranked;
     }


### PR DESCRIPTION
## What & why

Main went red on Node 20.19.0 with

```
FAIL packages/budget/src/budget.test.ts > routing telemetry > auto ranking rationale mirrors the comparator branch (round-2 #1) > reports declared_order for EQUAL non-null slacks (does not fall through to tiers)
AssertionError: expected 'expiring_quota_slack' to be 'declared_order'
```

on a commit that touched only a workflow schedule. The defect is in the ranking code, not in the test fixture.

`autoSlack` called `BudgetLedger.bindingPaceSlack` without a `now` argument, so the ledger fell back to its `now = Date.now()` default and read the clock once per candidate. `eligible` did the same through `cooldownActive`. Two candidates carrying identical quota observations were therefore measured against two different instants, and the difference leaked straight into the value the comparator subtracts:

```
remaining = (resetMs - now) / 1000 / window_seconds
slack     = 1 - remaining - used_ratio
```

For the five-hour window in the test, one millisecond between the two reads is about 5.6e-11 of pace slack. That is not zero, so `compareAutoTraced` returned a non-zero order and labelled the axis `expiring_quota_slack` for a pool that nothing had actually separated. `explainRanking` compounded it by walking the ranked pool through the comparator a second time at yet another set of instants, so the recorded rationale could describe an ordering the sort never took, which is precisely the guarantee that comparator was written to provide.

This was not only a test problem. In production the same re-read means a routing decision between two equally paced harnesses can be settled by scheduler jitter rather than by quota, and the persisted `routing_rationale` can name a factor the run did not use.

The fix pins one evaluation instant per pass. `RouteContext` gains an optional `now`; `rankHarnesses` and `explainRanking` pin a single `Date.now()` when the caller does not supply one; `explainRanking` shares its instant with both the sort and the reason walk; and the orchestrator pins the instant that its `rankHarnesses` and `explainRanking` calls share, so the persisted rationale and the executed order weigh the same quota state. The assertion was not loosened.

The new test makes the race deterministic instead of probabilistic: it stubs `Date.now` to advance on every read, which is the worst case the old code could hit, and asserts both that the reason stays `declared_order` and that the whole pass consumes exactly one clock read.

Evidence:

- The failure reproduces on the unfixed code with the clock stubbed to advance per read, giving the exact CI message. Reverting only `router.ts` and running the new test yields `expected "declared_order", received "expiring_quota_slack"`.
- `pnpm vitest run packages/budget/src/budget.test.ts` in a loop: 30/30 green after the fix, plus 35 green runs on the pre-rebase tree.
- Full `pnpm test`: 197 files, 2280 tests, all passing.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass
- [x] Docs updated in the SAME PR where behavior they describe changed. No documented behavior changed; the comparator contract is unchanged, this makes it hold.
- [x] `CLAUDEXOR_BIBLE.md` not changed, so no `CONCEPT-CHANGE(INV-xxx)` marker is needed
- [x] No secrets, tokens, or machine-local paths in the diff

Also verified: `pnpm knip`, `pnpm format:check`, and `node scripts/complexity-ratchet.mjs` pass. The orchestrator edit is line-neutral, so `orchestrator.ts` stays under its ratchet baseline.
