### PR TITLE
chore(deps): bump the ACP SDK to 1.3.0

### DIFF
--- a/packages/acp-server/package.json
+++ b/packages/acp-server/package.json
@@ -16,7 +16,7 @@
     "dist"
   ],
   "dependencies": {
-    "@agentclientprotocol/sdk": "1.2.1",
+    "@agentclientprotocol/sdk": "1.3.0",
     "@claudexor/schema": "workspace:*",
     "@claudexor/util": "workspace:*"
   },

--- a/packages/acp-server/src/acp.test.ts
+++ b/packages/acp-server/src/acp.test.ts
@@ -93,10 +93,15 @@ describe("AcpServer official SDK projection", () => {
       }
     };
     await withClient(runner, async (agent, updates) => {
+      // The stable ACP protocol version this server negotiates is pinned to the
+      // literal 1 (docs/INTEGRATIONS.md). An SDK bump that moves the stable wire
+      // version must fail here rather than silently renegotiate.
+      expect(ACP_PROTOCOL_VERSION).toBe(1);
       const initialized = await agent.request(acp.methods.agent.initialize, {
         protocolVersion: ACP_PROTOCOL_VERSION,
         clientCapabilities: {},
       });
+      expect(initialized.protocolVersion).toBe(1);
       expect(initialized.agentCapabilities).toMatchObject({
         loadSession: true,
         sessionCapabilities: { list: {}, resume: {}, close: {} },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
   packages/acp-server:
     dependencies:
       '@agentclientprotocol/sdk':
-        specifier: 1.2.1
-        version: 1.2.1(zod@4.4.3)
+        specifier: 1.3.0
+        version: 1.3.0(zod@4.4.3)
       '@claudexor/schema':
         specifier: workspace:*
         version: link:../schema
@@ -524,8 +524,8 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/sdk@1.2.1':
-    resolution: {integrity: sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==}
+  '@agentclientprotocol/sdk@1.3.0':
+    resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -1927,7 +1927,7 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/sdk@1.2.1(zod@4.4.3)':
+  '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 


### PR DESCRIPTION
## What & why

The ACP SDK part of #51, taken on its own: `@agentclientprotocol/sdk` 1.2.1 to 1.3.0. Zod 4 and the MCP server beta stay out; Zod 4 is a schema migration rather than a dependency bump and needs its own behavioral fixtures.

Verified rather than assumed. `PROTOCOL_VERSION` reads 1 on both 1.2.1 and 1.3.0, and the upstream schema v1.20.0 change is a separate axis from the wire version. The root export surface is byte identical between the two releases, same 22 names, and the v2 work is reachable only through a new experimental subpath that this repo does not import.

One real behavior change on the stable path is worth recording: 1.3.0 sets `allowBatches: false` on v1 connections, so JSON-RPC batch arrays are now refused. The bridge speaks the SDK's own ndJsonStream connection and never constructs batches, so nothing here is affected.

The existing initialize plus session round-trip test passed unchanged. It previously asserted the negotiated version only against the SDK's own constant, which would have let an upstream renegotiation pass silently, so it now pins the literal 1 on both the request and the initialize response.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass; `format:check` clean
- [x] Docs updated in the SAME PR where behavior they describe changed (none describe this)
- [x] `CLAUDEXOR_BIBLE.md` not changed
- [x] No secrets, tokens, or machine-local paths in the diff
