### PR TITLE
Fix Linux CI: confinement policy contradiction must be refused before the platform probe

### DIFF
--- a/packages/core/src/confinement.test.ts
+++ b/packages/core/src/confinement.test.ts
@@ -173,6 +173,18 @@ describe("an applied boundary is a proof, never a name", () => {
       applyConfinement({ ...fixture.input, worktree: fixture.input.operatorHome }),
     ).toThrowError(ConfinementUnavailableError);
   });
+
+  it("refuses that same contradiction on hosts that have no boundary mechanism at all", () => {
+    // The regression this pins: a host with no mechanism (every non-macOS
+    // platform, and a macOS without sandbox-exec) used to return "no boundary
+    // here" BEFORE the self-defeating layout was noticed, so the contradiction
+    // sailed through as a quiet scoped-HOME run. The refusal is about the
+    // policy's own shape and must not depend on the platform probe.
+    const swallowing = { ...fixture.input, worktree: fixture.input.operatorHome };
+    for (const host of [LINUX_HOST, WINDOWS_HOST, DARWIN_WITHOUT_SEATBELT]) {
+      expect(() => applyConfinement(swallowing, host)).toThrowError(ConfinementUnavailableError);
+    }
+  });
 });
 
 describe("a host with no boundary works and says so", () => {

--- a/packages/core/src/confinement.ts
+++ b/packages/core/src/confinement.ts
@@ -358,12 +358,13 @@ export function applyConfinement(
   input: ConfinementInput,
   host: ConfinementHost = DEFAULT_HOST,
 ): ConfinementOutcome {
-  const available = confinementMechanism(host);
-  if (!available.mechanism) return { confinement: null, unavailableReason: available.reason };
   const denied = confinementDeniedReadPaths(input);
   // The carve-outs re-open whatever they contain, so an "own root" that CONTAINS
-  // a denied path silently defeats the policy. Refuse rather than emit one that
-  // reads like a boundary and is not.
+  // a denied path silently defeats the policy. This contradiction is Claudexor's
+  // own layout being wrong, not a platform fact, so it is refused BEFORE the
+  // host is asked whether it can enforce anything: a host with no boundary must
+  // not turn a self-defeating policy into a quiet scoped-HOME run. Refuse rather
+  // than emit one that reads like a boundary and is not.
   const swallowed = ownRoots(input).find((root) =>
     denied.some((path) => path !== root && contains(root, path)),
   );
@@ -372,6 +373,8 @@ export function applyConfinement(
       `filesystem confinement would be self-defeating: the allowed root ${swallowed} contains a path the policy must deny`,
     );
   }
+  const available = confinementMechanism(host);
+  if (!available.mechanism) return { confinement: null, unavailableReason: available.reason };
   const profile = available.mechanism.buildProfile(input, available.bin);
   const probeCandidate = denied.find((path) => host.exists(path));
   if (!probeCandidate) {


### PR DESCRIPTION
CI on main has been red since the v3.3.7 batch landed: the confinement test that expects a self-defeating carve-out to be refused never throws on Linux. The cause is ordering, not the runner: the platform-availability early return ran before the policy-shape validation, and once the Linux mechanism was removed in the same-day course correction, no Linux host ever reached the check.

The policy contradiction is a fact about Claudexor's own layout, so it is now validated before the mechanism probe and refuses identically on every platform. A new test drives the same input through injected linux, win32 and darwin-without-seatbelt hosts so the class cannot quietly return. Verified red then green locally, and the full CI matrix already ran green on this exact commit.