### PR TITLE
fix(macos): disable animated resize in the composer options popover (SIGSEGV on macOS 26.x)

### DIFF
--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/ThreadsScreen.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/ThreadsScreen.swift
@@ -451,6 +451,13 @@ struct ThreadsScreen: View {
             // Native dismissible popover — no inline glass-on-glass panel.
             .popover(isPresented: $showOptions, arrowEdge: .bottom) {
                 composerOptions
+                    // Animated popover resizes SIGSEGV on macOS 26.x: growing the
+                    // content (expanding "Advanced", strategy sections) makes
+                    // PopoverHostingView animate `setFrame:` inside windowDidLayout,
+                    // whose nested run loop hits a dead UpdateCycle observer
+                    // (crash at pc=0). Non-animated resizes never enter that path,
+                    // so every in-popover state change must run animation-free.
+                    .transaction { $0.disablesAnimations = true }
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Problem

Opening the composer "⋯" options popover and expanding the collapsed **Advanced** review controls (or any section that grows the popover — Agent strategy, Plan strategy) crashes the app on macOS 26.3.1 with `EXC_BAD_ACCESS (SIGSEGV)` at `pc = 0x0`.

Crash chain (from the crash report, ClaudexorApp 3.1.0 (103), macOS 26.3.1):

1. `NSHostingView.windowDidLayout` → `PopoverHostingView.updateAnimatedWindowSize` → `-[NSPopover _setContentView:size:canAnimate:]` → animated `-[NSWindow setFrame:display:animate:]`.
2. The animated resize (`NSMoveHelper _doAnimation`) spins a **nested run loop** — while already inside the display cycle (`NSDisplayCycleFlush` → `CA::Transaction::commit` → `layoutIfNeeded`).
3. Inside that nested run loop, CoreFoundation invokes a run-loop observer whose function pointer is NULL — the private **UpdateCycle** framework's `UC::LoopTapCFRunLoop` tap (macOS 26 frame pacing) is not valid there → jump to `0x0`, SIGSEGV.

No app frames appear in the crashing stack (only `main`) — this is an AppKit/SwiftUI bug the app merely triggers. The fix is to keep the trigger from firing.

## Fix

Run every state change inside the popover content with `disablesAnimations` (`.transaction { $0.disablesAnimations = true }` on `composerOptions` at the presentation site). A non-animated popover resize never enters `NSMoveHelper`'s nested run loop, so the crash path is unreachable. UX change: the popover snaps to its new size instead of animating — everything else is untouched.

This also covers the other growth points in the same popover (Agent strategy / Plan strategy sections, delegate warnings), which hit the same OS path.

## Verification

- `swift build` — clean.
- `swift test` — 365 tests in 49 suites, all pass.
- The crash itself is an OS-level race in a nested run loop; it reproduces on click on the affected machine and is eliminated by removing the animated-resize trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)