### PR TITLE
fix(macos): bound Cursor model picker width

### DIFF
--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/ComposerModelsSection.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/ComposerModelsSection.swift
@@ -12,10 +12,6 @@ import ClaudexorKit
 /// `models` map that rides the turn; the pool is never poisoned by one
 /// vendor's model id.
 struct ComposerModelsSection: View {
-    /// Keep every closed picker inside the 380pt options popover even when a
-    /// vendor catalog contains very long labels (Cursor currently does).
-    static let modelPickerWidth: CGFloat = 180
-
     let families: [HarnessFamily]
     let primary: HarnessFamily?
     /// Effective per-turn credential route (W20): the server filters
@@ -116,17 +112,19 @@ struct ComposerModelsSection: View {
                 // A previously-chosen id the truth source no longer lists (or
                 // the current route hides) stays visible so the user can SEE
                 // and clear it (the engine refuses it at preflight either way
-                // — never silently dropped).
+                // — never silently dropped). Rendered through the shared cap
+                // so even a pathological stored id cannot widen the open menu
+                // (the tag keeps the FULL id).
                 if let current = selections[id], !current.isEmpty,
                    !visible.contains(where: { $0.id == current }) {
-                    Text("\(current) (not offered here)").tag(current)
+                    Text("\(HarnessModelPresentation.menuTitle(label: nil, id: current)) (not offered here)")
+                        .tag(current)
                 }
                 ForEach(visible) { m in
-                    Text(menuLabel(m)).tag(m.id)
+                    Text(HarnessModelPresentation.menuTitle(label: m.label, id: m.id)).tag(m.id)
                 }
             }
-            .labelsHidden()
-            .frame(width: Self.modelPickerWidth, alignment: .leading)
+            .catalogModelPicker()
             .help(pickerHelp(family, catalog, hiddenOnRoute: catalog.models.count - visible.count))
         } else if catalogs[key] != nil {
             // A LOADED catalog that cannot enumerate (source: none) — the
@@ -165,11 +163,6 @@ struct ComposerModelsSection: View {
                 else { selections[id] = newValue }
             },
         )
-    }
-
-    private func menuLabel(_ m: HarnessModel) -> String {
-        let name = m.label.map { $0.isEmpty ? m.id : $0 } ?? m.id
-        return name == m.id ? name : "\(name) (\(m.id))"
     }
 
     private func pickerHelp(_ family: HarnessFamily, _ catalog: HarnessModelsResponse, hiddenOnRoute: Int) -> String {

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/ComposerModelsSection.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/ComposerModelsSection.swift
@@ -12,6 +12,10 @@ import ClaudexorKit
 /// `models` map that rides the turn; the pool is never poisoned by one
 /// vendor's model id.
 struct ComposerModelsSection: View {
+    /// Keep every closed picker inside the 380pt options popover even when a
+    /// vendor catalog contains very long labels (Cursor currently does).
+    static let modelPickerWidth: CGFloat = 180
+
     let families: [HarnessFamily]
     let primary: HarnessFamily?
     /// Effective per-turn credential route (W20): the server filters
@@ -122,7 +126,7 @@ struct ComposerModelsSection: View {
                 }
             }
             .labelsHidden()
-            .fixedSize()
+            .frame(width: Self.modelPickerWidth, alignment: .leading)
             .help(pickerHelp(family, catalog, hiddenOnRoute: catalog.models.count - visible.count))
         } else if catalogs[key] != nil {
             // A LOADED catalog that cannot enumerate (source: none) — the

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/DesignSystemComponents.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/DesignSystemComponents.swift
@@ -170,6 +170,23 @@ struct OptionRow<Content: View>: View {
     }
 }
 
