### PR TITLE
fix(effort): disclose a cross-model effort clamp the same way a drop is disclosed (INV-105)

### DIFF
--- a/packages/harness-claude/src/effort-probe.ts
+++ b/packages/harness-claude/src/effort-probe.ts
@@ -18,7 +18,7 @@
  */
 import type { HarnessEvent, HarnessRunSpec } from "@claudexor/schema";
 import { EffortHint } from "@claudexor/schema";
-import { normalizeEffort, runCapture } from "@claudexor/core";
+import { normalizeEffort, resolveEffort, runCapture } from "@claudexor/core";
 import { nowIso, redactSecrets } from "@claudexor/util";
 
 export const BIN = process.env.CLAUDEXOR_CLAUDE_BIN || "claude";
@@ -259,6 +259,57 @@ export function claudeEffortIgnoredEvent(
     session_id: spec.session_id,
     ts: nowIso(),
     text: `[effort] ignored: ${detail}`,
+    payload: { ignored_settings: [detail] },
+  };
+}
+
+/**
+ * The INV-105 disclosure for an effort the resolution CLAMPED, or null when the
+ * level rode through verbatim (or was dropped — `claudeEffortIgnoredEvent`'s
+ * shape; the two are mutually exclusive: a drop sends no flag, a clamp sends a
+ * different one). Mirrors the codex clamp seam so a moved level is disclosed
+ * the same way on both adapters, and takes the SAME (advertised, ladder)
+ * inputs the arg builder's normalizer takes so the disclosure can never
+ * disagree with the flag actually sent.
+ *
+ * Reachability today: the arg builder resolves with the installed binary's own
+ * list as both advertised set and rank ladder (`normalizeEffort`'s two-arg
+ * form), and against one's own ladder every miss is a DROP, never a clamp —
+ * so with current call sites this event only fires if a rank ladder broader
+ * than the binary's list is ever threaded through (the codex-shaped future,
+ * e.g. `ultra` ranking above a max-capped binary and clamping onto `max`).
+ * The seam exists precisely so that future cannot be silent.
+ */
+/**
+ * The one INV-105 seam the run yields: the DROP disclosure or the CLAMP
+ * disclosure, whichever applies (they are mutually exclusive by construction —
+ * a drop sends no flag, a clamp sends a different one), or null when the
+ * requested level rode through verbatim or nothing was requested.
+ */
+export function claudeEffortDisclosureEvent(
+  spec: Pick<HarnessRunSpec, "session_id" | "effort_hint">,
+  advertised: readonly EffortHint[],
+): HarnessEvent | null {
+  return claudeEffortIgnoredEvent(spec, advertised) ?? claudeEffortClampedEvent(spec, advertised);
+}
+
+export function claudeEffortClampedEvent(
+  spec: Pick<HarnessRunSpec, "session_id" | "effort_hint">,
+  advertised: readonly EffortHint[],
+  ladder: readonly EffortHint[] = advertised,
+): HarnessEvent | null {
+  if (!spec.effort_hint) return null;
+  const check = resolveEffort(spec.effort_hint, advertised, ladder);
+  if (check.status !== "ok" || !check.clamped || check.effort === null) return null;
+  const detail =
+    `effort=${spec.effort_hint} (clamped to ${check.effort}: the requested level is not ` +
+    `advertised by the installed claude CLI (it advertises: ${advertised.join(", ")}), ` +
+    `so the run sent ${check.effort}, the nearest level it advertises)`;
+  return {
+    type: "message",
+    session_id: spec.session_id,
+    ts: nowIso(),
+    text: `[effort] clamped: ${detail}`,
     payload: { ignored_settings: [detail] },
   };
 }

--- a/packages/harness-claude/src/effort.test.ts
+++ b/packages/harness-claude/src/effort.test.ts
@@ -4,6 +4,7 @@ import { HarnessRunSpec } from "@claudexor/schema";
 import { normalizeEffort, resolveEffort } from "@claudexor/core";
 import {
   CLAUDE_EFFORT_SNAPSHOT,
+  claudeEffortClampedEvent,
   claudeEffortIgnoredEvent,
   parseClaudeEffortHelp,
 } from "./effort-probe.js";
