### PR TITLE
docs(contributing): align the review-protocol summary with the sealed v4 protocol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,10 @@ node scripts/fixture-freshness-check.mjs  # recorded fixtures carry provenance +
 
 Review authority is the cumulative diff on an exact, clean, committed and
 frozen candidate SHA, reviewed under the Owner-review release protocol in
-[`docs/CHECKLISTS.md`](docs/CHECKLISTS.md) (at least two independent
-full-context reviewer subagents, at most three rounds, sealed schemaVersion-3
-attestation — Bible INV-125); any tracked mutation invalidates the evidence
+[`docs/CHECKLISTS.md`](docs/CHECKLISTS.md) (the exact slot-bound triad plus
+scope reviewer panel, one wave plus one confirmation wave under the owner's
+decision, sealed schema-v4 attestation — Bible INV-125); any tracked
+mutation invalidates the evidence
 and requires a new freeze. Claudexor intentionally has no per-commit review
 hook or staged-diff review authority.
 


### PR DESCRIPTION
The immune scan before v3.1.1 found CONTRIBUTING.md restating the owner-review protocol with three facts the protocol no longer contains: a two-reviewer floor that was retired in favor of the exact slot-bound triad plus scope panel, a three-round cap that never was the wave discipline, and a schema-v3 attestation where current sealing is v4 and v3 is rejected as publish input. Same class as the ledgered X135, which fixed ARCHITECTURE and the sealer header and missed this file. Docs-only change.

Checks: prettier clean on the changed file; no code paths touched; CLAUDEXOR_BIBLE.md not changed; no secrets or machine-local paths in the diff.