+extension View {
+    /// The shared CLOSED-control contract for a catalog-fed model picker
+    /// (composer models rows + Settings model override). Vendor catalogs are
+    /// free text with no length contract, so the closed button pins to the
+    /// `Theme.Layout.modelPickerWidth` token and truncates mid-string — the
+    /// family prefix and the id tail both stay readable — instead of widening
+    /// its row (§1 rule 4; issue #53). The OPEN menu is bounded separately by
+    /// `HarnessModelPresentation.menuTitle`: an NSMenu sizes to its widest
+    /// ITEM, which no closed-control frame can cap.
+    func catalogModelPicker() -> some View {
+        labelsHidden()
+            .frame(width: Theme.Layout.modelPickerWidth, alignment: .leading)
+            .lineLimit(1)
+            .truncationMode(.middle)
+    }
+}
+
 // MARK: - Chrome glass (floating panel) with a Reduce-Transparency solid fallback
 
 extension View {

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/DesignTokens.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/DesignTokens.swift
@@ -180,6 +180,14 @@ enum Theme {
         static let conversationMaxWidth: CGFloat = 680
         /// The composer "⋯" options popover — a readable column for the option rows.
         static let composerOptionsWidth: CGFloat = 380
+        /// Closed width of a CATALOG-FED model picker (composer models rows,
+        /// Settings model override). Derived from the popover budget: the
+        /// 380pt `composerOptionsWidth` column minus its 2×`Spacing.lg`
+        /// padding leaves 348pt for a row; the 92pt harness-label column, the
+        /// `Spacing.sm` gaps and the trailing "primary" tag leave ~180pt for
+        /// the control. Long vendor labels truncate INSIDE this width (§1
+        /// rule 4) — they never widen their row.
+        static let modelPickerWidth: CGFloat = 180
     }
 
     /// Vertical padding for capsule chips (intent / primary / project). Between

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/HarnessModelOverride.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/HarnessModelOverride.swift
@@ -53,21 +53,30 @@ struct HarnessModelOverrideField: View {
         }
     }
 
+    /// Same `LabeledContent("Model")` shell as every sibling state above, so
+    /// the row does not re-layout when the catalog resolves; the control obeys
+    /// the shared catalog-picker contract (fixed token width + capped menu
+    /// titles) exactly like the composer surface.
     @ViewBuilder private var picker: some View {
         if let models {
-            Picker("Model override", selection: $modelDraft) {
-                Text("Harness default").tag("")
-                // A stored override the truth source no longer lists (legacy value)
-                // stays visible so the user can SEE and clear it — the engine
-                // refuses it at run preflight either way.
-                if !modelDraft.isEmpty, !models.models.contains(where: { $0.id == modelDraft }) {
-                    Text("\(modelDraft) (not in \(models.source) list)").tag(modelDraft)
+            LabeledContent("Model") {
+                Picker("Model override", selection: $modelDraft) {
+                    Text("Harness default").tag("")
+                    // A stored override the truth source no longer lists (legacy
+                    // value) stays visible so the user can SEE and clear it — the
+                    // engine refuses it at run preflight either way. Rendered
+                    // through the shared cap so a pathological stored id cannot
+                    // widen the open menu (the tag keeps the FULL id).
+                    if !modelDraft.isEmpty, !models.models.contains(where: { $0.id == modelDraft }) {
+                        Text("\(HarnessModelPresentation.menuTitle(label: nil, id: modelDraft)) (not in \(models.source) list)")
+                            .tag(modelDraft)
+                    }
+                    ForEach(models.models) { m in
+                        Text(HarnessModelPresentation.menuTitle(label: m.label, id: m.id)).tag(m.id)
+                    }
                 }
-                ForEach(models.models) { m in
-                    Text(modelMenuLabel(m)).tag(m.id)
-                }
+                .catalogModelPicker()
             }
-            .labelsHidden()
             .help(modelPickerHelp(models))
         }
     }
@@ -116,12 +125,6 @@ struct HarnessModelOverrideField: View {
                 }
             }
             .help("Could not load the \(family.label) model catalog. Retry after reconnecting.")
-    }
-
-    private func modelMenuLabel(_ m: HarnessModel) -> String {
-        let name = (m.label.map { $0.isEmpty ? m.id : $0 } ?? m.id)
-        let suffix = name == m.id ? "" : " (\(m.id))"
-        return name + suffix
     }
 
     private func modelPickerHelp(_ models: HarnessModelsResponse) -> String {

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/ComposerModelsSectionLayoutTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/ComposerModelsSectionLayoutTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import SwiftUI
+import Testing
+import ClaudexorKit
+@testable import ClaudexorApp
+
+@Suite(.serialized)
+struct ComposerModelsSectionLayoutTests {
+    @MainActor
+    @Test func cursorCatalogCannotWidenThePickerPastTheOptionsPopover() {
+        let cursor = HarnessFamily.cursor
+        let key = ComposerModelsSection.catalogKey(cursor, route: nil)
+        let longID = String(repeating: "cursor-agent-preview-", count: 6)
+        let catalog = HarnessModelsResponse(
+            harnessId: cursor.rawValue,
+            models: [
+                HarnessModel(
+                    id: longID,
+                    label: "A deliberately long Cursor model label that must stay inside the popover"
+                ),
+            ],
+            source: "api"
+        )
+        let section = ComposerModelsSection(
+            families: [cursor],
+            primary: cursor,
+            selections: .constant([cursor.rawValue: longID]),
+            catalogs: .constant([key: catalog]),
+            fetch: { _ in nil }
+        )
+        let host = NSHostingView(rootView: section)
+
+        host.layoutSubtreeIfNeeded()
+
+        let availableWidth = Theme.Layout.composerOptionsWidth - (2 * Theme.Spacing.lg)
+        #expect(host.fittingSize.width <= availableWidth)
+    }
+}

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/HarnessModelOverrideLayoutTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/HarnessModelOverrideLayoutTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import SwiftUI
+import Testing
+import ClaudexorKit
+@testable import ClaudexorApp
+
+/// The Settings surface of the catalog-fed picker class (issue #53 — same
+/// contract as `ComposerModelsSectionLayoutTests` proves for the composer):
+/// a vendor catalog with pathological label/id lengths must not widen the
+/// closed model-override control past its token width.
+@Suite(.serialized)
+struct HarnessModelOverrideLayoutTests {
+    @MainActor
+    @Test func cursorCatalogCannotWidenTheSettingsOverrideField() {
+        let longID = String(repeating: "cursor-agent-preview-", count: 6)
+        let models = HarnessModelsResponse(
+            harnessId: HarnessFamily.cursor.rawValue,
+            models: [
+                HarnessModel(
+                    id: longID,
+                    label: "A deliberately long Cursor model label that must stay inside the row"
+                ),
+            ],
+            source: "api"
+        )
+        let field = HarnessModelOverrideField(
+            family: .cursor,
+            modelDraft: .constant(""),
+            fetch: { _ in nil },
+            models: .constant(models)
+        )
+        let host = NSHostingView(rootView: field)
+
+        host.layoutSubtreeIfNeeded()
+
+        // The fixed 180pt control plus a generous allowance for the
+        // `LabeledContent` "Model" label column — an UNBOUNDED catalog string
+        // would blow hundreds of points past this.
+        #expect(host.fittingSize.width <= Theme.Layout.modelPickerWidth + 120)
+    }
+}

--- a/apps/macos/ClaudexorKit/Sources/ClaudexorKit/HarnessModels.swift
+++ b/apps/macos/ClaudexorKit/Sources/ClaudexorKit/HarnessModels.swift
@@ -164,6 +164,36 @@ public struct HarnessModel: Codable, Sendable, Identifiable, Equatable, Hashable
     }
 }
 
