### PR TITLE
docs: show how Ouroboros uses Claudexor in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Current status: **v3.3.7**. See "Stability at 2.0" below for what is a stable
 contract and what remains experimental; retired verbs and mode ids hard-error
 with the new spelling instead of silently aliasing.
 
+Claudexor also runs as the exact-pinned delegated execution layer inside
+[Ouroboros](https://github.com/razzant/ouroboros), a persistent self-developing
+agent. Ouroboros owns its tasks, memory, review, and final integration.
+Claudexor runs the connected coding harnesses and returns durable execution
+evidence. [See Ouroboros in action](https://ouroboros-agent.ai/).
+
 If you use Claudexor — or you are an agent whose human does — a
 [star](https://github.com/razzant/claudexor/stargazers) is the one-click way
 to say it works.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -15,7 +15,7 @@ changing Claudexor.
 | MCP server | Exposes Claudexor tools to MCP clients. | Stable contract: the tool set with input/output schemas. Tool list follows the implementation, not old docs. |
 | ACP server | Lets compatible editors or agents talk to Claudexor as a local agent surface. | Experimental (may change in minors, disclosed in the CHANGELOG). |
 | Host plugins | User-global Claude Code, Codex, Cursor, and OpenCode integrations managed by `claudexor plugin`. | Experimental file layout (regenerate with `claudexor plugin repair all`). Installs owned local files/config only; host enablement can still require reload/manual action. |
-| Engine runtime closure | Node-free release artifact for a host that owns its daemon lifecycle, such as Ouroboros. | Exact-pin contract: one link-free archive and the existing signed runtime manifest; the host supplies the tested Node version and verifies archive plus `--probe` identity. |
+| Engine runtime closure | Node-free release artifact for a host that owns its daemon lifecycle, such as [Ouroboros](https://github.com/razzant/ouroboros). | Exact-pin contract: one link-free archive and the existing signed runtime manifest; the host supplies the tested Node version and verifies archive plus `--probe` identity. |
 
 ## Embedded Engine Runtime
 
@@ -27,6 +27,9 @@ extraction it requires `node claudexord.bundle.cjs --probe` to report the same
 version/build identity. The existing signed runtime manifest remains the
 publication authority, so an embedder does not create a second artifact or
 trust root.
+
+The public [Ouroboros runtime pin](https://github.com/razzant/ouroboros/blob/ouroboros/ouroboros/claudexor_runtime_pin.json)
+is a working example of that exact-version, exact-build, and checksum contract.
 
 The host owns install location, daemon config root, process lifecycle, and
 rollback. Start, handshake, and stop must address the same config root/socket.

--- a/scripts/site-metadata-check.mjs
+++ b/scripts/site-metadata-check.mjs
@@ -4,16 +4,25 @@ import { readFileSync } from "node:fs";
 const productionUrl = "https://claudexor.ai/";
 const legacyUrl = "https://razzant.github.io/claudexor";
 const socialImageUrl = `${productionUrl}assets/social-preview-v2.png`;
+const ouroborosRepositoryUrl = "https://github.com/razzant/ouroboros";
+const ouroborosSiteUrl = "https://ouroboros-agent.ai/";
+const ouroborosRuntimePinUrl = `${ouroborosRepositoryUrl}/blob/ouroboros/ouroboros/claudexor_runtime_pin.json`;
 const failures = [];
 
 const index = readFileSync("site/index.html", "utf8");
 const sitemap = readFileSync("site/sitemap.xml", "utf8");
 const robots = readFileSync("site/robots.txt", "utf8");
+const llms = readFileSync("site/llms.txt", "utf8");
 const readme = readFileSync("README.md", "utf8");
+const integrations = readFileSync("docs/INTEGRATIONS.md", "utf8");
 const pagesWorkflow = readFileSync(".github/workflows/pages.yml", "utf8");
 
 function requireMatch(text, pattern, message) {
   if (!pattern.test(text)) failures.push(message);
+}
+
+function requireText(text, value, message) {
+  if (!text.includes(value)) failures.push(message);
 }
 
 for (const [name, text] of [
@@ -62,6 +71,26 @@ requireMatch(
   pagesWorkflow,
   /run: node scripts\/site-metadata-check\.mjs/,
   ".github/workflows/pages.yml: metadata verification step is missing",
+);
+requireMatch(
+  index,
+  /<div class="plane" id="ouroboros">/,
+  "site/index.html: Ouroboros production-use section is missing",
+);
+
+for (const [name, text] of [
+  ["README.md", readme],
+  ["site/index.html", index],
+  ["site/llms.txt", llms],
+]) {
+  requireText(text, ouroborosRepositoryUrl, `${name}: Ouroboros repository link is missing`);
+  requireText(text, ouroborosSiteUrl, `${name}: Ouroboros website link is missing`);
+}
+
+requireText(
+  integrations,
+  ouroborosRuntimePinUrl,
+  "docs/INTEGRATIONS.md: Ouroboros runtime pin example is missing",
 );
 
 const jsonLdMatch = index.match(/<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/);

--- a/site/index.html
+++ b/site/index.html
@@ -660,6 +660,62 @@
         margin: 0;
       }
 
+      .ouroboros-flow {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 30px;
+        padding: 0;
+        margin: 34px 0 0;
+        list-style: none;
+      }
+      .ouroboros-flow li {
+        position: relative;
+        min-height: 126px;
+        padding: 22px;
+      }
+      .ouroboros-flow li:not(:last-child)::after {
+        content: "→";
+        position: absolute;
+        top: 50%;
+        right: -23px;
+        width: 16px;
+        color: var(--glint);
+        font-family: var(--data);
+        font-size: 18px;
+        line-height: 1;
+        text-align: center;
+        transform: translateY(-50%);
+      }
+      .ouroboros-flow strong {
+        display: block;
+        margin-bottom: 9px;
+        color: var(--ice);
+        font-size: 16px;
+      }
+      .ouroboros-flow span {
+        display: block;
+        color: var(--ice-3);
+        font-family: var(--data);
+        font-size: 11px;
+        line-height: 1.55;
+      }
+      @media (max-width: 860px) {
+        .ouroboros-flow {
+          grid-template-columns: 1fr;
+          gap: 28px;
+        }
+        .ouroboros-flow li {
+          min-height: 0;
+        }
+        .ouroboros-flow li:not(:last-child)::after {
+          content: "↓";
+          top: auto;
+          right: 50%;
+          bottom: -23px;
+          transform: translateX(50%);
+        }
+      }
+
       dl.defs {
         margin: 0;
         display: grid;
@@ -1798,6 +1854,49 @@
                   </figcaption>
                 </figure>
               </div>
+            </section>
+          </div>
+        </div>
+
+        <div class="plane" id="ouroboros">
+          <div class="z">
+            <section>
+              <p class="kick">running in production</p>
+              <div class="split" style="align-items: center; margin-top: 0">
+                <div>
+                  <h2>Claudexor powers delegated coding in Ouroboros.</h2>
+                  <p class="lead">
+                    Ouroboros owns its tasks, memory, review, and final integration. It runs an
+                    exact-pinned Claudexor build to execute work through connected coding harnesses
+                    and receive durable execution evidence.
+                  </p>
+                  <div class="acts">
+                    <a class="btn p" href="https://ouroboros-agent.ai/">Explore Ouroboros</a>
+                    <a class="btn s" href="https://github.com/razzant/ouroboros">View source</a>
+                  </div>
+                </div>
+                <div class="cell flat" style="padding: 26px">
+                  <h3>One clear ownership boundary</h3>
+                  <p>
+                    Ouroboros decides what to do and what to keep. Claudexor routes and runs the
+                    selected harness, then returns the evidence needed for review and integration.
+                  </p>
+                </div>
+              </div>
+              <ol class="ouroboros-flow" aria-label="Ouroboros delegated coding flow">
+                <li class="flat">
+                  <strong>Ouroboros</strong>
+                  <span>tasks · memory · review</span>
+                </li>
+                <li class="flat">
+                  <strong>Claudexor</strong>
+                  <span>routing · execution · evidence</span>
+                </li>
+                <li class="flat">
+                  <strong>Connected harnesses</strong>
+                  <span>Claude Code · Codex · Cursor · OpenCode</span>
+                </li>
+              </ol>
             </section>
           </div>
         </div>

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -18,3 +18,8 @@ Claudexor runs locally and keeps one coding thread across harness and account la
 
 - [GitHub repository](https://github.com/razzant/claudexor)
 - [npm package](https://www.npmjs.com/package/claudexor)
+
+## Production use
+
+- [Ouroboros](https://github.com/razzant/ouroboros): A persistent self-developing agent that uses an exact-pinned Claudexor runtime for delegated coding.
+- [Ouroboros website](https://ouroboros-agent.ai/)


### PR DESCRIPTION
This adds Ouroboros as a concrete production integration across the README, landing page, llms.txt, and integration guide. The new section explains the boundary directly: Ouroboros owns tasks, memory, review, and final integration; Claudexor routes and runs the selected connected harness and returns durable execution evidence.

The integration guide links to Ouroboros's public exact runtime pin, and the metadata check now guards the reciprocal repository and site links. Metadata checks, formatting, and the Chromium and WebKit visual matrix pass. No versions, changesets, or Pages workflow were changed.
