### PR TITLE
Fix finite-budget fallback accounting and acceptance battery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,15 @@ Release history for Claudexor. The current version is declared in the root
   directly runnable bundled/remote inspect command. CI now executes the
   ClaudexorApp tests (#91). GitHub Actions move to checkout 7.0.1,
   pnpm/action-setup 6.0.9, and download-artifact 8.0.1; the one Node 20 timer
-  fixture exposed during refresh now uses deterministic fake time.
+  fixture exposed during refresh now uses deterministic fake time. The repaired
+  real-harness battery (#94) can use existing authenticated sessions in a
+  disposable VM without relocating or copying credentials, refuses a live
+  daemon, forces and digests the exact source build, binds cleanup to the daemon
+  it started, leaves the default config byte-identical, revokes temporary trust,
+  scans every durable route interval, and fails acceptance on any FAIL, ENV, or
+  SKIP. API fallback disclosure before process start no longer creates a
+  fictitious unpaid interval and incorrectly ends an exact paid run as
+  `cost_unverifiable`.
 
 - **v3.2.0** (2026-07-29) — an eight-pull-request batch: remote execution, a
   canonical run receipt, and the toolchain moved forward. Remote SSH

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1724,7 +1724,10 @@ native reviewers to valuation and API-key reviewers to cash independently;
 their aggregate is never blindly charged as cash. Candidate and reviewer
 retries classify EACH usage event by that event/current typed credential
 route; a native→API-key retry cannot hide later metered spend under the first
-native route, and an undisclosed route remains cost-unverifiable. `finite(0)` admits
+native route, and an undisclosed route remains cost-unverifiable. A typed auth
+fallback disclosed before the vendor process starts selects the carried route
+but does not create a billable interval; only a real `started` interval can end
+without a receipt and make cash cost permanently unknown. `finite(0)` admits
 only proven-zero or subscription-entitlement work; a positive finite cap permits
 at most one unknown-cost paid unit in flight. A later exact charge above the cap
 is retained and ends `budget_overshoot`; permanently unknown cost ends

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -257,7 +257,14 @@ pnpm test
   allowlisted, unless a justified baseline entry explains why).
 - When runtime/harness resilience changes, the fixed real-harness battery
   (`pnpm battery:real`) is rerun or explicitly waived with the ENV/network
-  evidence that made it inconclusive.
+  evidence that made it inconclusive. Release acceptance uses the credentialed
+  disposable-VM existing-default lane from `docs/DEVELOPMENT.md`, without a
+  phase filter: its forced uncached build and receipt must bind the launched
+  daemon entry digest to the exact candidate handshake, prove the default config
+  remained byte-identical, prove every durable route interval in every Codex and
+  Claude task attempt stayed on a disclosed native session, and report
+  `FAIL=0 ENV=0 SKIP=0`. A scratch or partial run is diagnostic evidence, not
+  this acceptance gate.
 - New terminal states, retry events, or telemetry fields are documented in
   architecture/development docs and have generated schema updates.
 - Swift tests/build pass.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -329,10 +329,34 @@ Tests and local smokes must never touch real user state:
   but never auto-start one (a typo'd run id reports `no such run`); only acting
   paths (`agent`/`best-of`/`create`, `decision`) auto-start it. `daemon start` blocks
   until the daemon is actually ready, so a follow-up `status`/run can't race it.
-- Real-harness dogfood lives in `scripts/real-harness-battery.mjs` and runs only
-  against disposable repos under `~/.claudexor/dogfood`. It asserts engine-owned
-  artifacts, quarantines repeated host/network transient failures as ENV, and
-  must not target the Claudexor repo for harness writes.
+- Real-harness dogfood lives in `scripts/real-harness-battery.mjs`. Its default
+  scratch mode runs disposable repos under `~/.claudexor/dogfood`, with an
+  isolated config root. It asserts engine-owned artifacts, quarantines repeated
+  host/network transient failures as ENV, and must not target the Claudexor repo
+  for harness writes.
+- A credentialed disposable VM may opt into the existing default login state:
+
+  ```bash
+  CLAUDEXOR_BATTERY_CONFIG_DIR="$HOME/.claudexor/v3" \
+  CLAUDEXOR_BATTERY_DIR="$HOME/claudexor-dogfood/repo/battery-$(git rev-parse --short=12 HEAD)-$(date -u +%Y%m%dT%H%M%SZ)" \
+    pnpm battery:real
+  ```
+
+  This mode accepts only the canonical default config path and requires the
+  battery directory outside both `~/.claudexor` and the source checkout. It
+  deliberately does not export `CLAUDEXOR_CONFIG_DIR`. The `pnpm battery:real`
+  entrypoint first forces every workspace build (no Turbo cache), then records
+  the launched daemon entry digest beside its exact SHA/entry handshake. The
+  lane refuses a pre-existing daemon, stops only the identity-bound daemon it
+  started, keeps `config.yaml` byte- and mode-identical, and revokes its
+  temporary disposable-repo full-access grant. Every Codex and
+  Claude task attempt in the daemon's complete new-job inventory must disclose
+  `local_session` from `native_session`; an API fallback or undisclosed route
+  fails this VM acceptance, while Cursor retains its declared credential
+  transport. The lane is strict: FAIL, ENV, or SKIP greater than zero, a phase
+  filter, or omission of Codex, Claude, or Cursor makes the acceptance run fail.
+  Calling the script directly cannot satisfy the build proof. Never use the lane
+  on the credential-free pristine VM or on a config root with live work.
 - Runtime retry/review knobs are user-global config (`runtime.transient_retry`
   and `runtime.reviewer_timeout_ms`) with env overrides
   `CLAUDEXOR_TRANSIENT_RETRY_MAX`,

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -187,7 +187,9 @@ deliverable is never a deliverable.
 No regex governance: risk, permissions, winners, web evidence, and
 tests-passed come from typed contracts and events, never from string-matching
 model output. Unknown cost is unknown — subscription valuation, metered cash,
-and absence are three different typed facts.
+and absence are three different typed facts. A route fallback announced before
+the vendor process starts is selection evidence, not a fabricated paid attempt;
+receipt certainty is judged only across real started intervals.
 
 Run evidence lives in two labeled planes: Claudexor's internal orchestration
 record (contracts, events, attempts, reviews), and the project's produced

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "schema:gen": "tsx packages/schema/scripts/gen-jsonschema.ts",
     "gen:version": "node scripts/gen-version.mjs",
     "bench:bundle": "node benchmarks/terminal_bench/scripts/bundle-cli.mjs",
-    "battery:real": "node scripts/real-harness-battery.mjs",
+    "battery:real": "turbo run build --force && CLAUDEXOR_BATTERY_BUILD_VERIFIED=1 node scripts/real-harness-battery.mjs",
     "docs:check": "pnpm --filter ...@claudexor/control-api build && pnpm --filter ...@claudexor/cli build && node scripts/docs-truth-check.mjs",
     "staged:check": "node scripts/staged-field-check.mjs",
     "retired:check": "node scripts/retired-key-check.mjs",

--- a/packages/orchestrator/src/attemptUsage.test.ts
+++ b/packages/orchestrator/src/attemptUsage.test.ts
@@ -147,6 +147,135 @@ describe("processAttemptUsage", () => {
     });
   });
 