@@ -301,5 +302,56 @@ describe("an effort dropped AFTER preflight is disclosed on the run (INV-105)", 
     ]);
     expect(cliArgs).toBeDefined();
     expect(cliArgs).not.toContain("--effort");
+  });
+});
+
+describe("an effort the resolution CLAMPED is disclosed too (INV-105) — the codex-symmetric seam", () => {
+  const maxCapped = ["low", "medium", "high", "xhigh", "max"] as const; // 2.1.165-shaped binary
+  const ladderWithUltra = [...maxCapped, "ultra"] as const; // a rank order that places ultra above max
+
+  it("discloses `ultra` clamped onto `max` when a rank ladder places it above a max-capped binary", () => {
+    // The claude-shaped clamp: the binary advertises up to `max`, the rank
+    // ladder knows `ultra` sits above it, so resolution clamps ultra -> max —
+    // and the seam says so, naming both levels.
+    const clamped = claudeEffortClampedEvent(
+      { session_id: "s1", effort_hint: "ultra" },
+      maxCapped,
+      ladderWithUltra,
+    );
+    expect(clamped?.type).toBe("message");
+    expect(clamped?.text).toContain("clamped");
+    expect(clamped?.payload?.["ignored_settings"]).toEqual([
+      expect.stringContaining("effort=ultra"),
+    ]);
+    expect(clamped?.payload?.["ignored_settings"]).toEqual([expect.stringContaining("max")]);
+    // ...and the SAME inputs make the normalizer send exactly that level, so
+    // the disclosure and the flag cannot disagree.
+    expect(normalizeEffort("ultra", maxCapped, ladderWithUltra)).toBe("max");
+  });
+
+  it("a PASS-THROUGH emits nothing; against the binary's OWN ladder a miss is a DROP, not a clamp", () => {
+    // Advertised verbatim: neither seam fires.
+    expect(
+      claudeEffortClampedEvent({ session_id: "s1", effort_hint: "max" }, maxCapped),
+    ).toBeNull();
+    expect(
+      claudeEffortIgnoredEvent({ session_id: "s1", effort_hint: "max" }, maxCapped),
+    ).toBeNull();
+    // TODAY'S production shape (two-arg resolution, ladder = the advertised
+    // list itself): an unadvertised level cannot clamp — it drops, and the
+    // existing DROP seam owns the disclosure. Pinned so the two seams stay
+    // mutually exclusive.
+    expect(
+      claudeEffortClampedEvent({ session_id: "s1", effort_hint: "ultra" }, maxCapped),
+    ).toBeNull();
+    expect(
+      claudeEffortIgnoredEvent({ session_id: "s1", effort_hint: "ultra" }, maxCapped)?.payload?.[
+        "ignored_settings"
+      ],
+    ).toEqual([expect.stringContaining("effort=ultra")]);
+    // Nothing requested: nothing to disclose.
+    expect(
+      claudeEffortClampedEvent({ session_id: "s1", effort_hint: null }, maxCapped, ladderWithUltra),
+    ).toBeNull();
   });
 });

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -46,7 +46,7 @@ import {
   BIN,
   CLAUDE_EFFORT_SNAPSHOT,
   CLAUDE_EFFORT_SNAPSHOT_VERIFIED_AGAINST,
-  claudeEffortIgnoredEvent,
+  claudeEffortDisclosureEvent,
   probeClaudeEffortLevels,
   probeClaudeHelp,
 } from "./effort-probe.js";
