### PR TITLE
Dev hygiene: Spotlight-shielded app bundle, dev-build chip suppression, gc data-root advisory

### DIFF
--- a/.changeset/gc-data-root-report-noindex-bundle.md
+++ b/.changeset/gc-data-root-report-noindex-bundle.md
@@ -1,0 +1,5 @@
+---
+"claudexor": patch
+---
+
+The `claudexor gc` receipt now discloses non-engine top-level entries in the Claudexor data root (advisory only — named, sorted, bounded, never deleted; the field is absent when the scan fails or the daemon predates it), and the packaged macOS app bundle plus the dmg-stage move under `apps/macos/dist/bundle.noindex/` so Spotlight never indexes dev-built bundles as launchable apps — DMG/ZIP artifacts and checksums stay in `apps/macos/dist/`.

--- a/.changeset/gc-data-root-report-noindex-bundle.md
+++ b/.changeset/gc-data-root-report-noindex-bundle.md
@@ -2,4 +2,4 @@
 "claudexor": patch
 ---
 
-The `claudexor gc` receipt now discloses non-engine top-level entries in the Claudexor data root (advisory only — named, sorted, bounded, never deleted; the field is absent when the scan fails or the daemon predates it), and the packaged macOS app bundle plus the dmg-stage move under `apps/macos/dist/bundle.noindex/` so Spotlight never indexes dev-built bundles as launchable apps — DMG/ZIP artifacts and checksums stay in `apps/macos/dist/`.
+The `claudexor gc` receipt now discloses non-engine top-level entries in the Claudexor data root (advisory only — the full sorted list, never deleted; opt-in via the `data_root_report` request flag, which the CLI sends only to a lockstep same-version daemon, so the field is absent under any version skew, when the scan fails, or when the daemon predates it), and the packaged macOS app bundle plus the dmg-stage move under `apps/macos/dist/bundle.noindex/` so Spotlight never indexes dev-built bundles as launchable apps — DMG/ZIP artifacts and checksums stay in `apps/macos/dist/`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,7 +229,7 @@ jobs:
           PREPARED_SHA: ${{ needs.prepare.outputs.sha }}
         run: |
           set -euo pipefail
-          app="apps/macos/dist/Claudexor.app"
+          app="apps/macos/dist/bundle.noindex/Claudexor.app"
           dmg="apps/macos/dist/Claudexor-$VERSION.dmg"
           zip="apps/macos/dist/Claudexor-$VERSION.zip"
           for file in "$dmg" "$dmg.sha256" "$zip" "$zip.sha256"; do
@@ -403,7 +403,7 @@ jobs:
             # Candidate builds straight from the signed+verified app bundle, so the
             # update unit is byte-identical to the closure the gates smoke-tested.
             node scripts/build-runtime-closure.mjs \
-              --app-bundle apps/macos/dist/Claudexor.app \
+              --app-bundle apps/macos/dist/bundle.noindex/Claudexor.app \
               --version "$VERSION" \
               --out "$closure"
           fi
@@ -430,7 +430,7 @@ jobs:
             cp candidate-assets/remote-runtime-manifest.json "$remote/"
           else
             node_version="$(cat .node-version)"
-            resources="apps/macos/dist/Claudexor.app/Contents/Resources"
+            resources="apps/macos/dist/bundle.noindex/Claudexor.app/Contents/Resources"
             for target in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
               archive="$RUNNER_TEMP/node-v$node_version-$target.tar.gz"
               curl --fail --location --proto '=https' --tlsv1.2 \
@@ -497,7 +497,7 @@ jobs:
             cp "apps/macos/dist/Claudexor-$VERSION.zip" "$assets/"
             GITHUB_SHA="$PREPARED_SHA" pnpm licenses list --prod --json | \
               GITHUB_SHA="$PREPARED_SHA" node scripts/generate-release-sbom.mjs \