+  it("does not turn a pre-start API fallback disclosure into an unpaid interval", () => {
+    const telemetry = createAttemptTelemetry("auto", false);
+    const ts = new Date().toISOString();
+    observeAttemptTelemetry(telemetry, {
+      type: "message",
+      session_id: "s",
+      ts,
+      text: "switching route",
+      payload: { auth_switched: true, to_auth_mode: "api_key" },
+    });
+    observeAttemptTelemetry(telemetry, {
+      type: "started",
+      session_id: "s",
+      ts,
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, {
+      ...usageEvent(false),
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, { type: "completed", session_id: "s", ts });
+
+    expect(telemetry.usageCost.cashKnowledge).toBe("exact");
+    expect(telemetry.usageCost.cashUsd).toBe(0.37);
+    const ledger = new BudgetLedger({ kind: "finite", maxUsd: 1.5 });
+    const lease = ledger.reserve({
+      taskId: "pre-start-api-fallback",
+      intent: "explain",
+      harnessId: "claude",
+    }).lease!;
+    ledger.settle(
+      lease.lease_id,
+      attemptUsageCostSettlement(
+        0.37,
+        false,
+        "a01",
+        "claude",
+        telemetry.authMode,
+        telemetry.usageCost,
+      ),
+    );
+    expect(ledger.spend()).toBe(0.37);
+    expect(ledger.terminal()).toBeNull();
+  });
+
+  it("keeps a real API interval without usage unresolved across a later retry", () => {
+    const telemetry = createAttemptTelemetry("auto", false);
+    const ts = new Date().toISOString();
+    observeAttemptTelemetry(telemetry, {
+      type: "message",
+      session_id: "s",
+      ts,
+      text: "switching route",
+      payload: { auth_switched: true, to_auth_mode: "api_key" },
+    });
+    observeAttemptTelemetry(telemetry, {
+      type: "started",
+      session_id: "s",
+      ts,
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, { type: "completed", session_id: "s", ts });
+    observeAttemptTelemetry(telemetry, {
+      type: "started",
+      session_id: "s",
+      ts,
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, {
+      ...usageEvent(false),
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, { type: "completed", session_id: "s", ts });
+
+    expect(telemetry.usageCost.cashKnowledge).toBe("unknown");
+    const ledger = new BudgetLedger({ kind: "finite", maxUsd: 1.5 });
+    const lease = ledger.reserve({
+      taskId: "missing-first-api-receipt",
+      intent: "explain",
+      harnessId: "claude",
+    }).lease!;
+    ledger.settle(
+      lease.lease_id,
+      attemptUsageCostSettlement(
+        0.37,
+        false,
+        "a01",
+        "claude",
+        telemetry.authMode,
+        telemetry.usageCost,
+      ),
+    );
+    expect(ledger.spend()).toBe(0.37);
+    expect(ledger.terminal()).toBe("cost_unverifiable");
+  });
+
+  it("keeps native completion separate from a paid retry with a pre-start fallback", () => {
+    const telemetry = createAttemptTelemetry("auto", false);
+    const ts = new Date().toISOString();
+    observeAttemptTelemetry(telemetry, {
+      type: "started",
+      session_id: "s",
+      ts,
+      credential_route: "vendor_native",
+    });
+    observeAttemptTelemetry(telemetry, { type: "completed", session_id: "s", ts });
+    observeAttemptTelemetry(telemetry, {
+      type: "message",
+      session_id: "s",
+      ts,
+      text: "switching route",
+      payload: { auth_switched: true, to_auth_mode: "api_key" },
+    });
+    observeAttemptTelemetry(telemetry, {
+      type: "started",
+      session_id: "s",
+      ts,
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, {
+      ...usageEvent(false),
+      credential_route: "managed_api_key",
+    });
+    observeAttemptTelemetry(telemetry, { type: "completed", session_id: "s", ts });
+
+    expect(telemetry.usageCost.cashKnowledge).toBe("exact");
+    expect(telemetry.usageCost.cashUsd).toBe(0.37);
+  });
+
   it("fails cash certainty closed when a native attempt switches to API without usage", () => {
     const telemetry = createAttemptTelemetry("auto", false);
     const ts = new Date().toISOString();

--- a/packages/orchestrator/src/attemptUsageCost.ts
+++ b/packages/orchestrator/src/attemptUsageCost.ts
@@ -23,6 +23,7 @@ interface RouteKnowledgeState {
   sawUnknownUsage: boolean;
   unresolvedApiRoute: boolean;
   unresolvedUndisclosedRoute: boolean;
+  activeStarted: boolean;
   activeSawEvent: boolean;
   activeSawNativeRoute: boolean;
   activeSawApiRoute: boolean;
@@ -151,7 +152,12 @@ export function newAttemptUsageCost(): AttemptUsageCost {
  * ended without a usage receipt remains unresolved even if a later retry pays. */
 function startAttemptUsageRoute(cost: AttemptUsageCost): void {
   const state = stateFor(cost);
-  finishActiveRoute(state);
+  // Adapters may disclose an auth fallback before the vendor process emits
+  // `started`. That prelude selects the carried mode but is not a billable
+  // interval of its own. Only a second real `started` may close a prior
+  // interval as missing its usage receipt.
+  if (state.activeStarted) finishActiveRoute(state);
+  state.activeStarted = true;
   state.activeSawEvent = false;
   state.activeSawNativeRoute = false;
   state.activeSawApiRoute = false;
@@ -163,6 +169,7 @@ function observeAttemptUsageRoute(
   mode: "local_session" | "api_key" | null,
 ): void {
   const state = stateFor(cost);
+  if (!state.activeStarted) return;
   state.activeSawEvent = true;
   if (mode === "local_session") {
     state.sawNativeRoute = true;
@@ -197,6 +204,11 @@ export function observeAttemptUsageEvent(
           ? "api_key"
           : mode;
     recordAttemptUsageCost(cost, receiptMode, usd, event.usage?.estimated === true);
+  }
+  if (event.type === "completed") {
+    const state = stateFor(cost);
+    finishActiveRoute(state);
+    state.activeStarted = false;
   }
   return mode;
 }
@@ -270,6 +282,7 @@ function newRouteKnowledgeState(): RouteKnowledgeState {
     sawUnknownUsage: false,
     unresolvedApiRoute: false,
     unresolvedUndisclosedRoute: false,
+    activeStarted: false,
     activeSawEvent: false,
     activeSawNativeRoute: false,
     activeSawApiRoute: false,

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -5156,6 +5156,48 @@ describe("Orchestrator", () => {
     expect(answer).not.toContain("[auth]");
   });
 
+  it("settles exact API cash when the readiness disclosure precedes started", async () => {
+    const repo = await initRepo();
+    const adapter = askAdapter("authy", function* (sessionId) {
+      const ts = new Date().toISOString();
+      yield {
+        type: "message",
+        session_id: sessionId,
+        ts,
+        credential_route: undefined,
+        text: "[auth] auto selected api_key route because doctor smoke-proved it",
+        payload: {
+          auth_switched: true,
+          from_auth_mode: "local_session",
+          to_auth_mode: "api_key",
+          reason: "readiness_preferred",
+        },
+      };
+      yield { type: "started", session_id: sessionId, ts };
+      yield { type: "message", session_id: sessionId, ts, text: "Answered." };
+      yield {
+        type: "usage",
+        session_id: sessionId,
+        ts,
+        usage: { cost_usd: 0.08005475 },
+      };
+      yield { type: "completed", session_id: sessionId, ts };
+    });
+    const orch = new Orchestrator({ registry: new Map([["authy", adapter]]), reviewers: [] });
+    const res = await orch.run({
+      repoRoot: repo,
+      prompt: "do it",
+      mode: "ask",
+      harnesses: ["authy"],
+      n: 1,
+      paidBudget: { kind: "finite", maxUsd: 1.5 },
+    });
+
+    expect(legacyOutcome(res)).toBe("success");
+    expect(res.facts.reason).toBeNull();
+    expectBudgetSplit(res.runDir, 0.08005475, 0);
+  });
+
   it("falls back to another ask harness when web evidence is unsatisfied", async () => {
     const repo = await initRepo();
     const bad = askAdapter("web-bad", function* (sessionId) {

--- a/scripts/lib/real-harness-battery-state.mjs
+++ b/scripts/lib/real-harness-battery-state.mjs
@@ -1,0 +1,206 @@
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+function isWithin(parent, candidate) {
+  const rel = relative(parent, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function canonicalFuturePath(path) {
+  const absolute = resolve(path);
+  let ancestor = absolute;
+  const suffix = [];
+  while (!existsSync(ancestor)) {
+    const parent = dirname(ancestor);
+    if (parent === ancestor) throw new Error(`battery path has no existing ancestor: ${absolute}`);
+    suffix.unshift(ancestor.slice(parent.length + 1));
+    ancestor = parent;
+  }
+  const stat = lstatSync(ancestor);
+  if (stat.isSymbolicLink() || !stat.isDirectory() || realpathSync.native(ancestor) !== ancestor) {
+    throw new Error(`battery path ancestor is not canonical: ${ancestor}`);
+  }
+  const canonical = join(ancestor, ...suffix);
+  if (canonical !== absolute) throw new Error(`battery path is not canonical: ${absolute}`);
+  return canonical;
+}
+
+export function assertNoPreexistingDaemon({ statusCode, socketIsAlive, leaseIsAlive }) {
+  if (statusCode === 0) throw new Error("refusing a pre-existing Claudexor daemon");
+  if (socketIsAlive || leaseIsAlive) {
+    throw new Error("daemon preflight found a live socket or writer-lease owner");
+  }
+}
+
+export function sameDaemonLease(expected, current) {
+  return Boolean(
+    expected && current && expected.pid === current.pid && expected.token === current.token,
+  );
+}
+
+/** Preserve the serving identity observed from a fresh daemon even when it is
+ * not the requested candidate, so cleanup can target that exact process. */
+export function runtimeReplacementIdentityFromHandshake(handshake) {
+  const engine = handshake?.engine;
+  if (
+    !engine ||
+    typeof engine !== "object" ||
+    typeof engine.version !== "string" ||
+    engine.version.length === 0 ||
+    typeof engine.sha !== "string" ||
+    !/^[0-9a-f]{40}$/.test(engine.sha)
+  ) {
+    return null;
+  }
+  return { version: engine.version, buildSha: engine.sha };
+}
+
+export function evaluateRequiredNativeRoutes(requiredHarnesses, observed) {
+  const missing = requiredHarnesses.filter(
+    (harnessId) => !observed.some((route) => route.harnessId === harnessId),
+  );
+  const nonNative = observed.filter(
+    (route) => route.authMode !== "local_session" || route.authSource !== "native_session",
+  );
+  return { valid: missing.length === 0 && nonNative.length === 0, missing, nonNative };
+}
+
+/** Normalize every durable route interval/switch without trusting first-route telemetry. */
+export function durableAttemptRouteEvidence(events) {
+  const observed = [];
+  let sawStarted = false;
+  for (const event of events) {
+    if (!event || typeof event !== "object") continue;
+    if (event.type === "started") {
+      sawStarted = true;
+      observed.push({
+        kind: "started",
+        authMode:
+          event.credential_route === "vendor_native"
+            ? "local_session"
+            : event.credential_route === "managed_api_key"
+              ? "api_key"
+              : null,
+        authSource: typeof event.credential_source === "string" ? event.credential_source : null,
+      });
+      continue;
+    }
+    if (event.credential_route === "managed_api_key") {
+      observed.push({
+        kind: "api_route_event",
+        authMode: "api_key",
+        authSource: typeof event.credential_source === "string" ? event.credential_source : null,
+      });
+    }
+    if (event.type === "message" && event.payload?.auth_switched === true) {
+      const toAuthMode = event.payload.to_auth_mode;
+      const switchedToNative = toAuthMode === "local_session" || toAuthMode === "subscription";
+      observed.push({
+        kind: "auth_switched",
+        authMode: toAuthMode === "api_key" ? "api_key" : switchedToNative ? "local_session" : null,
+        authSource: switchedToNative ? "native_session" : null,
+      });
+    }
+  }
+  return { sawStarted, observed };
+}
+
+/** Resolve the battery's storage mode before any directory or daemon mutation. */
+export function resolveRealHarnessBatteryLayout({
+  home,
+  sourceRoot,
+  defaultBatteryRoot,
+  batteryDir,
+  requestedConfigDir,
+  ambientConfigDir,
+}) {
+  const canonicalHome = realpathSync.native(resolve(home));
+  const canonicalSource = realpathSync.native(resolve(sourceRoot));
+  const requested = requestedConfigDir?.trim();
+  if (!requested) {
+    const batteryRoot = canonicalFuturePath(batteryDir?.trim() || defaultBatteryRoot);
+    return {
+      mode: "scratch",
+      batteryRoot,
+      configDir: join(batteryRoot, "config"),
+      exportConfigDir: true,
+    };
+  }
+
+  if (ambientConfigDir?.trim()) {
+    throw new Error(
+      "CLAUDEXOR_BATTERY_CONFIG_DIR cannot be combined with CLAUDEXOR_CONFIG_DIR; unset the latter",
+    );
+  }
+  if (!isAbsolute(requested)) {
+    throw new Error("CLAUDEXOR_BATTERY_CONFIG_DIR must be an absolute path");
+  }
+  const expectedConfigDir = join(canonicalHome, ".claudexor", "v3");
+  const requestedAbsolute = resolve(requested);
+  const requestedStat = lstatSync(requestedAbsolute);
+  if (
+    requestedAbsolute !== expectedConfigDir ||
+    requestedStat.isSymbolicLink() ||
+    !requestedStat.isDirectory() ||
+    realpathSync.native(requestedAbsolute) !== expectedConfigDir
+  ) {
+    throw new Error(
+      `CLAUDEXOR_BATTERY_CONFIG_DIR must be the canonical default config directory ${expectedConfigDir}`,
+    );
+  }
+  if (!batteryDir?.trim() || !isAbsolute(batteryDir.trim())) {
+    throw new Error(
+      "CLAUDEXOR_BATTERY_DIR must be an explicit absolute path in existing-default mode",
+    );
+  }
+  const batteryRoot = canonicalFuturePath(batteryDir.trim());
+  const ownedRoot = join(canonicalHome, ".claudexor");
+  if (isWithin(ownedRoot, batteryRoot)) {
+    throw new Error("CLAUDEXOR_BATTERY_DIR must be outside the Claudexor runtime tree");
+  }
+  if (isWithin(canonicalSource, batteryRoot)) {
+    throw new Error("CLAUDEXOR_BATTERY_DIR must be outside the Claudexor source checkout");
+  }
+  return {
+    mode: "existing_default",
+    batteryRoot,
+    configDir: expectedConfigDir,
+    // Omitting the override is semantically important: an explicit override
+    // would narrow claudexorOwnedRoot() and invalidate existing profile paths.
+    exportConfigDir: false,
+  };
+}
+
+export function snapshotRegularFile(path) {
+  if (!existsSync(path)) return { exists: false, bytes: null, digest: null, mode: null };
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+    throw new Error(`refusing unsafe battery state file: ${path}`);
+  }
+  const bytes = readFileSync(path);
+  return {
+    exists: true,
+    bytes,
+    digest: createHash("sha256").update(bytes).digest("hex"),
+    mode: stat.mode & 0o777,
+  };
+}
+
+export function describeFileSnapshot(snapshot) {
+  return {
+    exists: snapshot.exists,
+    digest: snapshot.digest,
+    mode: snapshot.mode,
+  };
+}
+
+export function assertRegularFileUnchanged(path, before) {
+  const after = snapshotRegularFile(path);
+  const same =
+    before.exists === after.exists &&
+    before.mode === after.mode &&
+    (before.bytes === null ? after.bytes === null : before.bytes.equals(after.bytes));
+  if (!same) throw new Error(`battery changed protected state file: ${path}`);
+  return after;
+}

--- a/scripts/lib/real-harness-battery-state.test.mjs
+++ b/scripts/lib/real-harness-battery-state.test.mjs
@@ -1,0 +1,270 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import {
+  assertNoPreexistingDaemon,
+  assertRegularFileUnchanged,
+  describeFileSnapshot,
+  durableAttemptRouteEvidence,
+  evaluateRequiredNativeRoutes,
+  resolveRealHarnessBatteryLayout,
+  runtimeReplacementIdentityFromHandshake,
+  sameDaemonLease,
+  snapshotRegularFile,
+} from "./real-harness-battery-state.mjs";
+
+const fixtureRoots = [];
+
+afterEach(() => {
+  for (const root of fixtureRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function fixture() {
+  const root = realpathSync.native(mkdtempSync(join(tmpdir(), "claudexor-battery-state-")));
+  fixtureRoots.push(root);
+  const home = join(root, "home");
+  const sourceRoot = join(root, "source");
+  const defaultConfig = join(home, ".claudexor", "v3");
+  mkdirSync(defaultConfig, { recursive: true });
+  mkdirSync(sourceRoot);
+  return { root, home, sourceRoot, defaultConfig };
+}
+
+test("scratch mode keeps its isolated config override", () => {
+  const f = fixture();
+  const defaultBatteryRoot = join(f.home, ".claudexor", "dogfood", "battery-1");
+  expect(
+    resolveRealHarnessBatteryLayout({
+      home: f.home,
+      sourceRoot: f.sourceRoot,
+      defaultBatteryRoot,
+    }),
+  ).toEqual({
+    mode: "scratch",
+    batteryRoot: defaultBatteryRoot,
+    configDir: join(defaultBatteryRoot, "config"),
+    exportConfigDir: true,
+  });
+});
+
+test("existing-default mode accepts only the canonical default root and external battery dir", () => {
+  const f = fixture();
+  const batteryRoot = join(f.root, "dogfood", "battery-1");
+  expect(
+    resolveRealHarnessBatteryLayout({
+      home: f.home,
+      sourceRoot: f.sourceRoot,
+      defaultBatteryRoot: join(f.root, "unused"),
+      batteryDir: batteryRoot,
+      requestedConfigDir: f.defaultConfig,
+    }),
+  ).toEqual({
+    mode: "existing_default",
+    batteryRoot,
+    configDir: f.defaultConfig,
+    exportConfigDir: false,
+  });
+});
+
+test("existing-default mode rejects ambient, foreign, symlinked, and overlapping roots", () => {
+  const f = fixture();
+  const args = {
+    home: f.home,
+    sourceRoot: f.sourceRoot,
+    defaultBatteryRoot: join(f.root, "unused"),
+    batteryDir: join(f.root, "dogfood"),
+    requestedConfigDir: f.defaultConfig,
+  };
+  expect(() =>
+    resolveRealHarnessBatteryLayout({ ...args, ambientConfigDir: join(f.root, "ambient") }),
+  ).toThrow(/cannot be combined/);
+  const foreign = join(f.root, "foreign");
+  mkdirSync(foreign);
+  expect(() => resolveRealHarnessBatteryLayout({ ...args, requestedConfigDir: foreign })).toThrow(
+    /canonical default/,
+  );
+  const link = join(f.root, "config-link");
+  symlinkSync(f.defaultConfig, link);
+  expect(() => resolveRealHarnessBatteryLayout({ ...args, requestedConfigDir: link })).toThrow(
+    /canonical default/,
+  );
+  expect(() =>
+    resolveRealHarnessBatteryLayout({
+      ...args,
+      batteryDir: join(f.home, ".claudexor", "dogfood"),
+    }),
+  ).toThrow(/outside the Claudexor runtime tree/);
+  expect(() =>
+    resolveRealHarnessBatteryLayout({ ...args, batteryDir: join(f.sourceRoot, "tmp") }),
+  ).toThrow(/outside the Claudexor source checkout/);
+});
+
+test("protected config snapshot detects byte and mode changes", () => {
+  const f = fixture();
+  const path = join(f.defaultConfig, "config.yaml");
+  writeFileSync(path, "version: 1\n", { mode: 0o600 });
+  const before = snapshotRegularFile(path);
+  expect(describeFileSnapshot(assertRegularFileUnchanged(path, before))).toEqual({
+    exists: true,
+    digest: before.digest,
+    mode: 0o600,
+  });
+  writeFileSync(path, "version: 1\nrouting: {}\n");
+  expect(() => assertRegularFileUnchanged(path, before)).toThrow(/changed protected state/);
+  writeFileSync(path, "version: 1\n");
+  chmodSync(path, 0o640);
+  expect(() => assertRegularFileUnchanged(path, before)).toThrow(/changed protected state/);
+});
+
+test("daemon preflight fails closed on each live ownership surface", () => {
+  const clear = {
+    statusCode: 1,
+    socketIsAlive: false,
+    leaseIsAlive: false,
+  };
+  expect(() => assertNoPreexistingDaemon(clear)).not.toThrow();
+  expect(() => assertNoPreexistingDaemon({ ...clear, statusCode: 0 })).toThrow(/pre-existing/);
+  expect(() => assertNoPreexistingDaemon({ ...clear, socketIsAlive: true })).toThrow(/live socket/);
+  expect(() => assertNoPreexistingDaemon({ ...clear, leaseIsAlive: true })).toThrow(/writer-lease/);
+});
+
+test("daemon cleanup authority is bound to the exact writer lease", () => {
+  const captured = { pid: 41, token: "captured" };
+  expect(sameDaemonLease(captured, { ...captured })).toBe(true);
+  expect(sameDaemonLease(captured, { pid: 42, token: "captured" })).toBe(false);
+  expect(sameDaemonLease(captured, { pid: 41, token: "successor" })).toBe(false);
+  expect(sameDaemonLease(captured, null)).toBe(false);
+});
+
+test("daemon cleanup keeps the observed identity when the candidate handshake mismatches", () => {
+  const observedSha = "a".repeat(40);
+  expect(
+    runtimeReplacementIdentityFromHandshake({
+      engine: { version: "3.2.1", sha: observedSha, entry: "/tmp/claudexord.js" },
+    }),
+  ).toEqual({ version: "3.2.1", buildSha: observedSha });
+  expect(
+    runtimeReplacementIdentityFromHandshake({
+      engine: { version: "3.2.1", sha: "not-a-sha", entry: "/tmp/claudexord.js" },
+    }),
+  ).toBeNull();
+});
+
+test("native-session acceptance rejects missing and API-fallback routes", () => {
+  const required = ["codex", "claude"];
+  const codex = {
+    harnessId: "codex",
+    authMode: "local_session",
+    authSource: "native_session",
+  };
+  const claude = {
+    harnessId: "claude",
+    authMode: "local_session",
+    authSource: "native_session",
+  };
+  expect(evaluateRequiredNativeRoutes(required, [codex, claude])).toEqual({
+    valid: true,
+    missing: [],
+    nonNative: [],
+  });
+  expect(evaluateRequiredNativeRoutes(required, [codex])).toMatchObject({
+    valid: false,
+    missing: ["claude"],
+  });
+  expect(
+    evaluateRequiredNativeRoutes(required, [
+      codex,
+      { ...claude, authMode: "api_key", authSource: "api_key_env" },
+    ]),
+  ).toMatchObject({ valid: false, nonNative: [{ harnessId: "claude" }] });
+  expect(
+    evaluateRequiredNativeRoutes(required, [
+      codex,
+      { ...claude, authMode: null, authSource: null },
+    ]),
+  ).toMatchObject({ valid: false, nonNative: [{ harnessId: "claude" }] });
+});
+
+test("durable route evidence catches native to API retries after the first start", () => {
+  const evidence = durableAttemptRouteEvidence([
+    {
+      type: "started",
+      credential_route: "vendor_native",
+      credential_source: "native_session",
+    },
+    { type: "completed" },
+    {
+      type: "message",
+      payload: { auth_switched: true, to_auth_mode: "api_key" },
+    },
+    {
+      type: "started",
+      credential_route: "managed_api_key",
+      credential_source: "api_key_env",
+    },
+  ]);
+  expect(evidence).toEqual({
+    sawStarted: true,
+    observed: [
+      { kind: "started", authMode: "local_session", authSource: "native_session" },
+      { kind: "auth_switched", authMode: "api_key", authSource: null },
+      { kind: "started", authMode: "api_key", authSource: "api_key_env" },
+    ],
+  });
+});
+
+test("durable route evidence fails closed on an unknown auth switch", () => {
+  const evidence = durableAttemptRouteEvidence([
+    {
+      type: "started",
+      credential_route: "vendor_native",
+      credential_source: "native_session",
+    },
+    {
+      type: "message",
+      payload: { auth_switched: true, to_auth_mode: "unknown" },
+    },
+  ]);
+  expect(evidence.observed).toEqual([
+    { kind: "started", authMode: "local_session", authSource: "native_session" },
+    { kind: "auth_switched", authMode: null, authSource: null },
+  ]);
+  const observed = evidence.observed.map((route) => ({ harnessId: "codex", ...route }));
+  expect(evaluateRequiredNativeRoutes(["codex"], observed)).toMatchObject({
+    valid: false,
+    missing: [],
+    nonNative: [{ harnessId: "codex", kind: "auth_switched", authMode: null, authSource: null }],
+  });
+});
+
+test.each(["local_session", "subscription"])(
+  "durable route evidence accepts a known native %s auth switch",
+  (toAuthMode) => {
+    const evidence = durableAttemptRouteEvidence([
+      {
+        type: "started",
+        credential_route: "vendor_native",
+        credential_source: "native_session",
+      },
+      {
+        type: "message",
+        payload: { auth_switched: true, to_auth_mode: toAuthMode },
+      },
+    ]);
+    const observed = evidence.observed.map((route) => ({ harnessId: "codex", ...route }));
+    expect(evaluateRequiredNativeRoutes(["codex"], observed)).toMatchObject({
+      valid: true,
+      missing: [],
+      nonNative: [],
+    });
+  },
+);

--- a/scripts/real-harness-battery.mjs
+++ b/scripts/real-harness-battery.mjs
@@ -9,7 +9,8 @@
  *
  * Safety:
  * - never targets the Claudexor repo as a mutation target;
- * - uses a temp CLAUDEXOR_CONFIG_DIR for daemon/settings state;
+ * - defaults to a temp CLAUDEXOR_CONFIG_DIR for daemon/settings state;
+ * - may use the exact default config only through an explicit, guarded VM lane;
  * - keeps HOME native so real harness sessions/Keychain remain available;
  * - never prints secret values.
  */
@@ -22,8 +23,29 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
 import { ArtifactStore } from "../packages/artifact-store/dist/index.js";
+import {
+  awaitDaemonTermination,
+  DaemonClient,
+  daemonLeaseOwner,
+  defaultSocketPath,
+  processIsAlive,
+  readToken,
+  socketAlive,
+} from "../packages/daemon/dist/index.js";
 import { ControlRunDetail, RunDeliveryState } from "../packages/schema/dist/index.js";
-import { redactSecrets } from "../packages/util/dist/index.js";
+import { CLAUDEXOR_VERSION, redactSecrets } from "../packages/util/dist/index.js";
+import { admitAndAwaitRuntimeReplacementStop } from "../packages/cli/dist/runtime-replacement-stop.js";
+import {
+  assertNoPreexistingDaemon,
+  assertRegularFileUnchanged,
+  describeFileSnapshot,
+  durableAttemptRouteEvidence,
+  evaluateRequiredNativeRoutes,
+  resolveRealHarnessBatteryLayout,
+  runtimeReplacementIdentityFromHandshake,
+  sameDaemonLease,
+  snapshotRegularFile,
+} from "./lib/real-harness-battery-state.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const cli = join(root, "packages", "cli", "dist", "cli.js");
@@ -31,8 +53,15 @@ const nodeBin = process.execPath;
 const home = homedir();
 const runId = new Date().toISOString().replace(/[:.]/g, "-");
 const defaultRoot = join(home, ".claudexor", "dogfood", `battery-${runId}`);
-const batteryRoot = resolve(process.env.CLAUDEXOR_BATTERY_DIR ?? defaultRoot);
-const configDir = join(batteryRoot, "config");
+const layout = resolveRealHarnessBatteryLayout({
+  home,
+  sourceRoot: root,
+  defaultBatteryRoot: defaultRoot,
+  batteryDir: process.env.CLAUDEXOR_BATTERY_DIR,
+  requestedConfigDir: process.env.CLAUDEXOR_BATTERY_CONFIG_DIR,
+  ambientConfigDir: process.env.CLAUDEXOR_CONFIG_DIR,
+});
+const { batteryRoot, configDir } = layout;
 const resultsDir = join(batteryRoot, "results");
 const reposDir = join(batteryRoot, "repos");
 const logsDir = join(batteryRoot, "logs");
@@ -43,6 +72,8 @@ const requestedHarnesses = (process.env.CLAUDEXOR_BATTERY_HARNESSES ?? "codex,cl
   .map((s) => s.trim())
   .filter(Boolean);
 const marker = process.env.CLAUDEXOR_BATTERY_IMAGE_MARKER ?? "CLAUDEXOR-7521";
+const buildVerified = process.env.CLAUDEXOR_BATTERY_BUILD_VERIFIED === "1";
+delete process.env.CLAUDEXOR_BATTERY_BUILD_VERIFIED;
 // Optional phase filter (e.g. "10,11,12"): an operator iterating on one
 // surface should not re-burn the whole battery. Default: every phase.
 const phaseFilter = (process.env.CLAUDEXOR_BATTERY_PHASES ?? "")
@@ -52,10 +83,14 @@ const phaseFilter = (process.env.CLAUDEXOR_BATTERY_PHASES ?? "")
   .map((s) => `phase${s.replace(/^phase/, "")}`);
 const phaseEnabled = (id) => phaseFilter.length === 0 || phaseFilter.includes(id);
 
-mkdirSync(configDir, { recursive: true });
-mkdirSync(resultsDir, { recursive: true });
-mkdirSync(reposDir, { recursive: true });
-mkdirSync(logsDir, { recursive: true });
+if (layout.mode === "scratch") mkdirSync(configDir, { recursive: true, mode: 0o700 });
+mkdirSync(resultsDir, { recursive: true, mode: 0o700 });
+mkdirSync(reposDir, { recursive: true, mode: 0o700 });
+mkdirSync(logsDir, { recursive: true, mode: 0o700 });
+
+const protectedConfigPath = join(configDir, "config.yaml");
+const protectedConfigBefore =
+  layout.mode === "existing_default" ? snapshotRegularFile(protectedConfigPath) : null;
 
 const env = {
   ...process.env,
@@ -66,9 +101,11 @@ const env = {
   ]
     .filter(Boolean)
     .join(":"),
-  CLAUDEXOR_CONFIG_DIR: configDir,
+  CLAUDEXOR_DAEMON_ENTRY: join(root, "packages", "cli", "dist", "claudexord.js"),
   CLAUDEXOR_DOCTOR_TTL_MS: "0",
 };
+if (layout.exportConfigDir) env.CLAUDEXOR_CONFIG_DIR = configDir;
+else delete env.CLAUDEXOR_CONFIG_DIR;
 if (existsSync(join(home, ".local", "bin", "cursor-agent"))) {
   env.CLAUDEXOR_CURSOR_BIN = join(home, ".local", "bin", "cursor-agent");
 }
@@ -80,18 +117,33 @@ if (existsSync(join(home, ".claudexor", "node", "bin", "claude"))) {
 }
 // The in-process Control API phase must resolve the same isolated daemon and
 // harness binaries as child CLI invocations.
+if (!layout.exportConfigDir) delete process.env.CLAUDEXOR_CONFIG_DIR;
 Object.assign(process.env, env);
 
 const results = [];
 const evidence = {
   batteryRoot,
   configDir,
+  configMode: layout.mode,
+  configBefore: protectedConfigBefore ? describeFileSnapshot(protectedConfigBefore) : null,
+  configAfter: null,
+  configUnchanged: layout.mode === "scratch" ? null : false,
+  forcedBuildVerified: buildVerified,
   cli,
   node: nodeBin,
   version: null,
+  candidate: { sha: null, tree: null },
+  daemon: { start: null, handshake: null, entrySha256: null, stop: null },
   requestedHarnesses,
   okHarnesses: [],
   harnessReports: {},
+};
+const runtimeState = {
+  daemonOwned: false,
+  daemonClient: null,
+  daemonIdentity: null,
+  daemonLease: null,
+  baselineJobIds: new Set(),
 };
 
 function rel(path) {
@@ -223,9 +275,238 @@ function runCliText(args, opts = {}) {
   return runCli(args, { ...opts, json: false });
 }
 
+async function startBatteryDaemon() {
+  const socketPath = defaultSocketPath();
+  const expectedEntry = join(root, "packages", "cli", "dist", "claudexord.js");
+  evidence.daemon.entrySha256 = createHash("sha256")
+    .update(readFileSync(expectedEntry))
+    .digest("hex");
+  const preflight = runCliJson(["daemon", "status"], {
+    name: "daemon-preflight",
+    envRetry: false,
+  });
+  const preflightLease = daemonLeaseOwner(socketPath);
+  const preflightSocketAlive = await socketAlive(socketPath);
+  assertNoPreexistingDaemon({
+    statusCode: preflight.code,
+    socketIsAlive: preflightSocketAlive,
+    leaseIsAlive: Boolean(preflightLease && processIsAlive(preflightLease.pid)),
+  });
+
+  const started = runCliJson(["daemon", "start"], {
+    name: "daemon-start",
+    envRetry: false,
+  });
+  const startedPid = started.json?.pid;
+  const lease = daemonLeaseOwner(socketPath);
+  if (Number.isSafeInteger(startedPid) && startedPid > 0 && lease?.pid === startedPid) {
+    const token = readToken();
+    if (token) {
+      // Capture cleanup authority as soon as the detached child proves writer
+      // ownership. A later readiness/handshake failure must not leak it.
+      runtimeState.daemonOwned = true;
+      runtimeState.daemonLease = lease;
+      runtimeState.daemonClient = new DaemonClient(socketPath, token);
+      evidence.daemon.start = {
+        pid: startedPid,
+        ready: started.json?.ready === true,
+        alreadyRunning: started.json?.alreadyRunning === true,
+        processIdentity: lease.identity?.status ?? null,
+      };
+    }
+  }
+  if (
+    started.code !== 0 ||
+    started.json?.ready !== true ||
+    started.json?.alreadyRunning === true ||
+    !Number.isSafeInteger(startedPid) ||
+    startedPid <= 0
+  ) {
+    throw new Error(`battery could not prove a fresh daemon start; inspect ${started.log}`);
+  }
+  if (!runtimeState.daemonOwned || !lease || lease.pid !== startedPid) {
+    throw new Error("fresh daemon pid does not own the writer lease; refusing cleanup authority");
+  }
+
+  const [{ ensureDaemon }, { controlApiFetch, CONTROL_PROTOCOL_MAJOR }] = await Promise.all([
+    import("../packages/cli/dist/daemon-run.js"),
+    import("../packages/cli/dist/live.js"),
+  ]);
+  const { addr } = await ensureDaemon();
+  const response = await controlApiFetch(addr, "/v2/handshake", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ protocolMajor: CONTROL_PROTOCOL_MAJOR, client: "battery" }),
+  });
+  if (!response.ok) throw new Error(`battery daemon handshake failed (HTTP ${response.status})`);
+  const handshake = await response.json();
+  // Capture the identity before candidate validation. A mismatching but valid
+  // fresh daemon must still be stopped through the identity-bound RPC.
+  runtimeState.daemonIdentity = runtimeReplacementIdentityFromHandshake(handshake);
+  if (
+    handshake?.engine?.sha !== evidence.candidate.sha ||
+    resolve(handshake?.engine?.entry ?? "") !== expectedEntry
+  ) {
+    throw new Error("battery daemon handshake does not match the exact source candidate");
+  }
+  evidence.daemon.handshake = {
+    version: handshake.engine.version,
+    sha: handshake.engine.sha,
+    entry: handshake.engine.entry,
+    entrySha256: evidence.daemon.entrySha256,
+  };
+  runtimeState.baselineJobIds = new Set(
+    (await runtimeState.daemonClient.list()).map((job) => job.id),
+  );
+  pass("phase0", "fresh exact-candidate daemon", evidence.daemon.handshake);
+}
+
+async function stopBatteryDaemon() {
+  if (!runtimeState.daemonOwned) return;
+  const socketPath = defaultSocketPath();
+  const expectedOwner = runtimeState.daemonLease;
+  const client = runtimeState.daemonClient;
+  const currentOwner = daemonLeaseOwner(socketPath);
+  if (!client || !sameDaemonLease(expectedOwner, currentOwner)) {
+    evidence.daemon.stop = {
+      stopped: false,
+      reason: "captured daemon owner is no longer current; successor left untouched",
+    };
+    fail("cleanup", "battery-owned daemon stopped", evidence.daemon.stop);
+    return;
+  }
+  try {
+    const target = {
+      version: runtimeState.daemonIdentity?.version ?? CLAUDEXOR_VERSION,
+      buildSha: runtimeState.daemonIdentity?.buildSha ?? evidence.candidate.sha,
+      leaseOwner: { pid: expectedOwner.pid, token: expectedOwner.token },
+    };
+    const termination = await admitAndAwaitRuntimeReplacementStop(
+      () => client.shutdownForRuntimeReplacement(target),
+      (options) => awaitDaemonTermination(socketPath, options),
+      expectedOwner,
+    );
+    const leaseReleased = daemonLeaseOwner(socketPath) === null;
+    const valid = termination.outcome !== "still_alive" && leaseReleased;
+    evidence.daemon.stop = {
+      stopped: valid,
+      outcome: termination.outcome,
+      detail: termination.detail,
+      leaseReleased,
+    };
+    (valid ? pass : fail)("cleanup", "battery-owned daemon stopped", evidence.daemon.stop);
+    if (valid) runtimeState.daemonOwned = false;
+  } catch (error) {
+    evidence.daemon.stop = {
+      stopped: false,
+      reason: error instanceof Error ? error.message : String(error),
+    };
+    fail("cleanup", "battery-owned daemon stopped", evidence.daemon.stop);
+  }
+}
+
+function verifyProtectedConfig() {
+  if (!protectedConfigBefore) return;
+  try {
+    const after = assertRegularFileUnchanged(protectedConfigPath, protectedConfigBefore);
+    evidence.configAfter = describeFileSnapshot(after);
+    evidence.configUnchanged = true;
+    pass("cleanup", "default config remained byte-identical", evidence.configAfter);
+  } catch (error) {
+    evidence.configAfter = (() => {
+      try {
+        return describeFileSnapshot(snapshotRegularFile(protectedConfigPath));
+      } catch {
+        return null;
+      }
+    })();
+    evidence.configUnchanged = false;
+    fail("cleanup", "default config remained byte-identical", {
+      error: error instanceof Error ? error.message : String(error),
+      before: evidence.configBefore,
+      after: evidence.configAfter,
+    });
+  }
+}
+
 function inspectRun(runId, cwd) {
   const out = runCliJson(["inspect", runId], { cwd, name: `inspect ${runId}` });
   return out.json;
+}
+
+async function verifyNativeSessionRoutes() {
+  if (layout.mode !== "existing_default") return;
+  const requiredHarnesses = requestedHarnesses.filter((h) => h === "codex" || h === "claude");
+  const observed = [];
+  let jobs;
+  try {
+    jobs = await runtimeState.daemonClient.list();
+  } catch (error) {
+    fail("acceptance", "complete battery run inventory", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  const batteryJobs = jobs.filter((job) => !runtimeState.baselineJobIds.has(job.id));
+  const inventoryErrors = [];
+  const seenRunDirs = new Set();
+  for (const job of batteryJobs) {
+    if (typeof job.runDir !== "string") continue;
+    if (seenRunDirs.has(job.runDir)) continue;
+    seenRunDirs.add(job.runDir);
+    const telemetry = new ArtifactStore(root).readYaml(join(job.runDir, "final", "telemetry.yaml"));
+    if (!telemetry || !Array.isArray(telemetry.attempts)) {
+      inventoryErrors.push({
+        jobId: job.id,
+        runId: job.runId ?? null,
+        reason: "telemetry_missing",
+      });
+      continue;
+    }
+    for (const attempt of telemetry.attempts) {
+      if (!requiredHarnesses.includes(attempt.harness_id)) continue;
+      const base = {
+        jobId: job.id,
+        runId: job.runId ?? null,
+        attemptId: attempt.attempt_id,
+        harnessId: attempt.harness_id,
+      };
+      if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(attempt.attempt_id ?? "")) {
+        observed.push({ ...base, kind: "invalid_attempt_id", authMode: null, authSource: null });
+        continue;
+      }
+      const eventsPath = join(job.runDir, "attempts", attempt.attempt_id, "events.jsonl");
+      let events;
+      try {
+        events = readFileSync(eventsPath, "utf8")
+          .split("\n")
+          .filter((line) => line.trim().length > 0)
+          .map((line) => JSON.parse(line));
+      } catch {
+        observed.push({
+          ...base,
+          kind: "events_missing_or_malformed",
+          authMode: null,
+          authSource: null,
+        });
+        continue;
+      }
+      const durable = durableAttemptRouteEvidence(events);
+      for (const route of durable.observed) observed.push({ ...base, ...route });
+      if (!durable.sawStarted) {
+        observed.push({ ...base, kind: "started_route_missing", authMode: null, authSource: null });
+      }
+    }
+  }
+  const routeResult = evaluateRequiredNativeRoutes(requiredHarnesses, observed);
+  const valid = routeResult.valid && inventoryErrors.length === 0;
+  (valid ? pass : fail)("acceptance", "Codex and Claude routes stayed vendor-native", {
+    batteryJobs: batteryJobs.length,
+    observed,
+    inventoryErrors,
+    missing: routeResult.missing,
+    nonNative: routeResult.nonNative,
+  });
 }
 
 async function controlRunDetail(runId) {
@@ -567,14 +848,6 @@ function runNeedsDecision(ev) {
 function patchLooksReal(ev) {
   const diffstat = ev?.wp?.meta?.diffstat;
   return ev?.patchNonEmpty && (diffstat?.files ?? 0) > 0;
-}
-
-function setGlobalConfig(yaml) {
-  writeFileSync(join(configDir, "config.yaml"), yaml);
-}
-
-function clearGlobalConfig() {
-  rmSync(join(configDir, "config.yaml"), { force: true });
 }
 
 // Tiny PNG encoder with a 5x7 bitmap font for the marker image.
@@ -1019,109 +1292,104 @@ function runMultiWritePhase() {
         log: rel(out.log),
       });
   }
-  runDegradationControl(phase, multi[0]);
+  const singleFamilyReviewer = multi.find((h) => harnessIntent(h, "review"));
+  if (singleFamilyReviewer) runDegradationControl(phase, singleFamilyReviewer);
+  else fail(phase, "single-family degradation control", { reason: "no doctor-ok reviewer" });
 }
 
 function runDegradationControl(phase, onlyHarness) {
-  const disabled = requestedHarnesses.filter((h) => h !== onlyHarness);
-  setGlobalConfig(
+  // An explicit same-family panel proves the degradation contract without
+  // rewriting user-global harness settings. This keeps the existing-session
+  // VM lane read-only with respect to config.yaml.
+  const reviewerPanel = ["--reviewer-panel", onlyHarness];
+  const repo = makeMathRepo(`${phase}-single-family-control`, { addBug: true });
+  const out = runCliJson(
     [
-      "version: 1",
-      "harnesses:",
-      ...disabled.flatMap((h) => [`  ${h}:`, "    enabled: false"]),
-      "",
-    ].join("\n"),
+      "best-of",
+      "Fix add(a,b) in src/math.js so tests pass. Do not change tests.",
+      "--harness",
+      onlyHarness,
+      "--n",
+      "1",
+      ...reviewerPanel,
+      "--test",
+      testCmd(),
+      "--effort",
+      "low",
+      "--max-usd",
+      maxUsd,
+    ],
+    { cwd: repo, name: `${phase}-single-family-control` },
   );
-  try {
-    const repo = makeMathRepo(`${phase}-single-family-control`, { addBug: true });
-    const out = runCliJson(
-      [
-        "best-of",
-        "Fix add(a,b) in src/math.js so tests pass. Do not change tests.",
-        "--harness",
-        onlyHarness,
-        "--n",
-        "1",
-        "--test",
-        testCmd(),
-        "--effort",
-        "low",
-        "--max-usd",
-        maxUsd,
-      ],
-      { cwd: repo, name: `${phase}-single-family-control` },
-    );
-    const ev = recordRunEvidence(phase, "single-family control", out, repo);
-    if (ev?.decision) {
-      const basis = ev.decision.verification_basis ?? "unknown";
-      const rec = basis === "none" ? pass : fail;
-      rec(phase, "single-family verification_basis=none", {
-        runId: out.json?.runId,
-        status: out.json?.status,
-        facts: ev.decision.facts,
-        basis,
-      });
-      const apply = runCliJson(["apply", out.json.runId, "--dry-run"], {
-        cwd: repo,
-        name: `${phase}-single-family-apply-refusal`,
-      });
-      if (
-        ev.detail?.runFacts?.apply?.eligibility?.eligible === false &&
-        ev.detail?.runFacts?.apply?.eligibility?.state === "not_verified" &&
-        apply.code !== 0 &&
-        apply.json?.runId === out.json.runId &&
-        apply.json?.dryRun === true &&
-        apply.json?.code === "invalid_request"
-      )
-        pass(phase, "single-family apply refused", { runId: out.json.runId });
-      else
-        fail(phase, "single-family apply refused", {
-          exit: apply.code,
-          stdout: apply.stdout,
-          stderr: apply.stderr,
-          log: rel(apply.log),
-        });
-    } else {
-      fail(phase, "single-family control decision", {
-        status: out.json?.status,
-        error: out.json?.error,
-        log: rel(out.log),
-      });
-    }
-    const convRepo = makeMathRepo(`${phase}-single-family-convergence`, { addBug: true });
-    const conv = runCliJson(
-      [
-        "agent",
-        "Fix add(a,b) in src/math.js so tests pass. Do not change tests.",
-        "--harness",
-        onlyHarness,
-        "--until-clean",
-        "--test",
-        testCmd(),
-        "--effort",
-        "low",
-        "--max-usd",
-        maxUsd,
-      ],
-      { cwd: convRepo, name: `${phase}-single-family-convergence` },
-    );
+  const ev = recordRunEvidence(phase, "single-family control", out, repo);
+  if (ev?.decision) {
+    const basis = ev.decision.verification_basis ?? "unknown";
+    const rec = basis === "none" ? pass : fail;
+    rec(phase, "single-family verification_basis=none", {
+      runId: out.json?.runId,
+      status: out.json?.status,
+      facts: ev.decision.facts,
+      basis,
+    });
+    const apply = runCliJson(["apply", out.json.runId, "--dry-run"], {
+      cwd: repo,
+      name: `${phase}-single-family-apply-refusal`,
+    });
     if (
-      conv.code !== 0 &&
-      /cross-family|review/.test(JSON.stringify(conv.json ?? {}) + conv.stdout + conv.stderr)
+      ev.detail?.runFacts?.apply?.eligibility?.eligible === false &&
+      ev.detail?.runFacts?.apply?.eligibility?.state === "not_verified" &&
+      apply.code !== 0 &&
+      apply.json?.runId === out.json.runId &&
+      apply.json?.dryRun === true &&
+      apply.json?.code === "invalid_request"
     )
-      pass(phase, "single-family convergence refused", {
-        status: conv.json?.status,
-        error: conv.json?.error ?? conv.json?.summary,
-      });
+      pass(phase, "single-family apply refused", { runId: out.json.runId });
     else
-      fail(phase, "single-family convergence refused", {
-        exit: conv.code,
-        json: conv.json,
-        log: rel(conv.log),
+      fail(phase, "single-family apply refused", {
+        exit: apply.code,
+        stdout: apply.stdout,
+        stderr: apply.stderr,
+        log: rel(apply.log),
       });
-  } finally {
-    clearGlobalConfig();
+  } else {
+    fail(phase, "single-family control decision", {
+      status: out.json?.status,
+      error: out.json?.error,
+      log: rel(out.log),
+    });
   }
+  const convRepo = makeMathRepo(`${phase}-single-family-convergence`, { addBug: true });
+  const conv = runCliJson(
+    [
+      "agent",
+      "Fix add(a,b) in src/math.js so tests pass. Do not change tests.",
+      "--harness",
+      onlyHarness,
+      "--until-clean",
+      ...reviewerPanel,
+      "--test",
+      testCmd(),
+      "--effort",
+      "low",
+      "--max-usd",
+      maxUsd,
+    ],
+    { cwd: convRepo, name: `${phase}-single-family-convergence` },
+  );
+  if (
+    conv.code !== 0 &&
+    /cross-family|review/.test(JSON.stringify(conv.json ?? {}) + conv.stdout + conv.stderr)
+  )
+    pass(phase, "single-family convergence refused", {
+      status: conv.json?.status,
+      error: conv.json?.error ?? conv.json?.summary,
+    });
+  else
+    fail(phase, "single-family convergence refused", {
+      exit: conv.code,
+      json: conv.json,
+      log: rel(conv.log),
+    });
 }
 
 function chooseVerifiedRun() {
@@ -1862,78 +2130,93 @@ async function runDelegationPhase() {
   for (const h of candidates) {
     const repo = makeMathRepo(`${phase}-${h}-delegate`, { addBug: true });
     const accessArgs = [];
-    if (h === "codex") {
-      const trust = runCliJson(["trust", "--allow-full-access"], {
-        cwd: repo,
-        name: `${phase}-${h}-delegate-trust`,
-      });
-      if (trust.code !== 0) {
-        fail(phase, `${h} Delegate disposable full-access grant`, {
-          exit: trust.code,
-          log: rel(trust.log),
+    let fullAccessGranted = false;
+    try {
+      if (h === "codex") {
+        const trust = runCliJson(["trust", "--allow-full-access"], {
+          cwd: repo,
+          name: `${phase}-${h}-delegate-trust`,
         });
-        continue;
+        if (trust.code !== 0) {
+          fail(phase, `${h} Delegate disposable full-access grant`, {
+            exit: trust.code,
+            log: rel(trust.log),
+          });
+          continue;
+        }
+        fullAccessGranted = true;
+        accessArgs.push("--access", "full");
       }
-      accessArgs.push("--access", "full");
+      const out = runCliJson(
+        [
+          "agent",
+          "First use exactly one claudexor_ask belt tool to locate where add is defined in the original project. Do not ask the child to inspect your private candidate workspace or run tests. Then fix add locally; the configured gate will verify it.",
+          "--delegate",
+          "--harness",
+          h,
+          ...accessArgs,
+          "--test",
+          testCmd(),
+          "--effort",
+          "low",
+          "--max-usd",
+          maxUsd,
+        ],
+        { cwd: repo, name: `${phase}-${h}-delegate` },
+      );
+      const projected = out.json?.runId
+        ? await controlRunDetail(out.json.runId)
+        : { detail: null, error: "run id missing" };
+      const delegation = projected.detail?.summary?.delegation;
+      const children = projected.detail?.children ?? [];
+      const child = children.find(
+        (item) =>
+          item.delegatedFromRunId === out.json?.runId &&
+          item.mode === "ask" &&
+          item.state === "succeeded",
+      );
+      if (
+        out.code === 0 &&
+        out.json?.status === "succeeded" &&
+        delegation?.requested === true &&
+        delegation?.effective === true &&
+        delegation?.used === true &&
+        projected.detail?.runFacts?.outcome?.checks === "passed" &&
+        projected.detail?.summary?.result?.kind === "patch" &&
+        children.length === 1 &&
+        child
+      )
+        pass(phase, `${h} agent --delegate`, {
+          runId: out.json.runId,
+          childRunId: child.runId,
+          delegation,
+        });
+      else
+        fail(phase, `${h} agent --delegate`, {
+          exit: out.code,
+          status: out.json?.status,
+          delegation,
+          projectionError: projected.error,
+          children: children.map((item) => ({
+            runId: item.runId,
+            state: item.state,
+            mode: item.mode,
+            delegatedFromRunId: item.delegatedFromRunId,
+          })),
+          log: rel(out.log),
+        });
+    } finally {
+      if (fullAccessGranted) {
+        const revoke = runCliJson(["trust", "--revoke-full-access"], {
+          cwd: repo,
+          name: `${phase}-${h}-delegate-trust-revoke`,
+        });
+        (revoke.code === 0 ? pass : fail)(phase, `${h} Delegate full-access grant revoked`, {
+          exit: revoke.code,
+          log: rel(revoke.log),
+        });
+      }
     }
-    const out = runCliJson(
-      [
-        "agent",
-        "First use exactly one claudexor_ask belt tool to locate where add is defined in the original project. Do not ask the child to inspect your private candidate workspace or run tests. Then fix add locally; the configured gate will verify it.",
-        "--delegate",
-        "--harness",
-        h,
-        ...accessArgs,
-        "--test",
-        testCmd(),
-        "--effort",
-        "low",
-        "--max-usd",
-        maxUsd,
-      ],
-      { cwd: repo, name: `${phase}-${h}-delegate` },
-    );
-    const projected = out.json?.runId
-      ? await controlRunDetail(out.json.runId)
-      : { detail: null, error: "run id missing" };
-    const delegation = projected.detail?.summary?.delegation;
-    const children = projected.detail?.children ?? [];
-    const child = children.find(
-      (item) =>
-        item.delegatedFromRunId === out.json?.runId &&
-        item.mode === "ask" &&
-        item.state === "succeeded",
-    );
-    if (
-      out.code === 0 &&
-      out.json?.status === "succeeded" &&
-      delegation?.requested === true &&
-      delegation?.effective === true &&
-      delegation?.used === true &&
-      projected.detail?.runFacts?.outcome?.checks === "passed" &&
-      projected.detail?.summary?.result?.kind === "patch" &&
-      children.length === 1 &&
-      child
-    )
-      pass(phase, `${h} agent --delegate`, {
-        runId: out.json.runId,
-        childRunId: child.runId,
-        delegation,
-      });
-    else
-      fail(phase, `${h} agent --delegate`, {
-        exit: out.code,
-        status: out.json?.status,
-        delegation,
-        projectionError: projected.error,
-        children: children.map((item) => ({
-          runId: item.runId,
-          state: item.state,
-          mode: item.mode,
-          delegatedFromRunId: item.delegatedFromRunId,
-        })),
-        log: rel(out.log),
-      });
   }
   if (candidates.length === 0)
     skip(phase, "agent --delegate", { reason: "need a doctor-ok claude/codex harness" });
@@ -2344,34 +2627,79 @@ const repos = {
 const state = { verifiedRuns: [], multiRace: null };
 
 async function main() {
+  evidence.candidate.sha = runGit(["rev-parse", "HEAD"], root);
+  evidence.candidate.tree = runGit(["rev-parse", "HEAD^{tree}"], root);
   process.stdout.write(
-    `Claudexor real-harness battery\nroot=${batteryRoot}\nconfig=${configDir}\nharnesses=${requestedHarnesses.join(",")}\nmaxUsd=${maxUsd}\n\n`,
+    `Claudexor real-harness battery\nroot=${batteryRoot}\nconfig=${configDir}\nconfigMode=${layout.mode}\ncandidate=${evidence.candidate.sha}\nharnesses=${requestedHarnesses.join(",")}\nmaxUsd=${maxUsd}\n\n`,
   );
   // Phase 12 (plugin lifecycle in a scratch HOME) needs NO real harness —
   // the readiness gate applies only to harness-dependent phases.
   const harnessPhasesRequested =
     phaseFilter.length === 0 || phaseFilter.some((p) => p !== "phase12");
-  const ready = phase0(harnessPhasesRequested);
-  if (!ready && harnessPhasesRequested) {
-    fail("phase0", "readiness gate", {
-      reason: "no requested harness is doctor-ok; harness-dependent phases cannot proceed",
+  try {
+    if (layout.mode === "existing_default" && phaseFilter.length > 0) {
+      throw new Error("an existing-default acceptance run cannot use CLAUDEXOR_BATTERY_PHASES");
+    }
+    if (layout.mode === "existing_default" && !buildVerified) {
+      throw new Error("existing-default acceptance must run through pnpm battery:real");
+    }
+    if (
+      layout.mode === "existing_default" &&
+      ["codex", "claude", "cursor"].some((harness) => !requestedHarnesses.includes(harness))
+    ) {
+      throw new Error(
+        "existing-default acceptance requires codex, claude, and cursor in CLAUDEXOR_BATTERY_HARNESSES",
+      );
+    }
+    if (
+      layout.mode === "existing_default" &&
+      runGit(["status", "--porcelain=v1", "--untracked-files=all"], root) !== ""
+    ) {
+      throw new Error("existing-default acceptance requires a clean exact-candidate checkout");
+    }
+    await startBatteryDaemon();
+    const ready = phase0(harnessPhasesRequested);
+    if (!ready && harnessPhasesRequested) {
+      fail("phase0", "readiness gate", {
+        reason: "no requested harness is doctor-ok; harness-dependent phases cannot proceed",
+      });
+    }
+    if (ready) {
+      if (phaseEnabled("phase1")) await runReadonlyPhase();
+      if (phaseEnabled("phase2")) runWritePhase();
+      if (phaseEnabled("phase3")) runMultiWritePhase();
+      if (phaseEnabled("phase4")) runLifecyclePhase();
+      if (phaseEnabled("phase5")) runCreatePhase();
+      if (phaseEnabled("phase6")) runVisionPhase();
+      if (phaseEnabled("phase7")) runWebPhase();
+      if (phaseEnabled("phase8")) await runPlanPhase();
+      if (phaseEnabled("phase9")) await runDelegationPhase();
+      if (phaseEnabled("phase10")) await runMcpServePhase();
+      if (phaseEnabled("phase11")) await runAcpServePhase();
+    }
+    if (phaseEnabled("phase12")) runPluginLifecyclePhase();
+  } catch (error) {
+    fail("fatal", "unhandled error", {
+      error: error instanceof Error ? (error.stack ?? error.message) : String(error),
     });
+  } finally {
+    try {
+      if (runtimeState.daemonOwned) await verifyNativeSessionRoutes();
+    } catch (error) {
+      fail("acceptance", "native-route verification completed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    try {
+      await stopBatteryDaemon();
+    } catch (error) {
+      fail("cleanup", "battery-owned daemon cleanup completed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      verifyProtectedConfig();
+    }
   }
-  if (ready) {
-    if (phaseEnabled("phase1")) await runReadonlyPhase();
-    if (phaseEnabled("phase2")) runWritePhase();
-    if (phaseEnabled("phase3")) runMultiWritePhase();
-    if (phaseEnabled("phase4")) runLifecyclePhase();
-    if (phaseEnabled("phase5")) runCreatePhase();
-    if (phaseEnabled("phase6")) runVisionPhase();
-    if (phaseEnabled("phase7")) runWebPhase();
-    if (phaseEnabled("phase8")) await runPlanPhase();
-    if (phaseEnabled("phase9")) await runDelegationPhase();
-    if (phaseEnabled("phase10")) await runMcpServePhase();
-    if (phaseEnabled("phase11")) await runAcpServePhase();
-  }
-  if (phaseEnabled("phase12")) runPluginLifecyclePhase();
-  runCliText(["daemon", "stop"], { name: "daemon-stop" });
   const summary = {
     generatedAt: new Date().toISOString(),
     evidence,
@@ -2391,6 +2719,8 @@ async function main() {
     `- root: \`${batteryRoot}\``,
     `- cli: \`${cli}\``,
     `- version: \`${evidence.version ?? "unknown"}\``,
+    `- candidate: \`${evidence.candidate.sha ?? "unknown"}\``,
+    `- config mode: \`${layout.mode}\``,
     `- requested harnesses: ${requestedHarnesses.join(", ")}`,
     `- doctor-ok harnesses: ${evidence.okHarnesses.join(", ") || "(none)"}`,
     `- counts: PASS=${summary.counts.pass} FAIL=${summary.counts.fail} ENV=${summary.counts.env} SKIP=${summary.counts.skip}`,
@@ -2408,12 +2738,15 @@ async function main() {
   process.stdout.write(
     `\nRESULT PASS=${summary.counts.pass} FAIL=${summary.counts.fail} ENV=${summary.counts.env} SKIP=${summary.counts.skip}\nreport=${jsonPath}\nsummary=${mdPath}\n`,
   );
-  process.exit(summary.counts.fail > 0 ? 1 : 0);
+  const strictFailure =
+    layout.mode === "existing_default" &&
+    (summary.counts.env > 0 || summary.counts.skip > 0 || evidence.configUnchanged !== true);
+  process.exitCode = summary.counts.fail > 0 || strictFailure ? 1 : 0;
 }
 
 main().catch((err) => {
-  fail("fatal", "unhandled error", {
-    error: err instanceof Error ? (err.stack ?? err.message) : String(err),
-  });
-  process.exit(1);
+  process.stderr.write(
+    `${redactSecrets(err instanceof Error ? (err.stack ?? err.message) : String(err))}\n`,
+  );
+  process.exitCode = 1;
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,11 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["packages/*/src/**/*.test.ts", "benchmarks/runner/src/**/*.test.ts"],
+    include: [
+      "packages/*/src/**/*.test.ts",
+      "benchmarks/runner/src/**/*.test.ts",
+      "scripts/lib/**/*.test.mjs",
+    ],
     environment: "node",
     passWithNoTests: true,
     clearMocks: true,


### PR DESCRIPTION
During the real-harness battery, a pre-start API fallback disclosure was counted as a billable interval before the actual started event. That made an exact usage receipt fail as cost_unverifiable under a finite cap.

This keeps pre-start disclosure as routing context, starts accounting only on real attempts, and strengthens the battery so it can safely exercise the default VM profile without modifying its config or accepting API fallbacks. Daemon cleanup is bound to the observed process identity, and the battery forces an exact-candidate build.

Refs #94