### PR TITLE
Reject client-supplied planRef on POST /runs (INV-081 boundary)

### DIFF
--- a/CLAUDEXOR_BIBLE.md
+++ b/CLAUDEXOR_BIBLE.md
@@ -403,8 +403,11 @@ invariant or owner decision before proceeding.
   is a server-owned file reference materialized outside every worktree, the
   engine verifies the hash before any harness spawns, and a tampered or
   unreadable plan fails loudly. Retry replays the reference verbatim — a
-  retried implement can never silently run without its plan. verify:
-  withPlanBrief hash tests; thread-turn plan_hash/409 tests.
+  retried implement can never silently run without its plan, and a client
+  can never mint the reference (POST /runs rejects planRef). verify:
+  `[INV-081:plan-brief-materialized]`, `[INV-081:plan-hash-mismatch]`,
+  `[INV-081:plan-missing]`, `[INV-081:planref-boundary]`; thread-turn
+  plan_hash/409 tests.
 - **INV-082** Plans and repo config cannot carry protected-path approvals;
   operator approval is always supplied on the current run. verify:
   run-level approval schema strictness.

--- a/packages/control-api/src/control-api.test.ts
+++ b/packages/control-api/src/control-api.test.ts
@@ -2906,6 +2906,7 @@ describe("DaemonControlApiServer", () => {
       const threadObj = planThread(repo, "run-plan");
       const turns: Record<string, unknown>[] = [];
       let overriddenRecorded: boolean | undefined;
+      let enqueuedParams: Record<string, unknown> | undefined;
       const jobs = new Map<string, DaemonRunRecord>([
         ["job-plan", { id: "job-plan", state: "succeeded", runId: "run-plan", runDir: planRunDir }],
       ]);
@@ -2913,6 +2914,7 @@ describe("DaemonControlApiServer", () => {
         // Override recorded on the turn -> the runner SKIPS the readiness gate
         // and the run binds normally.
         async enqueue(params: unknown) {
+          enqueuedParams = params as Record<string, unknown>;
           const rec: DaemonRunRecord = {
             id: "job-override",
             state: "running",
@@ -2978,6 +2980,14 @@ describe("DaemonControlApiServer", () => {
           // The override provenance is recorded on the turn (D17), not silently
           // dropped.
           expect(overriddenRecorded).toBe(true);
+          // The turn pipeline MINTS the frozen-plan reference server-side and
+          // enqueues it directly — the POST /runs planRef guard never applies
+          // to this path (INV-081).
+          expect(enqueuedParams?.["planRef"]).toEqual({
+            runId: "run-plan",
+            sha256: sha256("# Plan\n\nDo the thing.\n").replace(/^sha256:/, ""),
+            path: join(planRunDir, "final", "plan.md"),
+          });
         },
         undefined,
         services,
@@ -7292,7 +7302,10 @@ describe("DaemonControlApiServer", () => {
     record.params = {
       ...(record.params as Record<string, unknown>),
       turnId: "tn-old",
+      retryOf: "run-d0",
       planRunId: "run-plan",
+      planRef: { runId: "run-plan", sha256: "a".repeat(64), path: "/tmp/final/plan.md" },
+      threadId: "th-old",
     };
     await withDaemonServer(daemon, async (base) => {
       const response = await apiFetch(`${base}/runs/run-d1/run-again`, {
@@ -7304,9 +7317,21 @@ describe("DaemonControlApiServer", () => {
         differences: Array<{ field: string }>;
       };
       expect(body.request).toMatchObject({ prompt: "hello", mode: "agent" });
+      // The draft must be POSTable as-is: POST /runs 400s every one of these
+      // (planRef/threadId included — a surviving planRef would replay the
+      // frozen-plan reference past the boundary, INV-081).
       expect(body.request).not.toHaveProperty("turnId");
+      expect(body.request).not.toHaveProperty("retryOf");
       expect(body.request).not.toHaveProperty("planRunId");
-      expect(body.differences.map((entry) => entry.field)).toEqual(["turnId", "planRunId"]);
+      expect(body.request).not.toHaveProperty("planRef");
+      expect(body.request).not.toHaveProperty("threadId");
+      expect(body.differences.map((entry) => entry.field)).toEqual([
+        "turnId",
+        "retryOf",
+        "planRunId",
+        "planRef",
+        "threadId",
+      ]);
     });
   });
 
@@ -7967,6 +7992,82 @@ describe("DaemonControlApiServer", () => {
       await server.stop();
       rmSync(repo, { recursive: true, force: true });
     }
+  });
+
+  it("[INV-081:planref-boundary] rejects client-supplied planRef on POST /runs (a self-consistent forged hash never reaches the orchestrator)", async () => {
+    // The withPlanBrief tamper fence verifies the sha256 the planRef CARRIES,
+    // so a forged reference whose hash matches its own file passes the fence
+    // by construction — the boundary must refuse the field entirely.
+    const { daemon } = fakeDaemon();
+    let enqueued = 0;
+    const guarded: DaemonFacadeClient = {
+      ...daemon,
+      async enqueue(params, options) {
+        enqueued += 1;
+        return daemon.enqueue(params, options);
+      },
+    };
+    const server = new DaemonControlApiServer({ ...readyIdentity, token, daemon: guarded });
+    const { host, port } = await server.start();
+    const base = `http://${host}:${port}`;
+    const repo = reapMk(join(tmpdir(), "claudexor-planref-"));
+    try {
+      const secret = join(repo, "not-a-plan.txt");
+      writeFileSync(secret, "arbitrary file the forged planRef points at\n");
+      const forged = {
+        runId: "run-plan",
+        sha256: sha256(readFileSync(secret, "utf8")).replace(/^sha256:/, ""),
+        path: secret,
+      };
+      const response = await apiFetch(`${base}/runs`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          prompt: "x",
+          mode: "agent",
+          scope: { kind: "project", root: repo },
+          planRef: forged,
+        }),
+      });
+      expect(response.status).toBe(400);
+      expect(((await response.json()) as { message: string }).message).toContain(
+        "planRef is not accepted on POST /runs",
+      );
+      expect(enqueued).toBe(0);
+    } finally {
+      await server.stop();
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("Exact Retry still replays a server-minted planRef verbatim (the boundary guard is POST /runs only)", async () => {
+    const { daemon, record } = fakeDaemon();
+    const planRef = { runId: "run-plan", sha256: "b".repeat(64), path: "/tmp/final/plan.md" };
+    record.params = {
+      ...(record.params as Record<string, unknown>),
+      planRunId: "run-plan",
+      planRef,
+    };
+    let enqueuedParams: Record<string, unknown> | undefined;
+    const wrapped: DaemonFacadeClient = {
+      ...daemon,
+      async enqueue(params, options) {
+        enqueuedParams = params as Record<string, unknown>;
+        return daemon.enqueue(params, options);
+      },
+    };
+    await withDaemonServer(wrapped, async (base) => {
+      const retry = await apiFetch(`${base}/runs/run-d1/retry`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${token}`, "Idempotency-Key": "planref-retry" },
+        body: "{}",
+      });
+      expect(retry.status).toBe(200);
+      // INV-081: the frozen-plan reference survives the replay UNCHANGED — a
+      // retried implement can never silently run without its plan.
+      expect(enqueuedParams?.["planRef"]).toEqual(planRef);
+      expect(enqueuedParams?.["retryOf"]).toBe("run-d1");
+    });
   });
 });
 

--- a/packages/control-api/src/run-retry-routes.ts
+++ b/packages/control-api/src/run-retry-routes.ts
@@ -169,7 +169,12 @@ async function runAgain(ctx: RunRetryRouteContext, id: string, res: ServerRespon
     const parsed = ControlRunStartRequest.parse(
       await sourceParamsWithThreadAttachments(ctx, source),
     );
-    const { turnId, retryOf, planRunId, ...request } = parsed;
+    // Strip EVERY server-owned binding, with disclosure: the draft is an
+    // editable POST /runs request, and POST /runs 400s threadId/planRef (they
+    // belong to the turn pipeline) — surviving here would make the draft
+    // unpostable, and a replayed planRef would smuggle the frozen-plan
+    // reference past the boundary (INV-081). Same set as decision-rerun.
+    const { turnId, retryOf, planRunId, planRef, threadId, ...request } = parsed;
     const differences = [
       ...(turnId
         ? [{ field: "turnId", change: "omitted" as const, reason: "server-owned turn binding" }]
@@ -179,6 +184,18 @@ async function runAgain(ctx: RunRetryRouteContext, id: string, res: ServerRespon
         : []),
       ...(planRunId
         ? [{ field: "planRunId", change: "omitted" as const, reason: "server-owned plan binding" }]
+        : []),
+      ...(planRef
+        ? [
+            {
+              field: "planRef",
+              change: "omitted" as const,
+              reason: "server-owned frozen-plan reference",
+            },
+          ]
+        : []),
+      ...(threadId
+        ? [{ field: "threadId", change: "omitted" as const, reason: "server-owned thread binding" }]
         : []),
     ];
     ctx.json(

--- a/packages/control-api/src/run-start.ts
+++ b/packages/control-api/src/run-start.ts
@@ -179,6 +179,17 @@ export async function handleRunCreate(
         "planRunId is not accepted on POST /runs; use POST /threads/:id/turns (the turn pipeline implements the plan)",
     });
   }
+  if (params.planRef) {
+    // The frozen-plan reference is the tamper fence's INPUT: the orchestrator
+    // trusts its sha256 by construction (INV-081), so a client-supplied
+    // planRef would let a loopback caller point the plan brief at an
+    // arbitrary file with a self-consistent hash. Only the daemon-internal
+    // turn pipeline may mint one.
+    return ctx.json(res, 400, {
+      error:
+        "planRef is not accepted on POST /runs; the frozen-plan reference is server-owned and minted by POST /threads/:id/turns at implement time",
+    });
+  }
   if (params.retryOf) {
     return ctx.json(res, 400, {
       error: "retryOf is server-owned; use POST /runs/:id/retry for Exact Retry",

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -9480,3 +9480,93 @@ describe("delegation belt injection (D32)", () => {
     expect(failure).toMatch(/delegation belt|mcp_injection|nocap/);
   });
 });
+
+describe("frozen-plan brief delivery (withPlanBrief, INV-081)", () => {
+  type PlanBriefInput = {
+    prompt: string;
+    planRef?: { runId: string; sha256: string; path: string };
+  };
+  function planBriefFixture() {
+    const dir = reapMk(join(tmpdir(), "claudexor-planbrief-"));
+    const store = new ArtifactStore(join(dir, "repo"), { claudexorDir: join(dir, "claudexor") });
+    const paths = store.createRun("run-planbrief");
+    const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+    const orch = new Orchestrator({ registry: new Map() });
+    const apply = (input: PlanBriefInput): PlanBriefInput =>
+      (
+        orch as unknown as {
+          withPlanBrief(
+            input: PlanBriefInput,
+            store: ArtifactStore,
+            paths: unknown,
+            log: unknown,
+          ): PlanBriefInput;
+        }
+      ).withPlanBrief(input, store, paths, {
+        emit: (type: string, payload: Record<string, unknown>) => events.push({ type, payload }),
+      });
+    return { dir, paths, events, apply };
+  }
+
+  it("[INV-081:plan-brief-materialized] verifies the frozen hash and materializes context/PLAN.md in the run artifact tree", () => {
+    const { dir, paths, events, apply } = planBriefFixture();
+    const planText = "# Plan\n\n1. do the thing\n";
+    const planPath = join(dir, "final-plan.md");
+    writeFileSync(planPath, planText);
+    const digest = sha256(planText).replace(/^sha256:/, "");
+    const out = apply({
+      prompt: "implement it",
+      planRef: { runId: "run-plan", sha256: digest, path: planPath },
+    });
+    const briefPath = join(paths.contextDir, "PLAN.md");
+    // The brief lands OUTSIDE every worktree (the run artifact tree), and the
+    // prompt points at that absolute path — the plan is a file, never
+    // re-embedded prose.
+    expect(readFileSync(briefPath, "utf8")).toBe(planText);
+    expect(out.prompt).toContain("implement it");
+    expect(out.prompt).toContain(`The approved plan is at: ${briefPath}`);
+    expect(events).toEqual([
+      {
+        type: "plan.brief.materialized",
+        payload: { plan_run_id: "run-plan", sha256: digest, path: "context/PLAN.md" },
+      },
+    ]);
+  });
+
+  it("[INV-081:plan-missing] a missing or unreadable frozen plan fails LOUDLY before any harness spawns", () => {
+    const { dir, paths, events, apply } = planBriefFixture();
+    const gone = join(dir, "no-such-plan.md");
+    expect(() =>
+      apply({
+        prompt: "implement it",
+        planRef: { runId: "run-plan", sha256: "c".repeat(64), path: gone },
+      }),
+    ).toThrow(`implement plan: the frozen plan at ${gone} is missing or unreadable`);
+    expect(existsSync(join(paths.contextDir, "PLAN.md"))).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it("[INV-081:plan-hash-mismatch] a plan modified after freeze is a loud tamper failure, never a silent run", () => {
+    const { dir, paths, events, apply } = planBriefFixture();
+    const planPath = join(dir, "final-plan.md");
+    writeFileSync(planPath, "# Plan (original)\n");
+    const frozen = sha256(readFileSync(planPath, "utf8")).replace(/^sha256:/, "");
+    writeFileSync(planPath, "# Plan (tampered after freeze)\n");
+    expect(() =>
+      apply({
+        prompt: "implement it",
+        planRef: { runId: "run-plan", sha256: frozen, path: planPath },
+      }),
+    ).toThrow(/plan hash mismatch .*the plan was modified after freeze/);
+    expect(existsSync(join(paths.contextDir, "PLAN.md"))).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it("input without a planRef passes through untouched (one-shot runs carry no plan brief)", () => {
+    const { paths, events, apply } = planBriefFixture();
+    const input = { prompt: "just do it" };
+    expect(apply(input)).toBe(input);
+    expect(existsSync(join(paths.contextDir, "PLAN.md"))).toBe(false);
+    expect(events).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

Pre-tag blocking fix for v3.1.1, found by the immune scan.

POST /v2/runs rejects threadId, turnId, planRunId and retryOf, but never rejected planRef, even though the schema and the capability catalog both promise it is server-owned. A loopback client holding the bearer token could therefore post a forged planRef carrying its own path and its own sha256. Since withPlanBrief verifies the hash that the reference itself carries, the tamper fence passes by construction and the orchestrator reads an arbitrary file into context/PLAN.md and the prompt. The route now refuses planRef with the same typed 400 shape as its sibling guards, so the reference can only be minted by the daemon-internal turn pipeline.

Two smaller cleanups ride along. The run-again draft used to let planRef and threadId survive into the "editable" request with no differences entry, which also made the draft unpostable because POST /runs 400s threadId; both are now stripped with disclosure entries, matching decision-rerun. And the INV-081 verify note used to name withPlanBrief hash tests that did not exist; the tests exist now (happy-path materialization of context/PLAN.md, missing plan, hash mismatch) and the Bible hint points at real canary tags, so inv:check enforces them.

The legitimate internal planRef paths are proven untouched: the thread-turn override test now asserts the server-minted planRef reaches enqueue, and a new test proves Exact Retry replays a stored planRef verbatim.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass
- [x] Docs updated in the SAME PR where behavior they describe changed
      (`docs/FEATURES.md` row updated/deleted; ARCHITECTURE/README where relevant)
- [x] If `CLAUDEXOR_BIBLE.md` changed: the commit carries a
      `CONCEPT-CHANGE(INV-xxx)` marker approved by the maintainer
- [x] No secrets, tokens, or machine-local paths in the diff