-              --app-bundle apps/macos/dist/Claudexor.app \
+              --app-bundle apps/macos/dist/bundle.noindex/Claudexor.app \
               > "$assets/Claudexor-$VERSION.spdx.json"
           fi
           cp "$RUNNER_TEMP/runtime-closure/claudexor-runtime-$VERSION.tar.gz" "$assets/"

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+RuntimeUpdate.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+RuntimeUpdate.swift
@@ -12,6 +12,15 @@ extension AppModel {
         (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "dev"
     }
 
+    /// The honest status a dev build shows where the update chip would appear.
+    static let devBuildUpdateStatus = "Dev build — update check not applicable"
+
+    /// The APP version the update flow reasons about (test seam; production
+    /// reads the bundle).
+    var updateFlowAppVersion: String {
+        appVersionOverrideForUpdates ?? Self.appVersionString()
+    }
+
     var engineVersionDisplay: String { engineIdentity?.version ?? "unknown" }
 
     var engineShaDisplay: String {
@@ -29,6 +38,18 @@ extension AppModel {
             guard !didAutoCheckRuntime else { return }
         }
         didAutoCheckRuntime = true
+        let app = updateFlowAppVersion
+        // Display-only dev suppression (Р16/F9): a source-built dev app and the
+        // installed packaged app both recompute the running-engine fallback from
+        // the SHARED ~/.claudexor/runtime/current.json, so an AUTOMATIC check in
+        // a dev build would present the installed app's update decision. The dev
+        // app therefore never runs the automatic check and presents no chip —
+        // only the honest dev status line. Manual Check for Updates (force) and
+        // packaged behavior are unchanged.
+        if !force, app == "dev" {
+            runtimeUpdateStatus = Self.devBuildUpdateStatus
+            return
+        }
         if runtimeUpdateChecking { return }
         runtimeUpdateChecking = true
         defer { runtimeUpdateChecking = false }
@@ -37,7 +58,6 @@ extension AppModel {
             ?? RuntimeUpdater(transport: makeRuntimeTransport())
         runtimeUpdater = updater
         let running = resolvedRunningEngineVersion()
-        let app = Self.appVersionString()
         do {
             let outcome = try await updater.check(
                 runningEngineVersion: running, appVersion: app)
@@ -70,9 +90,11 @@ extension AppModel {
                 "App update required — install the latest app "
                 + "(needs v\(minAppVersion) or newer), then re-check."
         case let .unknown(reason):
+            // Keyed on the APP being a dev build (it always is when the
+            // resolved running version degrades to appVersionString()'s "dev").
             runtimeUpdateStatus =
-                resolvedRunningEngineVersion() == "dev"
-                ? "Dev build — update check not applicable"
+                updateFlowAppVersion == "dev"
+                ? Self.devBuildUpdateStatus
                 : "Update status unknown: \(reason)"
         }
     }

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+RuntimeUpdate.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+RuntimeUpdate.swift
@@ -90,10 +90,8 @@ extension AppModel {
                 "App update required — install the latest app "
                 + "(needs v\(minAppVersion) or newer), then re-check."
         case let .unknown(reason):
-            // Keyed on the APP being a dev build (it always is when the
-            // resolved running version degrades to appVersionString()'s "dev").
             runtimeUpdateStatus =
-                updateFlowAppVersion == "dev"
+                resolvedRunningEngineVersion() == "dev"
                 ? Self.devBuildUpdateStatus
                 : "Update status unknown: \(reason)"
         }

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel.swift
@@ -216,6 +216,11 @@ final class AppModel {
     @ObservationIgnored var runtimeUpdater: RuntimeUpdater?
     @ObservationIgnored var makeRuntimeTransport: @Sendable () -> RuntimeReleaseTransport = { GitHubRuntimeReleaseTransport() }
     @ObservationIgnored var didAutoCheckRuntime = false
+    /// Test seam for the APP version the update flow reasons about (the dev-build
+    /// chip suppression keys on it). Production always reads the bundle version;
+    /// tests inject a packaged/dev value so they never depend on the test
+    /// runner's bundle identity.
+    @ObservationIgnored var appVersionOverrideForUpdates: String?
     /// Optimistic auto-balance toggle value while the settings save round-trips
     /// (owner dogfood: the switch must flip INSTANTLY, not after the daemon
     /// replies). Cleared when the save settles; a failed save snaps back.

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/RuntimeUpdaterTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/RuntimeUpdaterTests.swift
@@ -138,6 +138,72 @@ private final class StubTransport: RuntimeReleaseTransport, @unchecked Sendable 
         #expect(model.updateAvailability?.version == "3.4.0")
     }
 
+    // MARK: - Dev-build chip suppression (Р16/F9, display-only)
+
+    /// A source-built dev app (app version "dev") must not PRESENT an automatic
+    /// update chip: both the dev binary and the installed packaged app recompute
+    /// the running-engine fallback from the shared runtime pointer, so the auto
+    /// check would advertise the installed app's decision. The dev app skips the
+    /// automatic check entirely (no fetch), shows the honest dev status, and
+    /// stores no availability.
+    @MainActor
+    @Test func devAppAutoCheckPresentsNoChipAndDoesNotFetch() async throws {
+        let transport = StubTransport()
+        let model = AppModel(requestNotificationAuthorization: false)
+        model.appVersionOverrideForUpdates = "dev"
+        model.engineIdentity = EngineBuildIdentity(version: "3.1.0", sha: "deadbee", entry: "/x")
+        model.runtimeUpdater = RuntimeUpdater(transport: transport, authority: try testAuthority())
+
+        await model.checkForRuntimeUpdate(force: false)
+
+        #expect(model.updateAvailability == nil)
+        #expect(model.runtimeUpdateStatus == "Dev build — update check not applicable")
+        // The automatic check never ran: no release fetch was attempted.
+        #expect(transport.receivedETags.isEmpty)
+    }
+
+    /// A PACKAGED app version keeps the existing automatic behavior byte-for-byte:
+    /// the auto check runs and the available chip is presented.
+    @MainActor
+    @Test func packagedAppAutoCheckStillPresentsTheAvailableChip() async throws {
+        let transport = StubTransport()
+        let manifestURL = "https://example/runtime-manifest.json"
+        let releaseJSON = #"{"assets":[{"name":"runtime-manifest.json","browser_download_url":"\#(manifestURL)"}]}"#
+        transport.assetData[manifestURL] = try signedManifestData()  // signed vector, 3.4.0
+        transport.queuedFetches = [ReleaseFetchResult(status: 200, etag: "\"e\"", data: Data(releaseJSON.utf8))]
+
+        let model = AppModel(requestNotificationAuthorization: false)
+        model.appVersionOverrideForUpdates = "3.3.0"  // packaged, satisfies minAppVersion 2.1.0
+        model.engineIdentity = EngineBuildIdentity(version: "3.1.0", sha: "deadbee", entry: "/x")
+        model.runtimeUpdater = RuntimeUpdater(transport: transport, authority: try testAuthority())
+
+        await model.checkForRuntimeUpdate(force: false)
+
+        #expect(model.updateAvailability?.version == "3.4.0")
+        #expect(model.runtimeUpdateStatus == "Update available: v3.4.0")
+    }
+
+    /// The MANUAL Check for Updates (force) still works in a dev build and shows
+    /// its real result — suppression is automatic-path-only.
+    @MainActor
+    @Test func devAppManualForceCheckStillRunsAndShowsItsResult() async throws {
+        let transport = StubTransport()
+        let manifestURL = "https://example/runtime-manifest.json"
+        let releaseJSON = #"{"assets":[{"name":"runtime-manifest.json","browser_download_url":"\#(manifestURL)"}]}"#
+        transport.assetData[manifestURL] = try signedManifestData()
+        transport.queuedFetches = [ReleaseFetchResult(status: 200, etag: "\"e\"", data: Data(releaseJSON.utf8))]
+
+        let model = AppModel(requestNotificationAuthorization: false)
+        model.appVersionOverrideForUpdates = "dev"
+        model.engineIdentity = EngineBuildIdentity(version: "3.1.0", sha: "deadbee", entry: "/x")
+        model.runtimeUpdater = RuntimeUpdater(transport: transport, authority: try testAuthority())
+
+        await model.checkForRuntimeUpdate(force: true)
+
+        #expect(model.updateAvailability?.version == "3.4.0")
+        #expect(model.runtimeUpdateStatus == "Update available: v3.4.0")
+    }
+
     /// Fix 3 (post-install truth): after a verified install, recording the
     /// installed version must recompute the cached decision to `.upToDate` AND
     /// clear the stored ETag — otherwise the next check reuses the stale

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -65,6 +65,10 @@ NOTARY_PROFILE="claudexor-notary" MAKE_DMG=1 \
 apps/macos/scripts/build-app.sh
 ```
 
+The assembled `Claudexor.app` bundle lands in `apps/macos/dist/bundle.noindex/`
+(the `.noindex` suffix keeps Spotlight from indexing dev builds as launchable
+apps), while the DMG/ZIP artifacts and their checksums stay directly in
+`apps/macos/dist/`.
 Local builds without signing env produce `Claudexor-<version>-unsigned.zip`
 and `Claudexor-<version>-unsigned.dmg`, with sibling `.sha256` checksum
 files — Gatekeeper blocks those on other Macs (local smoke only). The

--- a/apps/macos/scripts/build-app.sh
+++ b/apps/macos/scripts/build-app.sh
@@ -33,7 +33,11 @@ MACOS_DIR="$(cd "$HERE/.." && pwd)"
 APP_PKG="$MACOS_DIR/ClaudexorApp"
 PACKAGING="$MACOS_DIR/packaging"
 DIST="$MACOS_DIR/dist"
-APP="$DIST/Claudexor.app"
+# The assembled .app (and the transient dmg-stage) live under a .noindex
+# subdirectory so Spotlight never indexes dev-built bundles as launchable
+# apps. Final artifacts (DMG/ZIP/sha256/SBOM) stay directly in $DIST.
+BUNDLES="$DIST/bundle.noindex"
+APP="$BUNDLES/Claudexor.app"
 
 # Version SSOT is the generated CLAUDEXOR_VERSION constant (scripts/gen-version.mjs
 # from the root package.json). Read it so the bundle / DMG version can't silently
@@ -76,6 +80,7 @@ BIN="$APP_PKG/.build/release/ClaudexorApp"
 [ -x "$BIN" ] || { echo "ERROR: release binary not found at $BIN" >&2; exit 1; }
 
 echo "==> Assembling $APP"
+mkdir -p "$BUNDLES"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 cp "$BIN" "$APP/Contents/MacOS/ClaudexorApp"
@@ -505,7 +510,7 @@ if [ "${MAKE_DMG:-0}" = "1" ]; then
     DMG_SUFFIX="-signed-unnotarized"
   fi
   DMG="$DIST/Claudexor-$VERSION$DMG_SUFFIX.dmg"
-  STAGE="$DIST/dmg-stage"
+  STAGE="$BUNDLES/dmg-stage"
   rm -rf "$STAGE" "$DMG"; mkdir -p "$STAGE"
   cp -R "$APP" "$STAGE/"
   ln -s /Applications "$STAGE/Applications"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1356,7 +1356,10 @@ the configured age (`retention.*` in the global config: runs 30d, reviews
 referenced by any non-purged thread's lineage, undelivered/applyable
 patches, and trees with no terminal evidence are protected fail-closed. A
 reclaimed run leaves a tombstone projection behind, so its artifacts answer
-with a typed 410 `run_expired_by_retention` — never a mysterious 404.
+with a typed 410 `run_expired_by_retention` — never a mysterious 404. The
+receipt also carries an advisory `data_root_unrecognized` listing — names of
+top-level data-root entries the engine does not own and never touches
+(absent, with an `errors[]` entry, when that scan fails).
 While running it snapshots its live harness child process groups to
 `daemon/pids.json`; the NEXT startup reaps recorded orphans that survived a
 crash (pid liveness + command-name recycling guard) and sweeps workspace

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -293,13 +293,18 @@ deferred; they are recorded here now.
 
 ## v3.1.0 dogfood finding (2026-07-23)
 
-- Update-provider cache is keyed only by bundle id, so a source-built dev/side
-  build inherits the installed packaged app's cached update-chip decision
-  ("Update available → vX") through the shared `com.claudexor.ClaudexorApp`
-  UserDefaults domain. Harmless for real users (one packaged build per
-  machine) but misleads dev builds. Fix: namespace the update-provider cache
-  by build kind (dev vs packaged) or by resolved engine identity. Non-gating;
-  logged so it is not a silent drop.
+- A source-built dev/side build showed the installed packaged app's
+  update-chip decision ("Update available → vX"). The mechanism originally
+  logged here (an update-provider cache keyed by bundle id through shared
+  UserDefaults) does not exist: the chip decision is in-memory only
+  (`RuntimeUpdateProvider`), and the bare swift-build binary has no bundle id.
+  The real mechanism is convergent recomputation — both builds resolve the
+  running-engine fallback from the SHARED `~/.claudexor/runtime/current.json`
+  pointer, so a dev build recomputes the same "Update available" verdict.
+  RESOLVED (2026-08-08, dev-hygiene fix): a dev app (version "dev") suppresses
+  the automatic chip, display-only, and shows "Dev build — update check not
+  applicable"; the manual Check for Updates and packaged behavior are
+  unchanged.
 
 ## v3.1.0 Ф3/Ф4 review-wave advisories (acceleration directive — deferred)
 

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -19,6 +19,7 @@ import {
   handshakeControlApi,
   processExitCodeForRunStatus,
   type ControlApiAddress,
+  type EngineIdentity,
 } from "./live.js";
 import { TERMINAL_LIFECYCLES, type RunOutcomeFacts, outcomeExitCode } from "@claudexor/schema";
 import {
@@ -43,14 +44,20 @@ async function daemonReachable(client: DaemonClientType): Promise<boolean> {
   }
 }
 
-/** Is the daemon's control-api up and answering /healthz right now? */
-async function controlApiReachable(): Promise<ControlApiAddress | null> {
+/** Is the daemon's control-api up and answering /healthz right now? Returns
+ * the address WITH the handshake's validated engine identity — callers that
+ * need capability negotiation (gc's data_root_report) reuse this one
+ * handshake instead of performing a second. */
+async function controlApiReachable(): Promise<{
+  addr: ControlApiAddress;
+  engine: EngineIdentity;
+} | null> {
   try {
     const addr = controlApiAddress();
     const res = await controlApiFetch(addr, "/healthz", { signal: AbortSignal.timeout(1500) });
     if (!res.ok) return null;
-    await handshakeControlApi(addr);
-    return addr;
+    const engine = await handshakeControlApi(addr);
+    return { addr, engine };
   } catch {
     return null;
   }
@@ -66,7 +73,7 @@ async function controlApiReachable(): Promise<ControlApiAddress | null> {
  */
 export async function ensureDaemon(
   timeoutMs = 30_000,
-): Promise<{ client: DaemonClientType; addr: ControlApiAddress }> {
+): Promise<{ client: DaemonClientType; addr: ControlApiAddress; engine: EngineIdentity }> {
   const token = ensureToken();
   const socketPath = defaultSocketPath();
   let client = new DaemonClient(socketPath, token);
@@ -110,20 +117,20 @@ export async function ensureDaemon(
 
   // The control API (HTTP/SSE viewport over the daemon) is what streams events
   // and resolves the run for apply/decision. Wait for its pointer to be written.
-  let addr = await controlApiReachable();
-  if (!addr) {
+  let reached = await controlApiReachable();
+  if (!reached) {
     const deadline = Date.now() + 10_000;
-    while (Date.now() < deadline && !addr) {
+    while (Date.now() < deadline && !reached) {
       await sleep(150);
-      addr = await controlApiReachable();
+      reached = await controlApiReachable();
     }
   }
-  if (!addr) {
+  if (!reached) {
     throw new Error(
       `daemon is up but its control API is not reachable (no ${daemonDir()}/control-api.json); it may be disabled by CLAUDEXOR_NO_CONTROL_API=1`,
     );
   }
-  return { client, addr };
+  return { client, addr: reached.addr, engine: reached.engine };
 }
 
 /**
@@ -142,9 +149,9 @@ export async function connectDaemonIfRunning(): Promise<{
   if (!token) return null;
   const client = new DaemonClient(defaultSocketPath(), token);
   if (!(await daemonReachable(client))) return null;
-  const addr = await controlApiReachable();
-  if (!addr) return null;
-  return { client, addr };
+  const reached = await controlApiReachable();
+  if (!reached) return null;
+  return { client, addr: reached.addr };
 }
 
 /**

--- a/packages/cli/src/gc-command.test.ts
+++ b/packages/cli/src/gc-command.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CLAUDEXOR_VERSION } from "@claudexor/util";
+
+const mocks = vi.hoisted(() => ({
+  ensureDaemon: vi.fn(),
+  controlApiFetch: vi.fn(),
+}));
+
+// Partial mocks (spread the real module) so the wide ops-commands import graph
+// keeps every other export intact — only the daemon seam is stubbed.
+vi.mock("./daemon-run.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  ensureDaemon: mocks.ensureDaemon,
+}));
+vi.mock("./live.js", async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  controlApiFetch: mocks.controlApiFetch,
+}));
+
+import { parseArgs } from "./args.js";
+import { gcCommand } from "./ops-commands.js";
+
+/** Minimal receipt the pre-feature shape allows: no data_root_unrecognized. */
+const RECEIPT = {
+  schema_version: 1,
+  dry_run: false,
+  started_at: "2026-08-08T00:00:00.000Z",
+  finished_at: "2026-08-08T00:00:01.000Z",
+  policy: { runs_max_age_days: 30, reviews_max_age_days: 14, keep_last_runs_per_project: 1 },
+  examined_runs: 0,
+  deleted_runs: [],
+  kept: {},
+  deleted_reviews: [],
+  freed_bytes: 0,
+  errors: [],
+};
+
+function engine(version: string | null): { engineVersion: string | null; engineBuildSha: null } {
+  return { engineVersion: version, engineBuildSha: null };
+}
+
+function sentBody(): Record<string, unknown> {
+  const init = mocks.controlApiFetch.mock.calls[0]?.[2] as { body?: string } | undefined;
+  expect(init?.body).toBeTypeOf("string");
+  return JSON.parse(init!.body!) as Record<string, unknown>;
+}
+
+describe("gcCommand data_root_report capability negotiation", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mocks.controlApiFetch.mockResolvedValue(
+      new Response(JSON.stringify(RECEIPT), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it("sends data_root_report:true ONLY to a lockstep same-version daemon", async () => {
+    mocks.ensureDaemon.mockResolvedValue({
+      addr: { baseUrl: "http://127.0.0.1:1234", token: "t" },
+      engine: engine(CLAUDEXOR_VERSION),
+    });
+    expect(await gcCommand(parseArgs(["gc", "--dry-run"]), true)).toBe(0);
+    expect(sentBody()).toEqual({ dry_run: true, data_root_report: true });
+  });
+
+  it("omits the flag on engine-version skew (exact 3.3.11 request shape)", async () => {
+    mocks.ensureDaemon.mockResolvedValue({
+      addr: { baseUrl: "http://127.0.0.1:1234", token: "t" },
+      engine: engine("0.0.1"),
+    });
+    expect(await gcCommand(parseArgs(["gc"]), true)).toBe(0);
+    expect(sentBody()).toEqual({ dry_run: false });
+  });
+
+  it("omits the flag when the handshake reported no well-formed engine version", async () => {
+    mocks.ensureDaemon.mockResolvedValue({
+      addr: { baseUrl: "http://127.0.0.1:1234", token: "t" },
+      engine: engine(null),
+    });
+    expect(await gcCommand(parseArgs(["gc"]), true)).toBe(0);
+    expect(sentBody()).toEqual({ dry_run: false });
+  });
+});

--- a/packages/cli/src/mcp-runner.test.ts
+++ b/packages/cli/src/mcp-runner.test.ts
@@ -203,6 +203,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     vi.stubGlobal(
       "fetch",
@@ -306,6 +307,7 @@ describe("mcp daemon body mapping", () => {
       const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
         client: {} as never,
         addr: { baseUrl: "http://x", token: "t" } as never,
+        engine: { engineVersion: null, engineBuildSha: null },
       });
       const runDir = mkdtempSync(join(tmpdir(), "claudexor-mcp-detail-problem-"));
       mkdirSync(join(runDir, "final"));
@@ -357,6 +359,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-done",
@@ -393,6 +396,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     const enqueueSpy = vi
       .spyOn(daemonRun, "enqueueAndAwait")
@@ -420,6 +424,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-best-of",
@@ -452,6 +457,7 @@ describe("mcp daemon body mapping", () => {
     const connection = {
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     };
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue(connection);
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue(connection);
@@ -540,6 +546,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-durable",
@@ -586,6 +593,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-fast-failed",
@@ -629,6 +637,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-child",

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -502,7 +502,7 @@ export async function gcCommand(args: ParsedArgs, json: boolean): Promise<number
   const foreign = receipt.data_root_unrecognized;
   if (foreign && foreign.length > 0) {
     const shown = foreign.slice(0, 10).join(", ");
-    const ellipsis = foreign.length > 10 ? `, … (${foreign.length} listed)` : "";
+    const ellipsis = foreign.length > 10 ? `, … showing 10 of ${foreign.length}` : "";
     print(
       `note: ${foreign.length} non-engine entr${foreign.length === 1 ? "y" : "ies"} in ${claudexorOwnedRoot()}: ${shown}${ellipsis}`,
     );

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -17,6 +17,7 @@ import {
   rotateToken,
 } from "@claudexor/daemon";
 import { atRiskNodeAdvisory, harnessRuntimeEnv } from "@claudexor/core";
+import { claudexorOwnedRoot } from "@claudexor/util";
 import {
   ControlGcReceipt,
   ControlHarnessListResponse,
@@ -496,6 +497,16 @@ export async function gcCommand(args: ParsedArgs, json: boolean): Promise<number
       `(examined ${receipt.examined_runs}; kept active=${receipt.kept.active} recent=${receipt.kept.recent} young=${receipt.kept.young} ` +
       `referenced=${receipt.kept.referenced} actionable=${receipt.kept.actionable} unknown=${receipt.kept.unknown_state})`,
   );
+  // Advisory disclosure of foreign top-level data-root entries (never
+  // deleted; absent on old daemons or a failed scan — errors carry the why).
+  const foreign = receipt.data_root_unrecognized;
+  if (foreign && foreign.length > 0) {
+    const shown = foreign.slice(0, 10).join(", ");
+    const ellipsis = foreign.length > 10 ? `, … (${foreign.length} listed)` : "";
+    print(
+      `note: ${foreign.length} non-engine entr${foreign.length === 1 ? "y" : "ies"} in ${claudexorOwnedRoot()}: ${shown}${ellipsis}`,
+    );
+  }
   for (const error of receipt.errors) print(`warning: ${error}`);
   return 0;
 }

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -17,7 +17,7 @@ import {
   rotateToken,
 } from "@claudexor/daemon";
 import { atRiskNodeAdvisory, harnessRuntimeEnv } from "@claudexor/core";
-import { claudexorOwnedRoot } from "@claudexor/util";
+import { CLAUDEXOR_VERSION, claudexorOwnedRoot } from "@claudexor/util";
 import {
   ControlGcReceipt,
   ControlHarnessListResponse,
@@ -478,11 +478,18 @@ export function isKnownAuthLoginHarness(harness: string): boolean {
 /** Thin client of the daemon-owned retention service (W3.6). */
 export async function gcCommand(args: ParsedArgs, json: boolean): Promise<number> {
   const dryRun = flagBool(args, "dry-run") === true;
-  const { addr } = await ensureDaemon();
+  const { addr, engine } = await ensureDaemon();
+  // Capability negotiation over the handshake's validated engine identity:
+  // request the advisory data-root report ONLY from a lockstep daemon (same
+  // engine version as this CLI). Any skew — older daemon, newer daemon, or a
+  // malformed identity — omits the flag, so both sides exchange the exact
+  // pre-feature request/receipt shapes and a strict old schema never rejects
+  // the receipt of a mutating verb the daemon already executed.
+  const lockstep = engine.engineVersion === CLAUDEXOR_VERSION;
   const response = await controlApiFetch(addr, "/maintenance/gc", {
     method: "POST",
     headers: { Authorization: `Bearer ${addr.token}`, "content-type": "application/json" },
-    body: JSON.stringify({ dry_run: dryRun }),
+    body: JSON.stringify({ dry_run: dryRun, ...(lockstep ? { data_root_report: true } : {}) }),
   });
   if (!response.ok) throw new Error(`gc failed (${response.status}): ${await response.text()}`);
   const receipt = ControlGcReceipt.parse(await response.json());

--- a/packages/cli/src/retention-service.ts
+++ b/packages/cli/src/retention-service.ts
@@ -11,7 +11,7 @@ import type { ControlGcReceipt, ControlGcRequest } from "@claudexor/schema";
 import { ArtifactStore } from "@claudexor/artifact-store";
 import { runRetentionPass, type RetentionProject } from "@claudexor/control-api";
 import { loadConfig } from "@claudexor/config";
-import { noProjectRepoRoot } from "@claudexor/util";
+import { claudexorOwnedRoot, noProjectRepoRoot } from "@claudexor/util";
 import { sweepOrphanLanes } from "@claudexor/workspace";
 import { logLine } from "./daemon-lifecycle.js";
 
@@ -112,7 +112,16 @@ export function createRetentionRunner(deps: RetentionRunnerDeps): RetentionRunne
         keepLastRunsPerProject: retention.keep_last_runs_per_project,
       },
       request,
-      { projects: () => gcProjects, records: () => records, referencedRunIds },
+      {
+        projects: () => gcProjects,
+        records: () => records,
+        referencedRunIds,
+        // Advisory data-root disclosure: the ONE owned-root derivation
+        // (claudexorOwnedRoot covers both the default ~/.claudexor tree and
+        // an explicit CLAUDEXOR_CONFIG_DIR override) is injected here so the
+        // pass itself never reaches for globals.
+        dataRoot: claudexorOwnedRoot(),
+      },
     );
   };
   return (request) => {

--- a/packages/cli/src/retention-service.ts
+++ b/packages/cli/src/retention-service.ts
@@ -11,7 +11,7 @@ import type { ControlGcReceipt, ControlGcRequest } from "@claudexor/schema";
 import { ArtifactStore } from "@claudexor/artifact-store";
 import { runRetentionPass, type RetentionProject } from "@claudexor/control-api";
 import { loadConfig } from "@claudexor/config";
-import { claudexorOwnedRoot, noProjectRepoRoot } from "@claudexor/util";
+import { claudexorOwnedRoot, noProjectRepoRoot, userConfigDir } from "@claudexor/util";
 import { sweepOrphanLanes } from "@claudexor/workspace";
 import { logLine } from "./daemon-lifecycle.js";
 
@@ -119,8 +119,14 @@ export function createRetentionRunner(deps: RetentionRunnerDeps): RetentionRunne
         // Advisory data-root disclosure: the ONE owned-root derivation
         // (claudexorOwnedRoot covers both the default ~/.claudexor tree and
         // an explicit CLAUDEXOR_CONFIG_DIR override) is injected here so the
-        // pass itself never reaches for globals.
+        // pass itself never reaches for globals. The mode rides along:
+        // claudexorOwnedRoot() collapses onto userConfigDir() exactly when a
+        // CLAUDEXOR_CONFIG_DIR override is active (in the default mode the
+        // owned root is ~/.claudexor while the config dir is its v3 subtree),
+        // and the override root owns secrets.json/plugins/quota/workspaces at
+        // its top level where the default root does not.
         dataRoot: claudexorOwnedRoot(),
+        dataRootMode: claudexorOwnedRoot() === userConfigDir() ? "override" : "default",
       },
     );
   };

--- a/packages/control-api/src/retention.test.ts
+++ b/packages/control-api/src/retention.test.ts
@@ -361,6 +361,70 @@ describe("runRetentionPass", () => {
     expect(receipt.errors.join("\n")).toContain("truncated at 1");
   });
 
+  it("reports NON-engine top-level data-root entries by name, never engine-owned ones", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    // Engine-owned (current + legacy) and dotfile entries must NOT be listed.
+    for (const owned of ["v3", "node", "profiles", "runtime", "daemon", "isolated"]) {
+      mkdirSync(join(dataRoot, owned), { recursive: true });
+    }
+    writeFileSync(join(dataRoot, "config.yaml"), "retention: {}\n");
+    writeFileSync(join(dataRoot, ".DS_Store"), "");
+    // Foreign operator debris (dirs and files alike) IS listed, sorted.
+    mkdirSync(join(dataRoot, "reviews"), { recursive: true });
+    mkdirSync(join(dataRoot, "my-scratch"), { recursive: true });
+    writeFileSync(join(dataRoot, "notes.txt"), "n");
+
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true },
+      {
+        ...deps(project),
+        dataRoot,
+      },
+    );
+    expect(receipt.data_root_unrecognized).toEqual(["my-scratch", "notes.txt", "reviews"]);
+    expect(receipt.errors).toEqual([]);
+  });
+
+  it("a clean data root reports an EMPTY list (scanned, nothing foreign)", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    mkdirSync(join(dataRoot, "v3"), { recursive: true });
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true },
+      {
+        ...deps(project),
+        dataRoot,
+      },
+    );
+    expect(receipt.data_root_unrecognized).toEqual([]);
+  });
+
+  it("a failed data-root scan leaves the field ABSENT and discloses the error", async () => {
+    const { project, root } = sandbox();
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true },
+      {
+        ...deps(project),
+        dataRoot: join(root, "does-not-exist"),
+      },
+    );
+    expect(receipt.data_root_unrecognized).toBeUndefined();
+    expect(receipt.errors.join("\n")).toContain("data root scan");
+    // The advisory scan must never fail the pass itself.
+    expect(receipt.dry_run).toBe(true);
+  });
+
+  it("no injected data root means no scan and an absent field", async () => {
+    const { project } = sandbox();
+    const receipt = await runRetentionPass(POLICY, { dry_run: true }, deps(project));
+    expect(receipt.data_root_unrecognized).toBeUndefined();
+    expect(receipt.errors).toEqual([]);
+  });
+
   it("readRunTombstone round-trips what the pass wrote", async () => {
     const { project } = sandbox();
     seedRun(project.runsDir, "run-x");

--- a/packages/control-api/src/retention.test.ts
+++ b/packages/control-api/src/retention.test.ts
@@ -364,13 +364,26 @@ describe("runRetentionPass", () => {
   it("reports NON-engine top-level data-root entries by name, never engine-owned ones", async () => {
     const { project, root } = sandbox();
     const dataRoot = join(root, "data-root");
-    // Engine-owned (current + legacy) and dotfile entries must NOT be listed.
-    for (const owned of ["v3", "node", "profiles", "runtime", "daemon", "isolated"]) {
+    // Engine-owned (current + legacy + explicit-config-dir-root) and dotfile
+    // entries must NOT be listed.
+    for (const owned of [
+      "v3",
+      "node",
+      "profiles",
+      "runtime",
+      "daemon",
+      "plugins",
+      "quota",
+      "workspaces",
+    ]) {
       mkdirSync(join(dataRoot, owned), { recursive: true });
     }
     writeFileSync(join(dataRoot, "config.yaml"), "retention: {}\n");
+    writeFileSync(join(dataRoot, "secrets.json"), "{}\n");
     writeFileSync(join(dataRoot, ".DS_Store"), "");
     // Foreign operator debris (dirs and files alike) IS listed, sorted.
+    // "isolated" is operator scratch, not engine-owned — it is foreign too.
+    mkdirSync(join(dataRoot, "isolated"), { recursive: true });
     mkdirSync(join(dataRoot, "reviews"), { recursive: true });
     mkdirSync(join(dataRoot, "my-scratch"), { recursive: true });
     writeFileSync(join(dataRoot, "notes.txt"), "n");
@@ -383,8 +396,65 @@ describe("runRetentionPass", () => {
         dataRoot,
       },
     );
-    expect(receipt.data_root_unrecognized).toEqual(["my-scratch", "notes.txt", "reviews"]);
+    expect(receipt.data_root_unrecognized).toEqual([
+      "isolated",
+      "my-scratch",
+      "notes.txt",
+      "reviews",
+    ]);
     expect(receipt.errors).toEqual([]);
+  });
+
+  it("reports an owned NAME with the wrong on-disk kind as `<name> (unexpected-kind)`", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    mkdirSync(dataRoot, { recursive: true });
+    // A plain FILE where the engine expects the `v3` directory.
+    writeFileSync(join(dataRoot, "v3"), "not a directory");
+    // A SYMLINK under an owned name (even one pointing at a real directory) —
+    // the scan reads dirents WITHOUT following links and flags it.
+    const target = join(root, "elsewhere");
+    mkdirSync(target, { recursive: true });
+    const { symlinkSync } = await import("node:fs");
+    symlinkSync(target, join(dataRoot, "runtime"));
+    // A healthy owned directory and owned files stay unreported.
+    mkdirSync(join(dataRoot, "node"), { recursive: true });
+    writeFileSync(join(dataRoot, "config.yaml"), "retention: {}\n");
+    writeFileSync(join(dataRoot, "secrets.json"), "{}\n");
+
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true },
+      {
+        ...deps(project),
+        dataRoot,
+      },
+    );
+    expect(receipt.data_root_unrecognized).toEqual([
+      "runtime (unexpected-kind)",
+      "v3 (unexpected-kind)",
+    ]);
+    expect(receipt.errors).toEqual([]);
+  });
+
+  it("the report is the FULL sorted list, never truncated to a bound", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    mkdirSync(dataRoot, { recursive: true });
+    const names = Array.from({ length: 80 }, (_, i) =>
+      `foreign-${String(i).padStart(3, "0")}`,
+    );
+    for (const name of names) mkdirSync(join(dataRoot, name), { recursive: true });
+
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true },
+      {
+        ...deps(project),
+        dataRoot,
+      },
+    );
+    expect(receipt.data_root_unrecognized).toEqual(names);
   });
 
   it("a clean data root reports an EMPTY list (scanned, nothing foreign)", async () => {

--- a/packages/control-api/src/retention.test.ts
+++ b/packages/control-api/src/retention.test.ts
@@ -361,36 +361,32 @@ describe("runRetentionPass", () => {
     expect(receipt.errors.join("\n")).toContain("truncated at 1");
   });
 
-  it("reports NON-engine top-level data-root entries by name, never engine-owned ones", async () => {
+  it("reports NON-engine top-level data-root entries by name, never engine-owned ones (default mode)", async () => {
     const { project, root } = sandbox();
     const dataRoot = join(root, "data-root");
-    // Engine-owned (current + legacy + explicit-config-dir-root) and dotfile
-    // entries must NOT be listed.
-    for (const owned of [
-      "v3",
-      "node",
-      "profiles",
-      "runtime",
-      "daemon",
-      "plugins",
-      "quota",
-      "workspaces",
-    ]) {
+    // Engine-owned (current + legacy) and dotfile entries must NOT be listed.
+    // "remote" is engine-managed (harness-installer's pinned vendor prefix).
+    for (const owned of ["v3", "node", "profiles", "runtime", "daemon", "remote"]) {
       mkdirSync(join(dataRoot, owned), { recursive: true });
     }
     writeFileSync(join(dataRoot, "config.yaml"), "retention: {}\n");
-    writeFileSync(join(dataRoot, "secrets.json"), "{}\n");
     writeFileSync(join(dataRoot, ".DS_Store"), "");
     // Foreign operator debris (dirs and files alike) IS listed, sorted.
     // "isolated" is operator scratch, not engine-owned — it is foreign too.
+    // In the DEFAULT root mode the engine keeps secrets.json, plugins, quota
+    // and workspaces under the v3 subtree, so top-level copies are foreign.
     mkdirSync(join(dataRoot, "isolated"), { recursive: true });
     mkdirSync(join(dataRoot, "reviews"), { recursive: true });
     mkdirSync(join(dataRoot, "my-scratch"), { recursive: true });
     writeFileSync(join(dataRoot, "notes.txt"), "n");
+    mkdirSync(join(dataRoot, "plugins"), { recursive: true });
+    mkdirSync(join(dataRoot, "quota"), { recursive: true });
+    mkdirSync(join(dataRoot, "workspaces"), { recursive: true });
+    writeFileSync(join(dataRoot, "secrets.json"), "{}\n");
 
     const receipt = await runRetentionPass(
       POLICY,
-      { dry_run: true },
+      { dry_run: true, data_root_report: true },
       {
         ...deps(project),
         dataRoot,
@@ -400,8 +396,37 @@ describe("runRetentionPass", () => {
       "isolated",
       "my-scratch",
       "notes.txt",
+      "plugins",
+      "quota",
       "reviews",
+      "secrets.json",
+      "workspaces",
     ]);
+    expect(receipt.errors).toEqual([]);
+  });
+
+  it("override mode ALSO owns secrets.json/plugins/quota/workspaces at the top level", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    // Under an explicit CLAUDEXOR_CONFIG_DIR root the engine writes these
+    // directly at the top level — they are owned, not foreign.
+    for (const owned of ["v3", "plugins", "quota", "workspaces"]) {
+      mkdirSync(join(dataRoot, owned), { recursive: true });
+    }
+    writeFileSync(join(dataRoot, "config.yaml"), "retention: {}\n");
+    writeFileSync(join(dataRoot, "secrets.json"), "{}\n");
+    mkdirSync(join(dataRoot, "my-scratch"), { recursive: true });
+
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true, data_root_report: true },
+      {
+        ...deps(project),
+        dataRoot,
+        dataRootMode: "override",
+      },
+    );
+    expect(receipt.data_root_unrecognized).toEqual(["my-scratch"]);
     expect(receipt.errors).toEqual([]);
   });
 
@@ -417,14 +442,13 @@ describe("runRetentionPass", () => {
     mkdirSync(target, { recursive: true });
     const { symlinkSync } = await import("node:fs");
     symlinkSync(target, join(dataRoot, "runtime"));
-    // A healthy owned directory and owned files stay unreported.
+    // A healthy owned directory and owned file stay unreported.
     mkdirSync(join(dataRoot, "node"), { recursive: true });
     writeFileSync(join(dataRoot, "config.yaml"), "retention: {}\n");
-    writeFileSync(join(dataRoot, "secrets.json"), "{}\n");
 
     const receipt = await runRetentionPass(
       POLICY,
-      { dry_run: true },
+      { dry_run: true, data_root_report: true },
       {
         ...deps(project),
         dataRoot,
@@ -437,18 +461,40 @@ describe("runRetentionPass", () => {
     expect(receipt.errors).toEqual([]);
   });
 
+  it("the kind check is SYMMETRIC: a directory under an owned FILE name is flagged", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    // config.yaml must be a regular file in every mode; secrets.json must be
+    // a regular file in override mode (where the name is owned at all).
+    mkdirSync(join(dataRoot, "config.yaml"), { recursive: true });
+    mkdirSync(join(dataRoot, "secrets.json"), { recursive: true });
+
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true, data_root_report: true },
+      {
+        ...deps(project),
+        dataRoot,
+        dataRootMode: "override",
+      },
+    );
+    expect(receipt.data_root_unrecognized).toEqual([
+      "config.yaml (unexpected-kind)",
+      "secrets.json (unexpected-kind)",
+    ]);
+    expect(receipt.errors).toEqual([]);
+  });
+
   it("the report is the FULL sorted list, never truncated to a bound", async () => {
     const { project, root } = sandbox();
     const dataRoot = join(root, "data-root");
     mkdirSync(dataRoot, { recursive: true });
-    const names = Array.from({ length: 80 }, (_, i) =>
-      `foreign-${String(i).padStart(3, "0")}`,
-    );
+    const names = Array.from({ length: 80 }, (_, i) => `foreign-${String(i).padStart(3, "0")}`);
     for (const name of names) mkdirSync(join(dataRoot, name), { recursive: true });
 
     const receipt = await runRetentionPass(
       POLICY,
-      { dry_run: true },
+      { dry_run: true, data_root_report: true },
       {
         ...deps(project),
         dataRoot,
@@ -463,7 +509,7 @@ describe("runRetentionPass", () => {
     mkdirSync(join(dataRoot, "v3"), { recursive: true });
     const receipt = await runRetentionPass(
       POLICY,
-      { dry_run: true },
+      { dry_run: true, data_root_report: true },
       {
         ...deps(project),
         dataRoot,
@@ -472,11 +518,31 @@ describe("runRetentionPass", () => {
     expect(receipt.data_root_unrecognized).toEqual([]);
   });
 
+  it("a request WITHOUT data_root_report gets no scan and an absent field (skew-safe shape)", async () => {
+    const { project, root } = sandbox();
+    const dataRoot = join(root, "data-root");
+    mkdirSync(join(dataRoot, "definitely-foreign"), { recursive: true });
+    // The dataRoot is injected (a current daemon), but the client did not opt
+    // in — exactly what an old CLI sends. The receipt must be byte-compatible
+    // with the pre-feature shape: no field, not an empty list.
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true },
+      {
+        ...deps(project),
+        dataRoot,
+      },
+    );
+    expect(receipt.data_root_unrecognized).toBeUndefined();
+    expect("data_root_unrecognized" in receipt).toBe(false);
+    expect(receipt.errors).toEqual([]);
+  });
+
   it("a failed data-root scan leaves the field ABSENT and discloses the error", async () => {
     const { project, root } = sandbox();
     const receipt = await runRetentionPass(
       POLICY,
-      { dry_run: true },
+      { dry_run: true, data_root_report: true },
       {
         ...deps(project),
         dataRoot: join(root, "does-not-exist"),
@@ -488,9 +554,13 @@ describe("runRetentionPass", () => {
     expect(receipt.dry_run).toBe(true);
   });
 
-  it("no injected data root means no scan and an absent field", async () => {
+  it("no injected data root means no scan and an absent field even when requested", async () => {
     const { project } = sandbox();
-    const receipt = await runRetentionPass(POLICY, { dry_run: true }, deps(project));
+    const receipt = await runRetentionPass(
+      POLICY,
+      { dry_run: true, data_root_report: true },
+      deps(project),
+    );
     expect(receipt.data_root_unrecognized).toBeUndefined();
     expect(receipt.errors).toEqual([]);
   });

--- a/packages/control-api/src/retention.ts
+++ b/packages/control-api/src/retention.ts
@@ -55,24 +55,31 @@ export interface RetentionDeps {
    * entries (advisory disclosure only — the pass never deletes anything
    * there). Injected from composition, never derived from globals here, so
    * the pass stays a pure function of its deps. Absent = no scan and the
-   * receipt field stays absent.
+   * receipt field stays absent. The scan also runs ONLY when the request
+   * opted in via data_root_report (capability negotiation for version skew).
    */
   dataRoot?: string;
+  /**
+   * Which layout the injected dataRoot follows — "default" (~/.claudexor,
+   * where the engine keeps its state under the v3 generation subtree) or
+   * "override" (an explicit CLAUDEXOR_CONFIG_DIR root, which IS the complete
+   * relocatable tree, so the engine additionally writes secrets.json,
+   * plugins, quota, and workspaces directly at its top level). Injected from
+   * composition beside dataRoot; absent defaults to "default".
+   */
+  dataRootMode?: "default" | "override";
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const TOMBSTONE = "tombstone.yaml";
 /**
  * Exact top-level names the engine (or its documented operator surface) owns
- * inside the Claudexor data root — the union across root modes (the default
- * `~/.claudexor` tree and an explicit CLAUDEXOR_CONFIG_DIR override, where the
- * engine also writes `secrets.json`, `plugins`, `quota`, and `workspaces`
- * directly at the root). Everything else at the top level is a foreign entry
- * the engine will never touch: the receipt names it so the operator can see
- * their own debris. Dotfiles are treated as config/service files and never
- * reported.
+ * inside the DEFAULT `~/.claudexor` data root. Everything else at the top
+ * level is a foreign entry the engine will never touch: the receipt names it
+ * so the operator can see their own debris. Dotfiles are treated as
+ * config/service files and never reported.
  */
-const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
+const DEFAULT_ROOT_OWNED_ENTRIES = new Set([
   // current engine + documented operator dirs
   "v3",
   "node",
@@ -83,9 +90,7 @@ const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
   "keys",
   "release-authority",
   "planning",
-  "plugins",
-  "quota",
-  "workspaces",
+  "remote",
   // legacy engine generations kept as the archive (owner decision, v3.0.0)
   "daemon",
   "projects",
@@ -95,34 +100,49 @@ const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
   "telemetry",
   // config files
   "config.yaml",
+]);
+/**
+ * Owned names under an explicit CLAUDEXOR_CONFIG_DIR override root, where the
+ * override IS the complete relocatable tree: the engine also writes
+ * `secrets.json`, `plugins`, `quota`, and `workspaces` directly at the top
+ * level (in the default mode those live under the v3 generation subtree, so
+ * a top-level copy there is foreign debris and IS reported).
+ */
+const OVERRIDE_ROOT_OWNED_ENTRIES = new Set([
+  ...DEFAULT_ROOT_OWNED_ENTRIES,
   "secrets.json",
+  "plugins",
+  "quota",
+  "workspaces",
 ]);
 /** Owned names the engine expects as plain FILES; every other owned name is a directory. */
 const ENGINE_OWNED_FILE_ENTRIES = new Set(["config.yaml", "secrets.json"]);
 
 /**
  * Names of top-level data-root entries the engine does not own (the full
- * sorted list — advisory disclosure, never a deletion surface). An entry
- * whose NAME the engine owns but whose on-disk kind is wrong — a symbolic
- * link of any owned name (dirents are read WITHOUT following links), or a
- * non-directory where the engine expects a directory — is reported as
- * `<name> (unexpected-kind)`. Throws on an unreadable root — the caller
- * degrades that to an errors[] entry and an ABSENT field, never a misleading
- * empty list and never a failed pass.
+ * sorted list — advisory disclosure, never a deletion surface), classified
+ * against the owned set for the injected root mode. An entry whose NAME the
+ * engine owns but whose on-disk kind is wrong — a symbolic link of any owned
+ * name (dirents are read WITHOUT following links), a non-directory where the
+ * engine expects a directory, or a non-file where it expects a plain file —
+ * is reported as `<name> (unexpected-kind)`. Throws on an unreadable root —
+ * the caller degrades that to an errors[] entry and an ABSENT field, never a
+ * misleading empty list and never a failed pass.
  */
-function scanDataRootUnrecognized(dataRoot: string): string[] {
+function scanDataRootUnrecognized(dataRoot: string, mode: "default" | "override"): string[] {
+  const owned = mode === "override" ? OVERRIDE_ROOT_OWNED_ENTRIES : DEFAULT_ROOT_OWNED_ENTRIES;
   const report: string[] = [];
   for (const entry of readdirSync(dataRoot, { withFileTypes: true })) {
     const name = entry.name;
     if (name.startsWith(".")) continue;
-    if (!ENGINE_OWNED_DATA_ROOT_ENTRIES.has(name)) {
+    if (!owned.has(name)) {
       report.push(name);
       continue;
     }
-    const expectsDirectory = !ENGINE_OWNED_FILE_ENTRIES.has(name);
-    if (entry.isSymbolicLink() || (expectsDirectory && !entry.isDirectory())) {
-      report.push(`${name} (unexpected-kind)`);
-    }
+    const kindOk =
+      !entry.isSymbolicLink() &&
+      (ENGINE_OWNED_FILE_ENTRIES.has(name) ? entry.isFile() : entry.isDirectory());
+    if (!kindOk) report.push(`${name} (unexpected-kind)`);
   }
   return report.sort();
 }
@@ -321,10 +341,17 @@ export async function runRetentionPass(
 
   // Advisory data-root disclosure (never a deletion surface): a failed scan
   // leaves the field ABSENT — an empty list must always mean "scanned, clean".
+  // Emitted ONLY when the request opted in via data_root_report: a request
+  // from a client that never sent the flag (any pre-feature CLI) gets a
+  // receipt byte-compatible with pre-feature engines, so an old strict
+  // receipt schema never rejects the reply to a mutating verb it already ran.
   let dataRootUnrecognized: string[] | undefined;
-  if (deps.dataRoot) {
+  if (request.data_root_report === true && deps.dataRoot) {
     try {
-      dataRootUnrecognized = scanDataRootUnrecognized(deps.dataRoot);
+      dataRootUnrecognized = scanDataRootUnrecognized(
+        deps.dataRoot,
+        deps.dataRootMode ?? "default",
+      );
     } catch (error) {
       errors.push(
         `data root scan (${deps.dataRoot}): ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/control-api/src/retention.ts
+++ b/packages/control-api/src/retention.ts
@@ -50,10 +50,64 @@ export interface RetentionDeps {
   now?: () => number;
   /** Bounded batches: one pass deletes at most this many trees (disclosed). */
   maxDeletionsPerPass?: number;
+  /**
+   * Absolute Claudexor-owned data root to scan for NOT-engine-owned top-level
+   * entries (advisory disclosure only — the pass never deletes anything
+   * there). Injected from composition, never derived from globals here, so
+   * the pass stays a pure function of its deps. Absent = no scan and the
+   * receipt field stays absent.
+   */
+  dataRoot?: string;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const TOMBSTONE = "tombstone.yaml";
+/**
+ * Exact top-level names the engine (or its documented operator surface) owns
+ * inside the Claudexor data root — the union across root modes (the default
+ * `~/.claudexor` tree and an explicit CLAUDEXOR_CONFIG_DIR override, where
+ * generation dirs and their content share one root). Everything else at the
+ * top level is a foreign entry the engine will never touch: the receipt names
+ * it so the operator can see their own debris. Dotfiles are treated as
+ * config/service files and never reported.
+ */
+const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
+  // current engine + documented operator dirs
+  "v3",
+  "node",
+  "profiles",
+  "runtime",
+  "cache",
+  "dogfood",
+  "keys",
+  "release-authority",
+  "planning",
+  // legacy engine generations kept as the archive (owner decision, v3.0.0)
+  "daemon",
+  "projects",
+  "native",
+  "runs",
+  "trust",
+  "telemetry",
+  "isolated",
+  // config files
+  "config.yaml",
+]);
+/** Advisory listing stays bounded — a receipt is a report, not a du(1) dump. */
+const DATA_ROOT_REPORT_LIMIT = 64;
+
+/**
+ * Names of top-level data-root entries the engine does not own (sorted,
+ * bounded). Advisory only; throws on an unreadable root — the caller degrades
+ * that to an errors[] entry and an ABSENT field, never a misleading empty
+ * list and never a failed pass.
+ */
+function scanDataRootUnrecognized(dataRoot: string): string[] {
+  return readdirSync(dataRoot)
+    .filter((name) => !name.startsWith(".") && !ENGINE_OWNED_DATA_ROOT_ENTRIES.has(name))
+    .sort()
+    .slice(0, DATA_ROOT_REPORT_LIMIT);
+}
 /** Daemon-record states with an operator or scheduler still attached. */
 /**
  * Run states whose tree is COMPLETE and may age out — an explicit allowlist,
@@ -247,6 +301,19 @@ export async function runRetentionPass(
     );
   }
 
+  // Advisory data-root disclosure (never a deletion surface): a failed scan
+  // leaves the field ABSENT — an empty list must always mean "scanned, clean".
+  let dataRootUnrecognized: string[] | undefined;
+  if (deps.dataRoot) {
+    try {
+      dataRootUnrecognized = scanDataRootUnrecognized(deps.dataRoot);
+    } catch (error) {
+      errors.push(
+        `data root scan (${deps.dataRoot}): ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   return ControlGcReceipt.parse({
     schema_version: 1,
     dry_run: dryRun,
@@ -263,6 +330,7 @@ export async function runRetentionPass(
     deleted_reviews: deletedReviews,
     freed_bytes: freedBytes,
     errors,
+    ...(dataRootUnrecognized === undefined ? {} : { data_root_unrecognized: dataRootUnrecognized }),
   });
 }
 

--- a/packages/control-api/src/retention.ts
+++ b/packages/control-api/src/retention.ts
@@ -65,11 +65,12 @@ const TOMBSTONE = "tombstone.yaml";
 /**
  * Exact top-level names the engine (or its documented operator surface) owns
  * inside the Claudexor data root — the union across root modes (the default
- * `~/.claudexor` tree and an explicit CLAUDEXOR_CONFIG_DIR override, where
- * generation dirs and their content share one root). Everything else at the
- * top level is a foreign entry the engine will never touch: the receipt names
- * it so the operator can see their own debris. Dotfiles are treated as
- * config/service files and never reported.
+ * `~/.claudexor` tree and an explicit CLAUDEXOR_CONFIG_DIR override, where the
+ * engine also writes `secrets.json`, `plugins`, `quota`, and `workspaces`
+ * directly at the root). Everything else at the top level is a foreign entry
+ * the engine will never touch: the receipt names it so the operator can see
+ * their own debris. Dotfiles are treated as config/service files and never
+ * reported.
  */
 const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
   // current engine + documented operator dirs
@@ -82,6 +83,9 @@ const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
   "keys",
   "release-authority",
   "planning",
+  "plugins",
+  "quota",
+  "workspaces",
   // legacy engine generations kept as the archive (owner decision, v3.0.0)
   "daemon",
   "projects",
@@ -89,24 +93,38 @@ const ENGINE_OWNED_DATA_ROOT_ENTRIES = new Set([
   "runs",
   "trust",
   "telemetry",
-  "isolated",
   // config files
   "config.yaml",
+  "secrets.json",
 ]);
-/** Advisory listing stays bounded — a receipt is a report, not a du(1) dump. */
-const DATA_ROOT_REPORT_LIMIT = 64;
+/** Owned names the engine expects as plain FILES; every other owned name is a directory. */
+const ENGINE_OWNED_FILE_ENTRIES = new Set(["config.yaml", "secrets.json"]);
 
 /**
- * Names of top-level data-root entries the engine does not own (sorted,
- * bounded). Advisory only; throws on an unreadable root — the caller degrades
- * that to an errors[] entry and an ABSENT field, never a misleading empty
- * list and never a failed pass.
+ * Names of top-level data-root entries the engine does not own (the full
+ * sorted list — advisory disclosure, never a deletion surface). An entry
+ * whose NAME the engine owns but whose on-disk kind is wrong — a symbolic
+ * link of any owned name (dirents are read WITHOUT following links), or a
+ * non-directory where the engine expects a directory — is reported as
+ * `<name> (unexpected-kind)`. Throws on an unreadable root — the caller
+ * degrades that to an errors[] entry and an ABSENT field, never a misleading
+ * empty list and never a failed pass.
  */
 function scanDataRootUnrecognized(dataRoot: string): string[] {
-  return readdirSync(dataRoot)
-    .filter((name) => !name.startsWith(".") && !ENGINE_OWNED_DATA_ROOT_ENTRIES.has(name))
-    .sort()
-    .slice(0, DATA_ROOT_REPORT_LIMIT);
+  const report: string[] = [];
+  for (const entry of readdirSync(dataRoot, { withFileTypes: true })) {
+    const name = entry.name;
+    if (name.startsWith(".")) continue;
+    if (!ENGINE_OWNED_DATA_ROOT_ENTRIES.has(name)) {
+      report.push(name);
+      continue;
+    }
+    const expectsDirectory = !ENGINE_OWNED_FILE_ENTRIES.has(name);
+    if (entry.isSymbolicLink() || (expectsDirectory && !entry.isDirectory())) {
+      report.push(`${name} (unexpected-kind)`);
+    }
+  }
+  return report.sort();
 }
 /** Daemon-record states with an operator or scheduler still attached. */
 /**

--- a/packages/schema/generated/ControlGcReceipt.schema.json
+++ b/packages/schema/generated/ControlGcReceipt.schema.json
@@ -157,7 +157,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). The full sorted list. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead."
+          "description": "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). The full sorted list. Present ONLY when the request opted in via data_root_report; ABSENT (not empty) when the request did not opt in, the scan failed, or the serving daemon predates the feature; a scan failure is disclosed in errors instead."
         }
       },
       "required": [

--- a/packages/schema/generated/ControlGcReceipt.schema.json
+++ b/packages/schema/generated/ControlGcReceipt.schema.json
@@ -157,7 +157,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). Sorted and bounded. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead."
+          "description": "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). The full sorted list. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead."
         }
       },
       "required": [

--- a/packages/schema/generated/ControlGcReceipt.schema.json
+++ b/packages/schema/generated/ControlGcReceipt.schema.json
@@ -151,6 +151,13 @@
           },
           "default": [],
           "description": "Non-fatal per-tree failures; the pass continues past them."
+        },
+        "data_root_unrecognized": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). Sorted and bounded. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead."
         }
       },
       "required": [

--- a/packages/schema/generated/ControlGcRequest.schema.json
+++ b/packages/schema/generated/ControlGcRequest.schema.json
@@ -8,6 +8,10 @@
           "type": "boolean",
           "default": false,
           "description": "Report what WOULD be deleted without touching disk."
+        },
+        "data_root_report": {
+          "type": "boolean",
+          "description": "Opt in to the advisory data-root scan: when true, the receipt carries data_root_unrecognized. Capability negotiation for engine-version skew — a client omits this unless the serving daemon is the SAME engine version, so an older daemon never sees the unknown request key and an older client never receives the unknown receipt key."
         }
       },
       "additionalProperties": false,

--- a/packages/schema/src/control-gc.ts
+++ b/packages/schema/src/control-gc.ts
@@ -93,7 +93,7 @@ export const ControlGcReceipt = z
       .array(z.string())
       .optional()
       .describe(
-        "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). Sorted and bounded. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead.",
+        "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). The full sorted list. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead.",
       ),
   })
   .strict()

--- a/packages/schema/src/control-gc.ts
+++ b/packages/schema/src/control-gc.ts
@@ -89,6 +89,12 @@ export const ControlGcReceipt = z
       .array(z.string())
       .default([])
       .describe("Non-fatal per-tree failures; the pass continues past them."),
+    data_root_unrecognized: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). Sorted and bounded. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead.",
+      ),
   })
   .strict()
   .describe("Typed receipt of one retention pass.");

--- a/packages/schema/src/control-gc.ts
+++ b/packages/schema/src/control-gc.ts
@@ -22,6 +22,12 @@ export const ControlGcRequest = z
       .boolean()
       .default(false)
       .describe("Report what WOULD be deleted without touching disk."),
+    data_root_report: z
+      .boolean()
+      .optional()
+      .describe(
+        "Opt in to the advisory data-root scan: when true, the receipt carries data_root_unrecognized. Capability negotiation for engine-version skew — a client omits this unless the serving daemon is the SAME engine version, so an older daemon never sees the unknown request key and an older client never receives the unknown receipt key.",
+      ),
   })
   .strict()
   .describe("Run one retention pass over engine-owned runtime artifacts.");
@@ -93,7 +99,7 @@ export const ControlGcReceipt = z
       .array(z.string())
       .optional()
       .describe(
-        "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). The full sorted list. ABSENT (not empty) when the scan failed or the serving daemon predates the feature; a scan failure is disclosed in errors instead.",
+        "Names of top-level entries in the Claudexor-owned data root that the engine does not own and will never touch (advisory only — nothing here is ever deleted). The full sorted list. Present ONLY when the request opted in via data_root_report; ABSENT (not empty) when the request did not opt in, the scan failed, or the serving daemon predates the feature; a scan failure is disclosed in errors instead.",
       ),
   })
   .strict()

--- a/scripts/build-runtime-closure.mjs
+++ b/scripts/build-runtime-closure.mjs
@@ -11,7 +11,7 @@
  * hosts without POSIX symlink semantics.
  *
  *   node scripts/build-runtime-closure.mjs \
- *     --app-bundle apps/macos/dist/Claudexor.app \
+ *     --app-bundle apps/macos/dist/bundle.noindex/Claudexor.app \
  *     --version 3.0.0 \
  *     --out "$RUNNER_TEMP/runtime-closure"
  *

--- a/scripts/lib/release-review-runtime.mjs
+++ b/scripts/lib/release-review-runtime.mjs
@@ -156,7 +156,7 @@ export async function buildReleaseReviewRuntimeArtifacts(repoRoot, artifactRoot,
   const verifierPath = join(outputRoot, RELEASE_REVIEW_VERIFIER_ARTIFACT_PATH);
   const cliSource = join(
     root,
-    "apps/macos/dist/Claudexor.app/Contents/Resources/claudexor.bundle.cjs",
+    "apps/macos/dist/bundle.noindex/Claudexor.app/Contents/Resources/claudexor.bundle.cjs",
   );
   const cliPath = join(outputRoot, RELEASE_REVIEW_CLI_ARTIFACT_PATH);
   for (const path of [verifierPath, cliPath]) {

--- a/scripts/release-workflow-check.mjs
+++ b/scripts/release-workflow-check.mjs
@@ -84,12 +84,12 @@ for (const [label, pattern] of [
   ["Darwin npm tarball is smoke-tested", /verify-npm-darwin-package\.mjs --tarball/],
   [
     "SBOM inventories the packaged app",
-    /generate-release-sbom\.mjs\s+\\\s*\n\s*--app-bundle apps\/macos\/dist\/Claudexor\.app/,
+    /generate-release-sbom\.mjs\s+\\\s*\n\s*--app-bundle apps\/macos\/dist\/bundle\.noindex\/Claudexor\.app/,
   ],
   ["engine runtime update closure is built (M7)", /build-runtime-closure\.mjs/],
   [
     "runtime closure is built from the signed app bundle",
-    /build-runtime-closure\.mjs\s+\\\s*\n\s*--app-bundle apps\/macos\/dist\/Claudexor\.app/,
+    /build-runtime-closure\.mjs\s+\\\s*\n\s*--app-bundle apps\/macos\/dist\/bundle\.noindex\/Claudexor\.app/,
   ],
   [
     "runtime manifest digest is self-verified before upload",
@@ -743,7 +743,7 @@ function exactCandidateAppPromotionErrors(job) {
   );
   requirePattern(
     "candidate SBOM must bind both license input and document namespace to the prepared SHA",
-    /else[\s\S]*?GITHUB_SHA="\$PREPARED_SHA" pnpm licenses list --prod --json \|[\s\S]*?GITHUB_SHA="\$PREPARED_SHA" node scripts\/generate-release-sbom\.mjs[\s\S]*?--app-bundle apps\/macos\/dist\/Claudexor\.app/,
+    /else[\s\S]*?GITHUB_SHA="\$PREPARED_SHA" pnpm licenses list --prod --json \|[\s\S]*?GITHUB_SHA="\$PREPARED_SHA" node scripts\/generate-release-sbom\.mjs[\s\S]*?--app-bundle apps\/macos\/dist\/bundle\.noindex\/Claudexor\.app/,
     assembleStep,
   );
   // Every write into "$assets/" is pinned: the released asset set is exactly


### PR DESCRIPTION
Local release builds used to drop an indexable Claudexor.app into every worktree, so Spotlight and Launchpad filled up with duplicate icons. The packaged bundle and the dmg staging dir now live under apps/macos/dist/bundle.noindex, which Spotlight skips, while the DMG and ZIP outputs and the release byte-promotion contract stay exactly where they were.

A source-built dev app also used to show the installed app's Update available chip because both recompute it from the shared runtime pointer file. A dev build now shows an honest dev-build status instead of the automatic chip, and the manual Check for Updates flow keeps working. The old backlog note about a UserDefaults cache described a mechanism that does not exist, so it was corrected.

claudexor gc additionally reports top-level entries in the data root that the engine does not own, as a purely advisory list on the receipt. It never deletes anything, the field is optional for compatibility, and scan failures land in the existing errors list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)