+/// Menu-facing presentation for enumerable models (issue #53). An open
+/// `Picker` popup is an NSMenu, and an NSMenu sizes to its WIDEST item — a
+/// `.frame` on the closed control cannot bound it. Vendor catalogs are free
+/// text with no length contract (Cursor ships very long labels), so the menu
+/// STRING itself carries the guarantee. Kept in ClaudexorKit as a pure value
+/// transform so the cap semantics are unit-tested without the UI and run in
+/// CI (`QuotaPresentation` precedent).
+public enum HarnessModelPresentation {
+    /// Hard cap for one menu title. 48 characters keeps the widest possible
+    /// menu item close to the closed control's `modelPickerWidth` while
+    /// leaving both the human-label prefix and the id tail recognizable.
+    public static let menuTitleMaxCharacters = 48
+
+    /// The ONE shared "label (id)" derivation for catalog-fed picker menus
+    /// (composer models rows + Settings model override): the id alone when no
+    /// distinct label exists; whitespace runs collapse to single spaces (a
+    /// menu item must never carry a newline); overflow truncates in the
+    /// MIDDLE so the family prefix AND the differentiating id tail both stay
+    /// readable.
+    public static func menuTitle(label: String?, id: String) -> String {
+        let name = label.flatMap { $0.isEmpty ? nil : $0 } ?? id
+        let full = name == id ? name : "\(name) (\(id))"
+        let collapsed = full.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        guard collapsed.count > menuTitleMaxCharacters else { return collapsed }
+        let keep = menuTitleMaxCharacters - 1
+        let head = (keep + 1) / 2
+        return "\(collapsed.prefix(head))…\(collapsed.suffix(keep - head))"
+    }
+}
+
 /// Models enumerable for one harness (GET /harnesses/:id/models). `source` is
 /// honest about provenance: "api" when the adapter implemented a real
 /// enumeration, "manifest" reserved for a future manifest list, "none" when the