@@ -937,11 +937,11 @@ async function* runClaude(
   // re-spawns the CLI just to learn its ladder.
   const efforts = await runtime.probeEffortLevels(abortSignalFromSpec(spec));
   const args = claudeArgsForSpec(spec, interactive, useSubscription, efforts.levels);
-  // INV-105 rides the RUN too: preflight passed this level against the manifest
-  // ladder, but the INSTALLED binary's can be narrower — disclosed, never a
-  // silent vendor-default run (claudeEffortIgnoredEvent).
-  const droppedEffort = claudeEffortIgnoredEvent(spec, efforts.levels);
-  if (droppedEffort) yield droppedEffort;
+  // INV-105 rides the RUN too: the INSTALLED binary can be narrower than the
+  // manifest ladder preflight saw — a DROP or a CLAMP is disclosed here, on the
+  // same inputs the arg builder resolves with, never a silent divergence.
+  const effortDisclosure = claudeEffortDisclosureEvent(spec, efforts.levels);
+  if (effortDisclosure) yield effortDisclosure;
   // Scrub EVERY provider secret (incl. OpenAI/others — the cross-provider leak
   // fix) via the single core table, then re-add only the var this route needs.
   const env: Record<string, string | null | undefined> =

--- a/packages/harness-codex/src/effort-probe.ts
+++ b/packages/harness-codex/src/effort-probe.ts
@@ -20,7 +20,7 @@
 import { spawn } from "node:child_process";
 import type { HarnessEvent, HarnessRunSpec, ModelEffortCapability } from "@claudexor/schema";
 import { EffortHint, effortLevelsForModel, mergeEffortLadders } from "@claudexor/schema";
-import { normalizeEffort } from "@claudexor/core";
+import { resolveEffort } from "@claudexor/core";
 import { nowIso } from "@claudexor/util";
 import { BIN, probeEnv } from "./missing-cli.js";
 
@@ -416,6 +416,23 @@ export async function codexEffortsForEnv(
 }
 
 /**
+ * The full outcome of resolving one (model, requested) pair against a catalog:
+ * what to send, whether the merged vendor order MOVED it there, and which
+ * model's ladder decided. `codexEffortFor` keeps only the level for the arg
+ * builder; the disclosure seams need the other two facts, because a CLAMP is a
+ * changed setting the user asked for differently (INV-105) even though a flag
+ * is still sent.
+ */
+export interface CodexEffortResolution {
+  /** The level to send, or null when no flag should be sent at all. */
+  effort: EffortHint | null;
+  /** True when `effort` differs from the request — the merged vendor order clamped it. */
+  clamped: boolean;
+  /** The model whose advertised ladder decided this (the hint, or the catalog default). */
+  effectiveModel: string | null;
+}
+
+/**
  * The effort value to send for one (model, requested) pair: advertised passes
  * through verbatim, a level a SIBLING model advertises clamps inside the merged
  * vendor order (`ultra` on gpt-5.4 → `xhigh` because the merged codex ladder
@@ -427,11 +444,11 @@ export async function codexEffortsForEnv(
  * model's own list) and an unadvertised level is refused rather than clamped
  * along an order this repo would have had to invent.
  */
-export function codexEffortFor(
+export function codexEffortResolution(
   catalog: CodexEffortCatalog,
   model: string | null | undefined,
   requested: EffortHint | null | undefined,
-): EffortHint | null {
+): CodexEffortResolution {
   const merged = mergeEffortLadders(Object.values(catalog.models).map((entry) => entry.levels));
   // No model hint does NOT mean "any model": codex runs the catalog's DEFAULT
   // model (`model/list` isDefault), so the requested level is held to THAT
@@ -460,7 +477,23 @@ export function codexEffortFor(
         },
         effectiveModel,
       );
-  return normalizeEffort(requested, advertised, merged.consistent ? merged.order : advertised);
+  const check = resolveEffort(requested, advertised, merged.consistent ? merged.order : advertised);
+  if (check.status !== "ok") return { effort: null, clamped: false, effectiveModel };
+  return { effort: check.effort, clamped: check.clamped, effectiveModel };
+}
+
+/**
+ * The level the arg builder should emit for one (model, requested) pair, or
+ * null when no flag should be sent. Thin projection of
+ * `codexEffortResolution`; the run-side disclosure seams read the full
+ * resolution so a clamp or a drop is never silent.
+ */
+export function codexEffortFor(
+  catalog: CodexEffortCatalog,
+  model: string | null | undefined,
+  requested: EffortHint | null | undefined,
+): EffortHint | null {
+  return codexEffortResolution(catalog, model, requested).effort;
 }
 
 /**
@@ -488,6 +521,49 @@ export function codexEffortIgnoredEvent(
     session_id: spec.session_id,
     ts: nowIso(),
     text: `[effort] ignored: ${detail}`,
+    payload: { ignored_settings: [detail] },
+  };
+}
+
+/**
+ * The INV-105 disclosure for an effort the run CLAMPED, or null when the
+ * requested level rode through verbatim (or was dropped — that is
+ * `codexEffortIgnoredEvent`'s shape, and the two are mutually exclusive: a
+ * drop sends no level, a clamp sends a different one). A clamp is quieter than
+ * a drop but just as much a changed setting: `--effort ultra` on gpt-5.4 runs
+ * at `xhigh`, and without this event nothing in the timeline said so. The
+ * payload rides the same `ignored_settings` channel governance and the drop
+ * seam use, so every existing reader renders the same warning.
+ */
+/**
+ * The one INV-105 seam the run yields: the DROP disclosure or the CLAMP
+ * disclosure, whichever applies (they are mutually exclusive by construction —
+ * a drop sends no flag, a clamp sends a different one), or null when the
+ * requested level rode through verbatim or nothing was requested.
+ */
+export function codexEffortDisclosureEvent(
+  catalog: CodexEffortCatalog,
+  spec: Pick<HarnessRunSpec, "session_id" | "model_hint" | "effort_hint">,
+): HarnessEvent | null {
+  return codexEffortIgnoredEvent(catalog, spec) ?? codexEffortClampedEvent(catalog, spec);
+}
+
+export function codexEffortClampedEvent(
+  catalog: CodexEffortCatalog,
+  spec: Pick<HarnessRunSpec, "session_id" | "model_hint" | "effort_hint">,
+): HarnessEvent | null {
+  if (!spec.effort_hint) return null;
+  const resolved = codexEffortResolution(catalog, spec.model_hint, spec.effort_hint);
+  if (!resolved.clamped || resolved.effort === null) return null;
+  const detail =
+    `effort=${spec.effort_hint} (clamped to ${resolved.effort}: the requested level is not ` +
+    `advertised by${resolved.effectiveModel ? ` model ${resolved.effectiveModel}` : " the resolved model"}, ` +
+    `so the run sent ${resolved.effort}, the nearest level that model advertises)`;
+  return {
+    type: "message",
+    session_id: spec.session_id,
+    ts: nowIso(),
+    text: `[effort] clamped: ${detail}`,
     payload: { ignored_settings: [detail] },
   };
 }

--- a/packages/harness-codex/src/effort.test.ts
+++ b/packages/harness-codex/src/effort.test.ts
@@ -10,6 +10,7 @@ import { codexExecArgs } from "./index.js";
 import {
   CODEX_EFFORT_SNAPSHOT,
   codexEffortCacheSize,
+  codexEffortClampedEvent,
   codexEffortCapability,
   codexEffortIgnoredEvent,
   codexEffortsForEnv,
@@ -746,6 +747,126 @@ describe("an effort dropped AFTER preflight is disclosed on the run (INV-105)", 
     ]);
     // ...and the child was really spawned WITHOUT any effort flag.
     expect(cliArgs?.some((a) => a.startsWith("model_reasoning_effort="))).toBe(false);
+    clearCodexEffortCache();
+  });
+});
+
+describe("an effort the run CLAMPED is disclosed too (INV-105) — a moved level is a changed setting", () => {
+  /** The B2 shape: the routed model stops at xhigh while a sibling advertises
+   * ultra, so `ultra` clamps to `xhigh` inside the merged vendor order — which
+   * used to happen with zero disclosure. */
+  const catalog: CodexEffortCatalog = {
+    models: {
+      "gpt-cap": { levels: ["low", "medium", "high", "xhigh"], default: "medium" },
+      "gpt-top": { levels: ["low", "medium", "high", "xhigh", "max", "ultra"], default: "low" },
+    },
+    defaultModel: "gpt-cap",
+  };
+
+  it("codexEffortClampedEvent discloses the requested level, the level sent, and the deciding model", () => {
+    const clamped = codexEffortClampedEvent(catalog, {
+      session_id: "s1",
+      model_hint: "gpt-cap",
+      effort_hint: "ultra",
+    });
+    expect(clamped?.type).toBe("message");
+    expect(clamped?.text).toContain("clamped");
+    expect(clamped?.payload?.["ignored_settings"]).toEqual([
+      expect.stringContaining("effort=ultra"),
+    ]);
+    expect(clamped?.payload?.["ignored_settings"]).toEqual([expect.stringContaining("xhigh")]);
+    expect(clamped?.text).toContain("gpt-cap");
+    // ...and the flag really goes out at the clamped level, unchanged by the seam.
+    expect(
+      emittedEffort(
+        codexExecArgs(
+          { ...base, model_hint: "gpt-cap", effort_hint: "ultra" },
+          { effortCatalog: catalog },
+        ),
+      ),
+    ).toBe("xhigh");
+  });
+
+  it("a hint-less run clamping onto the DEFAULT model's ceiling names that model", () => {
+    const clamped = codexEffortClampedEvent(catalog, {
+      session_id: "s1",
+      model_hint: null,
+      effort_hint: "ultra",
+    });
+    expect(clamped?.text).toContain("gpt-cap");
+    expect(clamped?.payload?.["ignored_settings"]).toEqual([expect.stringContaining("xhigh")]);
+  });
+
+  it("a PASS-THROUGH (advertised level) emits nothing, and a DROP keeps the drop shape only", () => {
+    // Advertised verbatim: neither seam fires.
+    expect(
+      codexEffortClampedEvent(catalog, {
+        session_id: "s1",
+        model_hint: "gpt-cap",
+        effort_hint: "xhigh",
+      }),
+    ).toBeNull();
+    expect(
+      codexEffortIgnoredEvent(catalog, {
+        session_id: "s1",
+        model_hint: "gpt-cap",
+        effort_hint: "xhigh",
+      }),
+    ).toBeNull();
+    // Unplaceable level: the DROP seam owns it, the clamp seam stays silent.
+    const spec = { session_id: "s1", model_hint: "gpt-cap", effort_hint: "hyperdrive" };
+    expect(codexEffortClampedEvent(catalog, spec)).toBeNull();
+    expect(codexEffortIgnoredEvent(catalog, spec)?.payload?.["ignored_settings"]).toEqual([
+      expect.stringContaining("effort=hyperdrive"),
+    ]);
+    // Nothing requested: nothing to disclose.
+    expect(
+      codexEffortClampedEvent(catalog, {
+        session_id: "s1",
+        model_hint: "gpt-cap",
+        effort_hint: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("the RUN discloses the clamp and still sends the clamped flag", async () => {
+    clearCodexEffortCache();
+    let cliArgs: string[] | undefined;
+    const adapter = createCodexAdapter({
+      detectVersion: async () => "codex-cli 0.144.1",
+      probeLogin: async () => ({ authed: true, method: "chatgpt", probeError: null }),
+      hasApiKey: () => false,
+      probeEfforts: async () => catalog,
+      runCliHarness: async function* (options): AsyncGenerator<HarnessEvent> {
+        cliArgs = options.args;
+        yield {
+          type: "completed",
+          session_id: options.spec.session_id,
+          ts: "2026-01-01T00:00:00.000Z",
+        };
+      },
+    });
+    const spec = HarnessRunSpec.parse({
+      session_id: "codex-effort-clamp",
+      intent: "implement",
+      prompt: "do it",
+      cwd: "/repo",
+      // Governance forwards this verbatim (it sits in the harness-wide union);
+      // the routed model's ceiling is xhigh, so the run clamps — and says so.
+      effort_hint: "ultra",
+      model_hint: "gpt-cap",
+      auth_preference: "auto",
+    });
+    const events: HarnessEvent[] = [];
+    for await (const ev of adapter.run(spec)) events.push(ev);
+    const disclosure = events.find((ev) => Array.isArray(ev.payload?.["ignored_settings"]));
+    expect(disclosure?.payload?.["ignored_settings"]).toEqual([
+      expect.stringContaining("effort=ultra"),
+    ]);
+    expect(disclosure?.text).toContain("clamped");
+    expect(disclosure?.text).toContain("xhigh");
+    // ...and the child was really spawned WITH the clamped flag.
+    expect(cliArgs?.some((a) => a === 'model_reasoning_effort="xhigh"')).toBe(true);
     clearCodexEffortCache();
   });
 });

--- a/packages/harness-codex/src/index.ts
+++ b/packages/harness-codex/src/index.ts
@@ -20,8 +20,8 @@ import {
 import {
   CODEX_EFFORT_SNAPSHOT,
   CODEX_EFFORT_SNAPSHOT_VERIFIED_AGAINST,
+  codexEffortDisclosureEvent,
   codexEffortFor,
-  codexEffortIgnoredEvent,
   codexEffortsForEnv,
   probeCodexEfforts,
   unionEffortLevels,
@@ -755,10 +755,10 @@ async function* runCodex(
   // gets its OWN account's catalog, not whichever one landed in the cache first.
   const efforts = await codexEffortsForEnv(runtime, env);
   // INV-105 rides the RUN too: preflight passed this level against the DEFAULT
-  // account's manifest, but THIS env's catalog may still refuse it — disclosed,
-  // never a silent vendor-default run (codexEffortIgnoredEvent).
-  const droppedEffort = codexEffortIgnoredEvent(efforts.catalog, spec);
-  if (droppedEffort) yield droppedEffort;
+  // account's manifest, but THIS env's catalog may DROP it or CLAMP it onto the
+  // routed model's ceiling — disclosed either way, never a silent divergence.
+  const effortDisclosure = codexEffortDisclosureEvent(efforts.catalog, spec);
+  if (effortDisclosure) yield effortDisclosure;
   const args = codexExecArgs(spec, {
     suppressNodeRepl: codexConfigHasNodeRepl(env["CODEX_HOME"]),
     outputSchemaPath,


### PR DESCRIPTION
## What & why

Pre-tag fix for triad blocker B2 of the v3.1.1 release.

A cross-model effort clamp was silent. `resolveEffort` returns `clamped: true`, but `codexEffortFor` and `normalizeEffort` discarded that fact, and the `ignored_settings` disclosure seam (`codexEffortIgnoredEvent`, `claudeEffortIgnoredEvent`) fired only when the resolution dropped the flag entirely. Governance passes the requested level because it sits in the harness-wide union, so `--effort ultra` on gpt-5.4 ran at `xhigh` with zero disclosure, an INV-105 violation in this release's new per-model effort code.

The fix extends the existing adapter disclosure seam so a clamp is disclosed the same way a drop is. Each adapter now yields one INV-105 disclosure event per run: the drop shape (unchanged) or a new clamp shape, mutually exclusive by construction since a drop sends no flag and a clamp sends a different one. The clamp entry names the requested level, the level actually sent, and the model whose advertised ladder decided it, and rides the same `ignored_settings` payload channel every existing timeline reader already renders. The behavior of the flag itself is unchanged: advertised levels pass through verbatim, clamps still clamp, drops still drop, nothing became a refusal.

Details per adapter:

- codex: `codexEffortResolution` now carries the full outcome (level, clamped, deciding model); `codexEffortFor` stays a thin projection for the arg builder, and `codexEffortClampedEvent` discloses the clamp. The run yields `codexEffortDisclosureEvent` (drop or clamp).
- claude: `claudeEffortClampedEvent` mirrors the codex seam and takes exactly the inputs the arg builder resolves with, so the disclosure can never disagree with the flag sent. With today's two-argument resolution (rank ladder = the installed binary's own advertised list) an unadvertised level always drops, never clamps, so the claude clamp event only becomes reachable once a rank ladder broader than the binary's list is threaded through; the seam exists so that future cannot be silent. Tests pin both the ultra-to-max clamp disclosure under such a ladder and the drop/clamp mutual exclusion under today's call shape.

Tests: codex `ultra` on an xhigh-capped model emits the clamp disclosure and the child is spawned with `model_reasoning_effort="xhigh"` (unit and run level, hinted and hint-less); a pass-through emits nothing; a drop keeps the drop shape with the clamp seam silent; claude ultra-to-max clamp disclosure under a ladder that ranks ultra, plus the production two-argument shape pinned as a drop. Non-vacuity verified: with the clamp seam reverted to return null, 4 clamp tests fail (3 codex, 1 claude).

Note for the triad: the brief's claude example (ultra to max on a max-capped binary) is not reachable in today's production call shape, confirmed empirically against `resolveEffort`; on claude every miss is currently a drop and was already disclosed. The codex clamp was the real silent path. The claude seam is wired run-side anyway for symmetry and future-proofing.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass
- [x] Docs updated in the SAME PR where behavior they describe changed
      (`docs/FEATURES.md` row updated/deleted; ARCHITECTURE/README where relevant) - no documented behavior changed; the disclosure rides the existing `ignored_settings` channel
- [x] If `CLAUDEXOR_BIBLE.md` changed: the commit carries a
      `CONCEPT-CHANGE(INV-xxx)` marker approved by the maintainer - not changed
- [x] No secrets, tokens, or machine-local paths in the diff (CI-exact secret scan run locally, clean)
