### PR TITLE
chore(deps): keep major dependency bumps out of the dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    # Raised from 5 with the group change: the two group PRs (dev + prod) used
+    # to leave four free slots, but now every pending major wants a slot of its
+    # own. At 5 a week with four concurrent majors would silently defer the
+    # overflow until an earlier PR closes, which is the opposite of the intent.
+    open-pull-requests-limit: 10
     groups:
       dev-dependencies:
         dependency-type: "development"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
 updates:
-  # npm (pnpm workspace) — grouped so the flood of transitive bumps arrives as
-  # a small number of reviewable PRs, not one per package.
+  # npm (pnpm workspace) — minor/patch bumps arrive grouped so the flood of
+  # transitive updates is a small number of reviewable PRs, but MAJORS are
+  # deliberately excluded from the groups so each one arrives alone. A grouped
+  # major is unreviewable in practice: the July 2026 dev group shipped
+  # TypeScript 7 (which drops the root programmatic compiler API the ownership
+  # gate calls) in the same PR as a Prettier patch, and the production group
+  # shipped Zod 4 (changed `.default({})` / `z.record` semantics) alongside an
+  # unrelated SDK bump. Both were red and neither could be salvaged by dropping
+  # a file.
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -10,10 +17,20 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+        update-types: ["minor", "patch"]
       production-dependencies:
         dependency-type: "production"
+        update-types: ["minor", "patch"]
+    ignore:
+      # The runtime matrix is Node 20.19 / 24.16. A newer @types/node lets code
+      # typecheck against APIs that do not exist on the oldest supported
+      # runtime, so the major tracks the runtime floor by hand, not by bot.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
-  # GitHub Actions used by CI and the release workflow.
+  # GitHub Actions used by CI and the release workflow. Left ungrouped on
+  # purpose: each action pins a full commit SHA that has to be verified against
+  # the upstream tag one at a time.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## What & why

Dependabot groups every development dependency into one PR and every production dependency into another, regardless of how big the jump is. That works for the transitive minor and patch flood it was set up for, and it does not work for majors. The July batch produced #50, where TypeScript 7 rode along with a Prettier patch, and #51, where Zod 4 rode along with an SDK bump. Both were red for reasons specific to the major, and neither could be salvaged by dropping a file, so both are being replaced by narrow PRs.

Minor and patch updates stay grouped. Majors now fall out of the groups and arrive one per PR, which is the only form in which they can actually be reviewed. The `@types/node` major is additionally ignored, because the supported runtime matrix is Node 20.19 and 24.16 and a newer types package lets code typecheck against APIs the oldest supported runtime does not have.

The open PR limit for npm goes from 5 to 10 in the same change. With majors out of the groups, the two group PRs plus a cap of 5 left room for only three majors at a time, and the overflow would have been deferred silently until an earlier PR closed, which is the opposite of the intent.

The GitHub Actions ecosystem stays ungrouped, as before, since each action pins a full commit SHA that has to be checked against the upstream tag individually.

## Checks

- [x] Config-only change, no code paths touched; `prettier --check` clean
- [x] Docs updated in the SAME PR where behavior they describe changed (none describe this)
- [x] `CLAUDEXOR_BIBLE.md` not changed
- [x] No secrets, tokens, or machine-local paths in the diff