--- a/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/HarnessModelPresentationTests.swift
+++ b/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/HarnessModelPresentationTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import ClaudexorKit
+
+/// The OPEN-menu guarantee for catalog-fed model pickers (issue #53): an
+/// NSMenu sizes to its widest item, so the menu STRING cap — not any view
+/// frame — is what bounds the open dropdown. Both surfaces (composer models
+/// rows, Settings model override) render their items through this one
+/// derivation.
+@Suite struct HarnessModelPresentationTests {
+    @Test func longVendorLabelAndIdCapWithMiddleEllipsis() {
+        // Real failure shape: a free-text Cursor label plus a 126-char id.
+        let id = String(repeating: "cursor-agent-preview-", count: 6)
+        let label = "A deliberately long Cursor model label that must stay inside the menu"
+        let title = HarnessModelPresentation.menuTitle(label: label, id: id)
+        #expect(title.count == HarnessModelPresentation.menuTitleMaxCharacters)
+        // The ellipsis sits in the MIDDLE: the human prefix and the
+        // differentiating id tail both survive verbatim.
+        #expect(title == "A deliberately long Curs…-cursor-agent-preview-)")
+    }
+
+    @Test func shortInputsPassThroughUnchanged() {
+        #expect(HarnessModelPresentation.menuTitle(label: nil, id: "claude-opus-5") == "claude-opus-5")
+        // An EMPTY label degrades to the id, never to "" or " (id)".
+        #expect(HarnessModelPresentation.menuTitle(label: "", id: "gpt-5.6-sol") == "gpt-5.6-sol")
+        // label == id renders once, not "id (id)".
+        #expect(HarnessModelPresentation.menuTitle(label: "gpt-5.6-sol", id: "gpt-5.6-sol") == "gpt-5.6-sol")
+        #expect(HarnessModelPresentation.menuTitle(label: "GPT 5.6 Sol", id: "gpt-5.6-sol") == "GPT 5.6 Sol (gpt-5.6-sol)")
+        #expect(HarnessModelPresentation.menuTitle(label: nil, id: "") == "")
+    }
+
+    @Test func whitespaceRunsCollapseToSingleSpaces() {
+        // A menu item must never carry a newline or tab run (§1 rule 4).
+        let title = HarnessModelPresentation.menuTitle(label: "Cursor\n Composer\t\tPreview", id: "cmp-1")
+        #expect(title == "Cursor Composer Preview (cmp-1)")
+    }
+
+    @Test func capBoundaryIsExact() {
+        let fits = String(repeating: "a", count: HarnessModelPresentation.menuTitleMaxCharacters)
+        #expect(HarnessModelPresentation.menuTitle(label: nil, id: fits) == fits)
+        let over = String(repeating: "a", count: HarnessModelPresentation.menuTitleMaxCharacters + 1)
+        let capped = HarnessModelPresentation.menuTitle(label: nil, id: over)
+        #expect(capped == String(repeating: "a", count: 24) + "…" + String(repeating: "a", count: 23))
+    }
+}

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -1126,6 +1126,12 @@ DesignSystemComponents.swift, DesignTokens.swift.)
 - **`OptionSection` / `OptionRow`** — the "⋯" popover building blocks: a caption-titled
   section, and a `labelWidth`-aligned label+control row (replaces ad-hoc `.fixedSize()` /
   magic-width pickers so every option lines up). Solid surface, token spacing.
+- **`catalogModelPicker()` + `Layout.modelPickerWidth`** — the catalog-fed model picker
+  contract (composer models rows, Settings model override). Vendor catalogs are free text
+  with no length limit, so the CLOSED control pins to the 180pt token and truncates
+  mid-string, and every menu item renders through `HarnessModelPresentation.menuTitle`
+  (one capped "label (id)" derivation, middle ellipsis) — the OPEN `Picker` menu is an
+  NSMenu sized by its widest item, which no closed-control frame can bound (issue #53).
 - **`composerGlass()`** — the floating-panel glass modifier: static `.glassEffect(.regular)`
   (NOT `.interactive()` — see §3.1) with a `surfaceRaised` solid fallback under Reduce
   Transparency. Chrome only.


### PR DESCRIPTION
Closes #53

## Summary
- prevents a long Cursor model catalog entry from widening the closed model picker beyond the composer options popover
- replaces the intrinsic `.fixedSize()` sizing with a consistent 180pt picker width inside the popover's 348pt content area
- adds an AppKit/SwiftUI layout regression covering a selected long Cursor model plus the worst-case `primary` label

## Validation
- fail-first regression reproduced the bug at 1,423pt versus 348pt available
- targeted layout test: 1/1 passed after the fix
- full ClaudexorApp suite: 329/329 tests across 44 suites
- `swift build` passed
- `git diff --check` passed

## Merge independence
- clean merge-tree with current `main`
- clean pairwise merge-tree with draft PR #80 and open PRs #67, #68, and #69
- PR #54 already conflicts with current `main` in `scripts/complexity-baseline.json`; combining this branch with #54 shows only that identical pre-existing conflict