### PR TITLE
fix(deps): pin fast-uri to the patched 3.1.4 (GHSA-v2hh-gcrm-f6hx)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: ^3.1.4
+
 importers:
 
   .:
@@ -1327,8 +1330,8 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
-  fast-uri@3.1.3:
-    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2509,7 +2512,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2617,7 +2620,7 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,3 +17,10 @@ allowBuilds:
 # pnpm can run an implicit deps-status check before every `pnpm run` that
 # auto-installs; disable it and rely on explicit installs.
 verifyDepsBeforeRun: false
+
+# Security floor for a transitive dependency. fast-uri < 3.1.4 carries
+# GHSA-v2hh-gcrm-f6hx; it reaches us only through ajv, whose range (^3.0.1)
+# already permits the patched release, so this pins the floor without a
+# version bump anywhere else. Remove once ajv itself requires >=3.1.4.
+overrides:
+  fast-uri: ^3.1.4


### PR DESCRIPTION
## What & why

Closes the open high-severity Dependabot alert GHSA-v2hh-gcrm-f6hx by moving the
resolved `fast-uri` from 3.1.3 to the patched 3.1.4.

`fast-uri` is not a direct dependency. It enters the tree only through `ajv`:

```
fast-uri@3.1.3
└─┬ ajv@8.20.0
  ├─┬ ajv-formats@3.0.1
  │ └── claudexor-monorepo@3.1.0
  └── claudexor-monorepo@3.1.0
```

Bumping `ajv` is neither possible nor necessary: 8.20.0 is already the latest
release, and its declared range is `fast-uri: ^3.0.1`, which already permits the
patched 3.1.4. Only the lockfile was pinned to the vulnerable build. Letting pnpm
re-resolve the full transitive depth would have dragged unrelated packages along
(lightningcss 1.32.0 to 1.33.0, postcss 8.5.19 to 8.5.23), so the floor is pinned
narrowly instead, with an `overrides` entry scoped to `fast-uri` alone. The entry
lives in `pnpm-workspace.yaml` because pnpm 10 no longer reads `pnpm.overrides`
from `package.json` and warns when it is present there. The override can be
deleted as soon as `ajv` itself requires `fast-uri >=3.1.4`.

The resulting diff is the override entry plus the lockfile lines carrying the new
version and integrity hash. No other package changed version.

Reachability of the advisory here is low. `fast-uri` is ajv's URI parser for
`$id` and `$ref` resolution, and caller-supplied output schemas never reach it
with an arbitrary URI: `packages/schema/src/output-schema.ts` refuses external
references at the boundary, requiring every `$ref` to be a local JSON Pointer
fragment, and rejects `$ref`-wrapped or non-object roots. The alert is still
closed properly rather than dismissed, because `ajv` sits on a production path in
`packages/orchestrator/src/structuredOutput.ts` and the Dependabot "development"
scope label is misleading.

Verification:

```
$ pnpm why fast-uri     # before
fast-uri@3.1.3
└─┬ ajv@8.20.0
  ├─┬ ajv-formats@3.0.1
  │ └── claudexor-monorepo@3.1.0 (devDependencies)
  └── claudexor-monorepo@3.1.0 (devDependencies)

$ pnpm why fast-uri     # after
fast-uri@3.1.4
└─┬ ajv@8.20.0
  ├─┬ ajv-formats@3.0.1
  │ └── claudexor-monorepo@3.1.0 (devDependencies)
  └── claudexor-monorepo@3.1.0 (devDependencies)
```

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass
- [x] Docs updated in the SAME PR where behavior they describe changed
      (no behavior changed; nothing in docs to update)
- [x] If `CLAUDEXOR_BIBLE.md` changed: the commit carries a
      `CONCEPT-CHANGE(INV-xxx)` marker approved by the maintainer
      (the Bible is untouched)
- [x] No secrets, tokens, or machine-local paths in the diff
