### PR TITLE
Preserve OpenRouter cost receipts and reject provider-error completions

### DIFF
--- a/.changeset/raw-api-openrouter-receipts.md
+++ b/.changeset/raw-api-openrouter-receipts.md
@@ -1,0 +1,10 @@
+---
+"claudexor": patch
+---
+
+Preserve the built-in OpenRouter instance's finite non-negative `usage.cost`,
+including zero, as an exact USD account charge receipt while keeping generic
+raw-api cost unknown. Treat explicit terminal provider-error completions as
+failures with safe typed error, usage, and completion evidence, never as
+deliverable messages or patches; ordinary stop and length completions remain
+successful.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -575,6 +575,14 @@ search as `cached`, `live`, or `disabled`, with live search controlled by
 maps its typed policy onto those native surfaces and records observed tool
 evidence rather than relying on final-answer claims.
 
+Raw API, including the built-in OpenRouter instance, uses non-streaming Chat
+Completions HTTP JSON rather than a native CLI stream. Its terminal semantics
+are pinned by adapter unit tests, not a recorded stream fixture: an explicit
+terminal provider error yields a bounded, redacted typed `error`, followed by
+`usage` and `completed` events, and never yields a message or patch. Ordinary
+`finish_reason: "stop"` and `finish_reason: "length"` remain successful
+completions.
+
 ### Harness Stream Reference
 
 The per-harness wire truth every parser change must be checked against. Each
@@ -729,10 +737,13 @@ Deliberate limits of the external/host surfaces. Each is a designed boundary
   synthetic until real transcripts are captured.
 - opencode sources any configured provider key — opencode/openai/anthropic
   order — because the vendor CLI consumes provider keys directly.
-- Raw-api routes report token usage but no dollar cost — chat-completions
-  responses carry no price and Claudexor maintains no vendor price tables.
-  Under a finite paid budget that missing cash cost remains `unknown` and can
-  end `cost_unverifiable`; Claudexor never fabricates `$0`.
+- The built-in OpenRouter raw-api instance carries a documented finite
+  non-negative response `usage.cost`, including zero, as an exact USD account
+  charge receipt. Generic raw-api routes, untrusted provider cost, and missing
+  cost remain `unknown` under a finite paid budget and can end
+  `cost_unverifiable`. `cost_details.upstream_inference_cost` is not the account
+  charge receipt and is not lifted into canonical cost; Claudexor neither
+  estimates raw-api spend nor maintains vendor price tables.
 - Cursor native auth lives in the macOS Keychain, so scoped envelopes bridge
   the host keychain (declared `scoped_home_keychain_bridge` containment)
   rather than fully isolating HOME; the cursor doctor's paid smoke result is

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@claudexor/secrets", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@claudexor/secrets")>()),
+  resolveSecret: () => null,
+}));
+
+import { HarnessEvent, HarnessRunSpec } from "@claudexor/schema";
+import { buildRegistry } from "./registry.js";
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+describe("built-in OpenRouter registry wiring", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env.OPENROUTER_API_KEY = "sk-test";
+    process.env.CLAUDEXOR_OPENROUTER_BASE_URL = "https://unit.test/openrouter/v1";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it("declares the provider's account-charge receipt as exact USD", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            model: "openrouter/model",
+            choices: [{ message: { content: "done" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 2, completion_tokens: 3, cost: 0.125 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = buildRegistry({ includeFakes: false }).get("openrouter");
+    expect(adapter).toBeDefined();
+
+    const events = await collect(
+      adapter!.run(
+        HarnessRunSpec.parse({
+          session_id: "registry-openrouter-cost",
+          intent: "review",
+          prompt: "x",
+          cwd: process.cwd(),
+          access: "readonly",
+          external_context_policy: "auto",
+          tool_permission_policy: { web: "auto", allow: [], deny: [] },
+        }),
+      ),
+    );
+    const usageEvent = HarnessEvent.parse(events.find((event) => event.type === "usage"));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://unit.test/openrouter/v1/chat/completions");
+    expect(usageEvent).toMatchObject({
+      usage: { input_tokens: 2, output_tokens: 3, cost_usd: 0.125 },
+      observed_model: "openrouter/model",
+    });
+    expect(usageEvent?.usage).not.toHaveProperty("estimated");
+  });
+});

--- a/packages/cli/src/registry.test.ts
+++ b/packages/cli/src/registry.test.ts
@@ -14,10 +14,13 @@ async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
   return out;
 }
 
-describe("built-in OpenRouter registry wiring", () => {
+describe("built-in raw-api registry cost wiring", () => {
   const ORIGINAL_ENV = { ...process.env };
 
   beforeEach(() => {
+    delete process.env.CLAUDEXOR_RAWAPI_KEY;
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.CLAUDEXOR_RAWAPI_BASE_URL = "https://unit.test/raw-api/v1";
     process.env.OPENROUTER_API_KEY = "sk-test";
     process.env.CLAUDEXOR_OPENROUTER_BASE_URL = "https://unit.test/openrouter/v1";
   });
@@ -56,14 +59,77 @@ describe("built-in OpenRouter registry wiring", () => {
         }),
       ),
     );
-    const usageEvent = HarnessEvent.parse(events.find((event) => event.type === "usage"));
+    const rawUsageEvent = events.find((event) => event.type === "usage");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://unit.test/openrouter/v1/chat/completions");
+    expect(rawUsageEvent).toStrictEqual({
+      type: "usage",
+      session_id: "registry-openrouter-cost",
+      ts: expect.any(String),
+      usage: { input_tokens: 2, output_tokens: 3, cost_usd: 0.125 },
+      observed_model: "openrouter/model",
+    });
+    expect(rawUsageEvent?.usage).not.toHaveProperty("provider_cost");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+
+    const usageEvent = HarnessEvent.parse(rawUsageEvent);
     expect(usageEvent).toMatchObject({
       usage: { input_tokens: 2, output_tokens: 3, cost_usd: 0.125 },
       observed_model: "openrouter/model",
     });
     expect(usageEvent?.usage).not.toHaveProperty("estimated");
+  });
+
+  it("keeps the default raw-api instance untrusted for the same provider extension", async () => {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(
+          JSON.stringify({
+            model: "compatible/model",
+            choices: [{ message: { content: "done" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 5, completion_tokens: 8, cost: 0.5 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = buildRegistry({ includeFakes: false }).get("raw-api");
+    expect(adapter).toBeDefined();
+
+    const events = await collect(
+      adapter!.run(
+        HarnessRunSpec.parse({
+          session_id: "registry-generic-cost",
+          intent: "review",
+          prompt: "x",
+          cwd: process.cwd(),
+          access: "readonly",
+          external_context_policy: "auto",
+          tool_permission_policy: { web: "auto", allow: [], deny: [] },
+        }),
+      ),
+    );
+    const rawUsageEvent = events.find((event) => event.type === "usage");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://unit.test/raw-api/v1/chat/completions");
+    expect(rawUsageEvent).toStrictEqual({
+      type: "usage",
+      session_id: "registry-generic-cost",
+      ts: expect.any(String),
+      usage: { input_tokens: 5, output_tokens: 8 },
+      observed_model: "compatible/model",
+    });
+    expect(rawUsageEvent?.usage).not.toHaveProperty("cost_usd");
+    expect(rawUsageEvent?.usage).not.toHaveProperty("provider_cost");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+
+    const usageEvent = HarnessEvent.parse(rawUsageEvent);
+    expect(usageEvent).toMatchObject({
+      usage: { input_tokens: 5, output_tokens: 8 },
+      observed_model: "compatible/model",
+    });
+    expect(usageEvent.usage).not.toHaveProperty("cost_usd");
   });
 });

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -30,6 +30,7 @@ export function buildRegistry(opts: RegistryOptions = {}): AdapterRegistry {
     createRawApiAdapter({
       id: "openrouter",
       providerFamily: "unknown",
+      providerUsageCostUnit: "usd",
       baseUrl: process.env.CLAUDEXOR_OPENROUTER_BASE_URL ?? "https://openrouter.ai/api/v1",
       keyEnv: "OPENROUTER_API_KEY",
       defaultModel: process.env.CLAUDEXOR_OPENROUTER_MODEL ?? "openai/gpt-5.5",

--- a/packages/harness-raw-api/src/index.test.ts
+++ b/packages/harness-raw-api/src/index.test.ts
@@ -184,6 +184,7 @@ describe("raw-api provider cost receipts", () => {
   async function runWithProviderCost(
     cost: unknown,
     providerUsageCostUnit?: "usd",
+    upstreamInferenceCost?: unknown,
   ): Promise<HarnessEvent[]> {
     vi.stubGlobal(
       "fetch",
@@ -193,7 +194,14 @@ describe("raw-api provider cost receipts", () => {
             JSON.stringify({
               model: "openrouter/model",
               choices: [{ message: { content: "done" }, finish_reason: "stop" }],
-              usage: { prompt_tokens: 2, completion_tokens: 3, cost },
+              usage: {
+                prompt_tokens: 2,
+                completion_tokens: 3,
+                cost,
+                ...(upstreamInferenceCost === undefined
+                  ? {}
+                  : { cost_details: { upstream_inference_cost: upstreamInferenceCost } }),
+              },
             }),
             { status: 200, headers: { "content-type": "application/json" } },
           ),
@@ -212,45 +220,61 @@ describe("raw-api provider cost receipts", () => {
         }),
       ),
     );
-    return events.map((event) => HarnessEvent.parse(event));
+    return events;
   }
 
   it.each([
-    ["a positive fractional receipt", 0.000_123],
-    ["an exact zero receipt", 0],
-  ])("emits %s as exact USD only for a trusted instance", async (_label, cost) => {
-    const events = await runWithProviderCost(cost, "usd");
+    ["the account-charge receipt instead of upstream inference cost", 0.01, 99],
+    ["an exact zero receipt", 0, undefined],
+  ])("emits %s as exact USD only for a trusted instance", async (_label, cost, upstreamCost) => {
+    const events = await runWithProviderCost(cost, "usd", upstreamCost);
     const usageEvent = events.find((event) => event.type === "usage");
 
     expect(events.map((event) => event.type)).toEqual(["started", "message", "usage", "completed"]);
-    expect(usageEvent).toMatchObject({
+    expect(usageEvent).toStrictEqual({
+      type: "usage",
+      session_id: "provider-cost",
+      ts: expect.any(String),
       usage: { input_tokens: 2, output_tokens: 3, cost_usd: cost },
       observed_model: "openrouter/model",
     });
+    expect(usageEvent?.usage).not.toHaveProperty("provider_cost");
+    expect(usageEvent?.usage?.cost_usd).not.toBe(99);
     expect(usageEvent?.usage).not.toHaveProperty("estimated");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 
   it("keeps the same provider extension untrusted on a generic instance", async () => {
     const events = await runWithProviderCost(0.25);
     const usageEvent = events.find((event) => event.type === "usage");
 
-    expect(usageEvent).toMatchObject({
+    expect(usageEvent).toStrictEqual({
+      type: "usage",
+      session_id: "provider-cost",
+      ts: expect.any(String),
       usage: { input_tokens: 2, output_tokens: 3 },
       observed_model: "openrouter/model",
     });
     expect(usageEvent?.usage).not.toHaveProperty("cost_usd");
+    expect(usageEvent?.usage).not.toHaveProperty("provider_cost");
     expect(usageEvent?.usage).not.toHaveProperty("estimated");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 
   it("still emits usage without fabricating zero when a trusted receipt is absent", async () => {
     const events = await runWithProviderCost(undefined, "usd");
     const usageEvent = events.find((event) => event.type === "usage");
 
-    expect(usageEvent).toMatchObject({
+    expect(usageEvent).toStrictEqual({
+      type: "usage",
+      session_id: "provider-cost",
+      ts: expect.any(String),
       usage: { input_tokens: 2, output_tokens: 3 },
       observed_model: "openrouter/model",
     });
     expect(usageEvent?.usage).not.toHaveProperty("cost_usd");
+    expect(usageEvent?.usage).not.toHaveProperty("provider_cost");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 
   it("emits a cost-only usage receipt even when token counts are absent", async () => {
@@ -278,11 +302,19 @@ describe("raw-api provider cost receipts", () => {
         }),
       ),
     );
-    const usageEvent = HarnessEvent.parse(events.find((event) => event.type === "usage"));
+    const usageEvent = events.find((event) => event.type === "usage");
 
-    expect(usageEvent).toMatchObject({ usage: { cost_usd: 0.75 } });
+    expect(usageEvent).toStrictEqual({
+      type: "usage",
+      session_id: "provider-cost-only",
+      ts: expect.any(String),
+      usage: { input_tokens: undefined, output_tokens: undefined, cost_usd: 0.75 },
+      observed_model: "openrouter/model",
+    });
+    expect(usageEvent?.usage).not.toHaveProperty("provider_cost");
     expect(usageEvent?.usage?.input_tokens).toBeUndefined();
     expect(usageEvent?.usage?.output_tokens).toBeUndefined();
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 });
 

--- a/packages/harness-raw-api/src/index.test.ts
+++ b/packages/harness-raw-api/src/index.test.ts
@@ -137,7 +137,10 @@ describe("raw-api models() — enumeration producer", () => {
       ),
     );
     const error = events.find((e) => e.type === "error");
+    expect(events.map((event) => event.type)).toEqual(["started", "error", "completed"]);
+    expect(events.some((event) => event.type === "usage")).toBe(false);
     expect(error?.transient?.kind).toBe("service_unavailable");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 
   it("normalizes a fractional Retry-After delay before emitting typed events", async () => {
@@ -602,5 +605,352 @@ describe("raw-api typed patch producer", () => {
       error: "raw-api implement patch refused by sensitive-content policy",
     });
     expect(JSON.stringify(events)).not.toContain(tokenLike);
+  });
+});
+
+describe("raw-api terminal provider completions", () => {
+  const ORIGINAL_ENV = { ...process.env };
+  const patch = "diff --git a/a.txt b/a.txt\n--- a/a.txt\n+++ b/a.txt\n@@ -1 +1 @@\n-old\n+new\n";
+  const rawContextPacket = {
+    schema_version: 1 as const,
+    packet_hash: "sha256:packet",
+    base_commit_sha: "commit",
+    base_tree_sha: "tree",
+    readable_files: [
+      {
+        path: "a.txt",
+        mode: "100644",
+        blob_oid: "blob",
+        content_hash: "sha256:old",
+        content: "old\n",
+      },
+    ],
+    editable_paths: ["a.txt"],
+    file_manifest: [{ path: "a.txt", disposition: "full" as const }],
+    omissions: [],
+    evidence_refs: ["git:tree:a.txt:blob"],
+  };
+
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-test";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  function responseFor(options: {
+    content?: unknown;
+    finishReason?: string | null;
+    error?: unknown;
+    model?: string;
+  }): Response {
+    return new Response(
+      JSON.stringify({
+        model: options.model ?? "provider-model",
+        choices: [
+          {
+            message: { role: "assistant", content: options.content ?? "partial output" },
+            ...(options.finishReason === undefined ? {} : { finish_reason: options.finishReason }),
+            ...(options.error === undefined ? {} : { error: options.error }),
+          },
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 3 },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  function runSpec(intent: "explain" | "review" | "implement" | "synthesize", sessionId: string) {
+    return HarnessRunSpec.parse({
+      session_id: sessionId,
+      intent,
+      prompt: "x",
+      cwd: process.cwd(),
+      access: "readonly",
+      external_context_policy: "auto",
+      tool_permission_policy: { web: "auto", allow: [], deny: [] },
+      ...((intent === "implement" || intent === "synthesize") && {
+        raw_context_packet: rawContextPacket,
+      }),
+    });
+  }
+
+  it.each(["review", "explain"] as const)(
+    "treats finish_reason:error as terminal for %s without emitting partial output",
+    async (intent) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          responseFor({
+            finishReason: "error",
+            error: {
+              code: 502,
+              message: "Provider disconnected",
+              metadata: { error_type: "provider_unavailable" },
+            },
+          }),
+        ),
+      );
+
+      const events = await collect(
+        createRawApiAdapter().run(runSpec(intent, `terminal-${intent}`)),
+      );
+      expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+      expect(events.some((event) => event.type === "message")).toBe(false);
+      expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+      expect(events.find((event) => event.type === "error")?.payload).toMatchObject({
+        partial_output: "partial output",
+        partial_output_truncated: false,
+      });
+      expect(events.find((event) => event.type === "usage")).toMatchObject({
+        observed_model: "provider-model",
+        usage: { input_tokens: 7, output_tokens: 3 },
+      });
+      expect(events.at(-1)).toMatchObject({
+        type: "completed",
+        observed_model: "provider-model",
+      });
+    },
+  );
+
+  it.each(["implement", "synthesize"] as const)(
+    "suppresses a valid partial patch on a terminal %s completion",
+    async (intent) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          responseFor({
+            content: JSON.stringify({ patch }),
+            finishReason: "error",
+            error: {
+              code: 502,
+              message: "Provider unavailable",
+              metadata: { error_type: "provider_unavailable" },
+            },
+          }),
+        ),
+      );
+
+      const events = await collect(createRawApiAdapter().run(runSpec(intent, `patch-${intent}`)));
+      expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+      expect(events.some((event) => event.type === "patch_produced")).toBe(false);
+      expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["rate_limit_exceeded", "service_unavailable", true],
+    ["provider_overloaded", "service_unavailable", false],
+    ["provider_unavailable", "service_unavailable", false],
+    ["server", "service_unavailable", false],
+    ["timeout", "timeout", false],
+  ] as const)(
+    "maps documented %s failures onto existing typed retry evidence",
+    async (errorType, transientKind, hasRateLimit) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          responseFor({
+            finishReason: "error",
+            error: {
+              code: 502,
+              message: "typed failure",
+              metadata: { error_type: errorType },
+            },
+          }),
+        ),
+      );
+
+      const events = await collect(
+        createRawApiAdapter().run(runSpec("review", `mapping-${errorType}`)),
+      );
+      const error = events.find((event) => event.type === "error");
+      expect(error?.transient).toEqual({ kind: transientKind, retry_delay_ms: null });
+      if (hasRateLimit) {
+        expect(error?.rate_limit).toEqual({ resets_at: null, retry_delay_ms: null });
+      } else {
+        expect(error).not.toHaveProperty("rate_limit");
+      }
+      expect(() => HarnessEvent.parse(error)).not.toThrow();
+    },
+  );
+
+  it.each(["unknown_future_type", "authentication", "payment_required", "invalid_input", "policy"])(
+    "does not invent transient or rate-limit evidence for %s",
+    async (errorType) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          responseFor({
+            error: {
+              code: 400,
+              message: "deterministic failure",
+              metadata: { error_type: errorType },
+            },
+          }),
+        ),
+      );
+
+      const events = await collect(
+        createRawApiAdapter().run(runSpec("review", `deterministic-${errorType}`)),
+      );
+      const error = events.find((event) => event.type === "error");
+      expect(error).not.toHaveProperty("transient");
+      expect(error).not.toHaveProperty("rate_limit");
+      expect(events.some((event) => event.type === "message")).toBe(false);
+      expect(() => HarnessEvent.parse(error)).not.toThrow();
+    },
+  );
+
+  it("redacts full strings before bounding allowlisted diagnostic evidence", async () => {
+    const secret = ["sk", "or", "v1"].join("-") + `-${"s".repeat(48)}`;
+    const providerMessage = `${"m".repeat(700)} ${secret}`;
+    const partialOutput = `${"p".repeat(700)} ${secret}`;
+    const finishReason = `${"f".repeat(700)} ${secret}`;
+    const errorType = `${"e".repeat(700)} ${secret}`;
+    const providerCode = `${"c".repeat(700)} ${secret}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        responseFor({
+          content: partialOutput,
+          finishReason,
+          error: {
+            code: 502,
+            message: providerMessage,
+            metadata: {
+              error_type: errorType,
+              provider_code: providerCode,
+              flagged_input: "unknown metadata sentinel",
+            },
+            raw: "unknown top-level sentinel",
+          },
+        }),
+      ),
+    );
+
+    const events = await collect(createRawApiAdapter().run(runSpec("review", "bounded-error")));
+    const error = events.find((event) => event.type === "error");
+    expect(error?.error).toBe("raw-api provider completion failed");
+    expect(error?.payload).toMatchObject({
+      provider_error: {
+        code: 502,
+      },
+      partial_output_truncated: true,
+    });
+    const payload = error?.payload as {
+      finish_reason?: string;
+      provider_error?: { message?: string; error_type?: string; provider_code?: string };
+      partial_output?: string;
+    };
+    expect(payload.finish_reason?.length).toBeLessThanOrEqual(500);
+    expect(payload.provider_error?.message?.length).toBeLessThanOrEqual(500);
+    expect(payload.provider_error?.error_type?.length).toBeLessThanOrEqual(500);
+    expect(payload.provider_error?.provider_code?.length).toBeLessThanOrEqual(500);
+    expect(payload.partial_output?.length).toBeLessThanOrEqual(500);
+    expect(JSON.stringify(error)).not.toContain(secret);
+    expect(JSON.stringify(error)).not.toContain("flagged_input");
+    expect(JSON.stringify(error)).not.toContain("unknown metadata sentinel");
+    expect(JSON.stringify(error)).not.toContain("unknown top-level sentinel");
+  });
+
+  it("redacts a secret that straddles the diagnostic boundary before slicing", async () => {
+    const secret = ["sk", "or", "v1"].join("-") + `-${"z".repeat(48)}`;
+    const straddlingPartialOutput = `${"p".repeat(480)} ${secret}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        responseFor({
+          content: straddlingPartialOutput,
+          finishReason: "error",
+        }),
+      ),
+    );
+
+    const events = await collect(createRawApiAdapter().run(runSpec("review", "straddling-secret")));
+    const error = events.find((event) => event.type === "error");
+    const partialOutput = (error?.payload as { partial_output?: string }).partial_output;
+    expect(partialOutput).toBe(`${"p".repeat(480)} [redacted]`);
+    expect(JSON.stringify(error)).not.toContain(secret);
+  });
+
+  it("accepts either terminal signal, but not a malformed choice error by itself", async () => {
+    for (const [sessionId, options] of [
+      ["finish-only", { finishReason: "error", error: undefined }],
+      [
+        "choice-only",
+        {
+          finishReason: undefined,
+          error: { code: 500, message: "failed", metadata: { error_type: "server" } },
+        },
+      ],
+    ] as const) {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => responseFor(options)),
+      );
+      const events = await collect(createRawApiAdapter().run(runSpec("review", sessionId)));
+      expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+    }
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFor({ finishReason: undefined, error: { code: "500" } })),
+    );
+    const malformed = await collect(createRawApiAdapter().run(runSpec("review", "malformed")));
+    expect(malformed.map((event) => event.type)).toEqual([
+      "started",
+      "message",
+      "usage",
+      "completed",
+    ]);
+  });
+
+  it.each(["stop", "length"] as const)(
+    "keeps finish_reason:%s successful for both messages and patch envelopes",
+    async (finishReason) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => responseFor({ content: "done", finishReason })),
+      );
+      const messageEvents = await collect(
+        createRawApiAdapter().run(runSpec("explain", `${finishReason}-message`)),
+      );
+      expect(messageEvents.map((event) => event.type)).toEqual([
+        "started",
+        "message",
+        "usage",
+        "completed",
+      ]);
+
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => responseFor({ content: JSON.stringify({ patch }), finishReason })),
+      );
+      const patchEvents = await collect(
+        createRawApiAdapter().run(runSpec("implement", `${finishReason}-patch`)),
+      );
+      expect(patchEvents.some((event) => event.type === "patch_produced")).toBe(true);
+      expect(patchEvents.some((event) => event.type === "error")).toBe(false);
+      expect(patchEvents.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+    },
+  );
+
+  it("omits partial-output diagnostics when message content is not a string", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        responseFor({
+          content: [{ type: "text", text: "rich content" }],
+          finishReason: "error",
+        }),
+      ),
+    );
+    const events = await collect(createRawApiAdapter().run(runSpec("review", "rich-content")));
+    const error = events.find((event) => event.type === "error");
+    expect(error?.payload).not.toHaveProperty("partial_output");
+    expect(error?.payload).not.toHaveProperty("partial_output_truncated");
   });
 });

--- a/packages/harness-raw-api/src/index.test.ts
+++ b/packages/harness-raw-api/src/index.test.ts
@@ -1150,6 +1150,36 @@ describe("raw-api terminal provider completions", () => {
     expect(JSON.stringify(error)).not.toContain(secret);
   });
 
+  it.each([
+    [499, 499, false],
+    [500, 500, false],
+    [501, 500, true],
+  ] as const)(
+    "marks a %i-character partial output as length %i with truncated=%s",
+    async (sourceLength, storedLength, truncated) => {
+      const partialOutput = "p".repeat(sourceLength);
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          responseFor({
+            content: partialOutput,
+            finishReason: "error",
+          }),
+        ),
+      );
+
+      const events = await collect(
+        createRawApiAdapter().run(runSpec("review", `diagnostic-boundary-${sourceLength}`)),
+      );
+      const payload = events.find((event) => event.type === "error")?.payload as {
+        partial_output?: string;
+        partial_output_truncated?: boolean;
+      };
+      expect(payload.partial_output).toBe("p".repeat(storedLength));
+      expect(payload.partial_output_truncated).toBe(truncated);
+    },
+  );
+
   it("accepts either terminal signal, but not a malformed choice error by itself", async () => {
     for (const [sessionId, options] of [
       ["finish-only", { finishReason: "error", error: undefined }],

--- a/packages/harness-raw-api/src/index.test.ts
+++ b/packages/harness-raw-api/src/index.test.ts
@@ -169,6 +169,123 @@ describe("raw-api models() — enumeration producer", () => {
   });
 });
 
+describe("raw-api provider cost receipts", () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env.OPENAI_API_KEY = "sk-test";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  async function runWithProviderCost(
+    cost: unknown,
+    providerUsageCostUnit?: "usd",
+  ): Promise<HarnessEvent[]> {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              model: "openrouter/model",
+              choices: [{ message: { content: "done" }, finish_reason: "stop" }],
+              usage: { prompt_tokens: 2, completion_tokens: 3, cost },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const events = await collect(
+      createRawApiAdapter({ providerUsageCostUnit }).run(
+        HarnessRunSpec.parse({
+          session_id: "provider-cost",
+          intent: "review",
+          prompt: "x",
+          cwd: process.cwd(),
+          access: "readonly",
+          external_context_policy: "auto",
+          tool_permission_policy: { web: "auto", allow: [], deny: [] },
+        }),
+      ),
+    );
+    return events.map((event) => HarnessEvent.parse(event));
+  }
+
+  it.each([
+    ["a positive fractional receipt", 0.000_123],
+    ["an exact zero receipt", 0],
+  ])("emits %s as exact USD only for a trusted instance", async (_label, cost) => {
+    const events = await runWithProviderCost(cost, "usd");
+    const usageEvent = events.find((event) => event.type === "usage");
+
+    expect(events.map((event) => event.type)).toEqual(["started", "message", "usage", "completed"]);
+    expect(usageEvent).toMatchObject({
+      usage: { input_tokens: 2, output_tokens: 3, cost_usd: cost },
+      observed_model: "openrouter/model",
+    });
+    expect(usageEvent?.usage).not.toHaveProperty("estimated");
+  });
+
+  it("keeps the same provider extension untrusted on a generic instance", async () => {
+    const events = await runWithProviderCost(0.25);
+    const usageEvent = events.find((event) => event.type === "usage");
+
+    expect(usageEvent).toMatchObject({
+      usage: { input_tokens: 2, output_tokens: 3 },
+      observed_model: "openrouter/model",
+    });
+    expect(usageEvent?.usage).not.toHaveProperty("cost_usd");
+    expect(usageEvent?.usage).not.toHaveProperty("estimated");
+  });
+
+  it("still emits usage without fabricating zero when a trusted receipt is absent", async () => {
+    const events = await runWithProviderCost(undefined, "usd");
+    const usageEvent = events.find((event) => event.type === "usage");
+
+    expect(usageEvent).toMatchObject({
+      usage: { input_tokens: 2, output_tokens: 3 },
+      observed_model: "openrouter/model",
+    });
+    expect(usageEvent?.usage).not.toHaveProperty("cost_usd");
+  });
+
+  it("emits a cost-only usage receipt even when token counts are absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              model: "openrouter/model",
+              choices: [{ message: { content: "done" }, finish_reason: "stop" }],
+              usage: { cost: 0.75 },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      ),
+    );
+    const events = await collect(
+      createRawApiAdapter({ providerUsageCostUnit: "usd" }).run(
+        HarnessRunSpec.parse({
+          session_id: "provider-cost-only",
+          intent: "review",
+          prompt: "x",
+          cwd: process.cwd(),
+        }),
+      ),
+    );
+    const usageEvent = HarnessEvent.parse(events.find((event) => event.type === "usage"));
+
+    expect(usageEvent).toMatchObject({ usage: { cost_usd: 0.75 } });
+    expect(usageEvent?.usage?.input_tokens).toBeUndefined();
+    expect(usageEvent?.usage?.output_tokens).toBeUndefined();
+  });
+});
+
 // Release wave round-15 #5: the instance secret fence accepts only NAMESPACED
 // refs whose base belongs to the instance — a foreign provider's namespaced
 // slot must refuse typed before any secret read or network call.

--- a/packages/harness-raw-api/src/index.test.ts
+++ b/packages/harness-raw-api/src/index.test.ts
@@ -176,6 +176,8 @@ describe("raw-api provider cost receipts", () => {
   const ORIGINAL_ENV = { ...process.env };
 
   beforeEach(() => {
+    delete process.env.CLAUDEXOR_RAWAPI_KEY;
+    delete process.env.CLAUDEXOR_RAWAPI_BASE_URL;
     process.env.OPENAI_API_KEY = "sk-test";
   });
 
@@ -264,8 +266,8 @@ describe("raw-api provider cost receipts", () => {
     expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 
-  it("still emits usage without fabricating zero when a trusted receipt is absent", async () => {
-    const events = await runWithProviderCost(undefined, "usd");
+  it("ignores upstream inference cost when the trusted account receipt is absent", async () => {
+    const events = await runWithProviderCost(undefined, "usd", 99);
     const usageEvent = events.find((event) => event.type === "usage");
 
     expect(usageEvent).toStrictEqual({
@@ -781,6 +783,8 @@ describe("raw-api terminal provider completions", () => {
   };
 
   beforeEach(() => {
+    delete process.env.CLAUDEXOR_RAWAPI_KEY;
+    delete process.env.CLAUDEXOR_RAWAPI_BASE_URL;
     process.env.OPENAI_API_KEY = "sk-test";
   });
 
@@ -791,11 +795,14 @@ describe("raw-api terminal provider completions", () => {
 
   function responseFor(options: {
     content?: unknown;
-    finishReason?: string | null;
+    finishReason?: unknown;
     error?: unknown;
     model?: string;
     omitModel?: boolean;
     omitUsage?: boolean;
+    omitTokenCounts?: boolean;
+    cost?: unknown;
+    upstreamInferenceCost?: unknown;
   }): Response {
     return new Response(
       JSON.stringify({
@@ -807,7 +814,21 @@ describe("raw-api terminal provider completions", () => {
             ...(options.error === undefined ? {} : { error: options.error }),
           },
         ],
-        ...(options.omitUsage ? {} : { usage: { prompt_tokens: 7, completion_tokens: 3 } }),
+        ...(options.omitUsage
+          ? {}
+          : {
+              usage: {
+                ...(options.omitTokenCounts ? {} : { prompt_tokens: 7, completion_tokens: 3 }),
+                ...(options.cost === undefined ? {} : { cost: options.cost }),
+                ...(options.upstreamInferenceCost === undefined
+                  ? {}
+                  : {
+                      cost_details: {
+                        upstream_inference_cost: options.upstreamInferenceCost,
+                      },
+                    }),
+              },
+            }),
       }),
       { status: 200, headers: { "content-type": "application/json" } },
     );
@@ -886,6 +907,75 @@ describe("raw-api terminal provider completions", () => {
     expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
   });
 
+  it.each([
+    ["a positive receipt with tokens", 0.25, false],
+    ["an exact zero receipt with tokens", 0, false],
+    ["a positive cost-only receipt", 0.5, true],
+  ] as const)("preserves trusted terminal cost for %s", async (_label, cost, omitTokenCounts) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFor({ finishReason: "error", cost, omitTokenCounts })),
+    );
+
+    const events = await collect(
+      createRawApiAdapter({ providerUsageCostUnit: "usd" }).run(
+        runSpec("review", `trusted-terminal-${cost}-${omitTokenCounts}`),
+      ),
+    );
+    const usage = events.find((event) => event.type === "usage");
+
+    expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+    expect(events.some((event) => event.type === "message")).toBe(false);
+    expect(usage).toStrictEqual({
+      type: "usage",
+      session_id: `trusted-terminal-${cost}-${omitTokenCounts}`,
+      ts: expect.any(String),
+      usage: {
+        input_tokens: omitTokenCounts ? undefined : 7,
+        output_tokens: omitTokenCounts ? undefined : 3,
+        cost_usd: cost,
+      },
+      observed_model: "provider-model",
+    });
+    expect(usage?.usage).not.toHaveProperty("provider_cost");
+    expect(usage?.usage).not.toHaveProperty("estimated");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+  });
+
+  it("keeps terminal provider cost untrusted for a generic instance", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFor({ finishReason: "error", cost: 0.25 })),
+    );
+
+    const events = await collect(createRawApiAdapter().run(runSpec("review", "generic-terminal")));
+    const usage = events.find((event) => event.type === "usage");
+
+    expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+    expect(usage?.usage).toStrictEqual({ input_tokens: 7, output_tokens: 3 });
+    expect(usage?.usage).not.toHaveProperty("cost_usd");
+    expect(usage?.usage).not.toHaveProperty("provider_cost");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+  });
+
+  it("does not promote an upstream-only terminal cost to an account receipt", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFor({ finishReason: "error", upstreamInferenceCost: 99 })),
+    );
+
+    const events = await collect(
+      createRawApiAdapter({ providerUsageCostUnit: "usd" }).run(
+        runSpec("review", "upstream-only-terminal"),
+      ),
+    );
+    const usage = events.find((event) => event.type === "usage");
+
+    expect(usage?.usage).toStrictEqual({ input_tokens: 7, output_tokens: 3 });
+    expect(usage?.usage).not.toHaveProperty("cost_usd");
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+  });
+
   it.each(["implement", "synthesize"] as const)(
     "suppresses a valid partial patch on a terminal %s completion",
     async (intent) => {
@@ -895,6 +985,7 @@ describe("raw-api terminal provider completions", () => {
           responseFor({
             content: JSON.stringify({ patch }),
             finishReason: "error",
+            cost: 0.25,
             error: {
               code: 502,
               message: "Provider unavailable",
@@ -904,9 +995,16 @@ describe("raw-api terminal provider completions", () => {
         ),
       );
 
-      const events = await collect(createRawApiAdapter().run(runSpec(intent, `patch-${intent}`)));
+      const events = await collect(
+        createRawApiAdapter({ providerUsageCostUnit: "usd" }).run(
+          runSpec(intent, `patch-${intent}`),
+        ),
+      );
       expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
       expect(events.some((event) => event.type === "patch_produced")).toBe(false);
+      expect(events.find((event) => event.type === "usage")?.usage).toMatchObject({
+        cost_usd: 0.25,
+      });
       expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
     },
   );
@@ -1139,17 +1237,42 @@ describe("raw-api terminal provider completions", () => {
     },
   );
 
-  it("omits partial-output diagnostics when message content is not a string", async () => {
+  it("keeps finish_reason:length successful while preserving trusted cost", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => responseFor({ content: "done", finishReason: "length", cost: 0 })),
+    );
+
+    const events = await collect(
+      createRawApiAdapter({ providerUsageCostUnit: "usd" }).run(
+        runSpec("explain", "length-with-cost"),
+      ),
+    );
+
+    expect(events.map((event) => event.type)).toEqual(["started", "message", "usage", "completed"]);
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(events.find((event) => event.type === "usage")?.usage).toStrictEqual({
+      input_tokens: 7,
+      output_tokens: 3,
+      cost_usd: 0,
+    });
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+  });
+
+  it.each([
+    ["empty", ""],
+    ["rich", [{ type: "text", text: "rich content" }]],
+  ] as const)("omits partial-output diagnostics for %s message content", async (label, content) => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
         responseFor({
-          content: [{ type: "text", text: "rich content" }],
+          content,
           finishReason: "error",
         }),
       ),
     );
-    const events = await collect(createRawApiAdapter().run(runSpec("review", "rich-content")));
+    const events = await collect(createRawApiAdapter().run(runSpec("review", `${label}-content`)));
     const error = events.find((event) => event.type === "error");
     expect(error?.payload).not.toHaveProperty("partial_output");
     expect(error?.payload).not.toHaveProperty("partial_output_truncated");

--- a/packages/harness-raw-api/src/index.test.ts
+++ b/packages/harness-raw-api/src/index.test.ts
@@ -645,10 +645,12 @@ describe("raw-api terminal provider completions", () => {
     finishReason?: string | null;
     error?: unknown;
     model?: string;
+    omitModel?: boolean;
+    omitUsage?: boolean;
   }): Response {
     return new Response(
       JSON.stringify({
-        model: options.model ?? "provider-model",
+        ...(options.omitModel ? {} : { model: options.model ?? "provider-model" }),
         choices: [
           {
             message: { role: "assistant", content: options.content ?? "partial output" },
@@ -656,7 +658,7 @@ describe("raw-api terminal provider completions", () => {
             ...(options.error === undefined ? {} : { error: options.error }),
           },
         ],
-        usage: { prompt_tokens: 7, completion_tokens: 3 },
+        ...(options.omitUsage ? {} : { usage: { prompt_tokens: 7, completion_tokens: 3 } }),
       }),
       { status: 200, headers: { "content-type": "application/json" } },
     );
@@ -714,6 +716,26 @@ describe("raw-api terminal provider completions", () => {
       });
     },
   );
+
+  it("preserves terminal order and schema validity when model and usage are absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        responseFor({
+          finishReason: "error",
+          omitModel: true,
+          omitUsage: true,
+        }),
+      ),
+    );
+
+    const events = await collect(createRawApiAdapter().run(runSpec("review", "terminal-empty")));
+    expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+    expect(events.find((event) => event.type === "usage")?.usage).toEqual({});
+    expect(events.find((event) => event.type === "usage")?.observed_model).toBeUndefined();
+    expect(events.at(-1)?.observed_model).toBeUndefined();
+    expect(events.every((event) => HarnessEvent.safeParse(event).success)).toBe(true);
+  });
 
   it.each(["implement", "synthesize"] as const)(
     "suppresses a valid partial patch on a terminal %s completion",
@@ -871,8 +893,13 @@ describe("raw-api terminal provider completions", () => {
 
     const events = await collect(createRawApiAdapter().run(runSpec("review", "straddling-secret")));
     const error = events.find((event) => event.type === "error");
-    const partialOutput = (error?.payload as { partial_output?: string }).partial_output;
+    const payload = error?.payload as {
+      partial_output?: string;
+      partial_output_truncated?: boolean;
+    };
+    const partialOutput = payload.partial_output;
     expect(partialOutput).toBe(`${"p".repeat(480)} [redacted]`);
+    expect(payload.partial_output_truncated).toBe(false);
     expect(JSON.stringify(error)).not.toContain(secret);
   });
 
@@ -907,6 +934,31 @@ describe("raw-api terminal provider completions", () => {
       "completed",
     ]);
   });
+
+  it.each(["stop", "length"] as const)(
+    "gives a structurally valid choice error precedence over finish_reason:%s",
+    async (finishReason) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () =>
+          responseFor({
+            finishReason,
+            error: {
+              code: 502,
+              message: "Provider unavailable",
+              metadata: { error_type: "provider_unavailable" },
+            },
+          }),
+        ),
+      );
+
+      const events = await collect(
+        createRawApiAdapter().run(runSpec("review", `${finishReason}-with-choice-error`)),
+      );
+      expect(events.map((event) => event.type)).toEqual(["started", "error", "usage", "completed"]);
+      expect(events.some((event) => event.type === "message")).toBe(false);
+    },
+  );
 
   it.each(["stop", "length"] as const)(
     "keeps finish_reason:%s successful for both messages and patch envelopes",

--- a/packages/harness-raw-api/src/index.ts
+++ b/packages/harness-raw-api/src/index.ts
@@ -29,6 +29,7 @@ import {
   sha256,
 } from "@claudexor/util";
 import { parseChatCompletion, parseModelsList } from "./parse.js";
+import { isTerminalProviderCompletion, providerCompletionErrorEvent } from "./providerError.js";
 
 /** A stalled remote endpoint must not hang a run forever. */
 const RAW_API_TIMEOUT_MS = 180_000;
@@ -446,6 +447,26 @@ export function createRawApiAdapter(config: RawApiConfig = {}): HarnessAdapter {
         }
         const json = await res.json();
         const parsed = parseChatCompletion(json);
+        if (isTerminalProviderCompletion(parsed)) {
+          yield providerCompletionErrorEvent(id, spec.session_id, nowIso(), parsed);
+          yield {
+            type: "usage",
+            session_id: spec.session_id,
+            ts: nowIso(),
+            usage: {
+              input_tokens: parsed.usage.input_tokens,
+              output_tokens: parsed.usage.output_tokens,
+            },
+            observed_model: parsed.model ?? undefined,
+          };
+          yield {
+            type: "completed",
+            session_id: spec.session_id,
+            ts: nowIso(),
+            observed_model: parsed.model ?? undefined,
+          };
+          return;
+        }
         if (spec.intent === "implement" || spec.intent === "synthesize") {
           if (!spec.raw_context_packet) {
             yield {

--- a/packages/harness-raw-api/src/index.ts
+++ b/packages/harness-raw-api/src/index.ts
@@ -119,6 +119,11 @@ function buildPatchEnvelope(
 export interface RawApiConfig {
   id?: string;
   providerFamily?: ProviderFamily;
+  /**
+   * Declared unit for this endpoint's provider-reported `usage.cost`;
+   * absent leaves the extension untrusted.
+   */
+  providerUsageCostUnit?: "usd";
   baseUrl?: string;
   keyEnv?: string;
   defaultModel?: string;
@@ -132,6 +137,7 @@ export interface RawApiConfig {
 export function createRawApiAdapter(config: RawApiConfig = {}): HarnessAdapter {
   const id = config.id ?? "raw-api";
   const providerFamily = config.providerFamily ?? "openai";
+  const providerUsageCostUnit = config.providerUsageCostUnit;
   const baseUrl =
     config.baseUrl ?? process.env.CLAUDEXOR_RAWAPI_BASE_URL ?? "https://api.openai.com/v1";
   const keyEnv =
@@ -498,6 +504,9 @@ export function createRawApiAdapter(config: RawApiConfig = {}): HarnessAdapter {
           usage: {
             input_tokens: parsed.usage.input_tokens,
             output_tokens: parsed.usage.output_tokens,
+            ...(providerUsageCostUnit === "usd" && parsed.usage.provider_cost !== undefined
+              ? { cost_usd: parsed.usage.provider_cost }
+              : {}),
           },
           observed_model: parsed.model ?? undefined,
         };

--- a/packages/harness-raw-api/src/parse.test.ts
+++ b/packages/harness-raw-api/src/parse.test.ts
@@ -18,6 +18,110 @@ describe("parseChatCompletion", () => {
     expect(parseChatCompletion({}).text).toBe("");
     expect(parseChatCompletion({ choices: [] }).model).toBeNull();
   });
+
+  it("retains allowlisted terminal provider-error facts and string diagnostics", () => {
+    const result = parseChatCompletion({
+      model: "openrouter/model",
+      choices: [
+        {
+          message: { role: "assistant", content: "partial output" },
+          finish_reason: "error",
+          error: {
+            code: 502,
+            message: "Provider disconnected",
+            metadata: {
+              error_type: "provider_unavailable",
+              provider_code: "upstream_502",
+              flagged_input: "must not survive",
+            },
+            unknown: "must not survive either",
+          },
+        },
+      ],
+      usage: { prompt_tokens: 12, completion_tokens: 3 },
+    });
+
+    expect(result.finish_reason).toBe("error");
+    expect(result.diagnostic_text).toBe("partial output");
+    expect(result.provider_error).toEqual({
+      code: 502,
+      message: "Provider disconnected",
+      error_type: "provider_unavailable",
+      provider_code: "upstream_502",
+    });
+    expect(JSON.stringify(result.provider_error)).not.toContain("flagged_input");
+    expect(JSON.stringify(result.provider_error)).not.toContain("unknown");
+  });
+
+  it("keeps either terminal signal independently and rejects malformed choice errors", () => {
+    expect(
+      parseChatCompletion({
+        choices: [{ message: { content: "partial" }, finish_reason: "error" }],
+      }),
+    ).toMatchObject({ finish_reason: "error", provider_error: null });
+
+    expect(
+      parseChatCompletion({
+        choices: [
+          {
+            message: { content: "partial" },
+            error: {
+              code: 429,
+              message: "limited",
+              metadata: { error_type: "rate_limit_exceeded" },
+            },
+          },
+        ],
+      }),
+    ).toMatchObject({
+      finish_reason: null,
+      provider_error: {
+        code: 429,
+        message: "limited",
+        error_type: "rate_limit_exceeded",
+        provider_code: null,
+      },
+    });
+
+    for (const error of [
+      null,
+      "failed",
+      [],
+      { code: "502", message: "failed" },
+      { code: 502 },
+      { code: Number.NaN, message: "failed" },
+      { code: Number.POSITIVE_INFINITY, message: "failed" },
+    ]) {
+      expect(parseChatCompletion({ choices: [{ error }] }).provider_error).toBeNull();
+    }
+
+    expect(
+      parseChatCompletion({
+        choices: [
+          {
+            error: {
+              code: 502,
+              message: "failed",
+              metadata: { error_type: 42, provider_code: { raw: true } },
+            },
+          },
+        ],
+      }).provider_error,
+    ).toMatchObject({ error_type: null, provider_code: null });
+  });
+
+  it("retains stop/length as ordinary finish reasons and never stringifies rich content for diagnostics", () => {
+    expect(
+      parseChatCompletion({
+        choices: [
+          { message: { content: [{ type: "text", text: "rich" }] }, finish_reason: "length" },
+        ],
+      }),
+    ).toMatchObject({ finish_reason: "length", diagnostic_text: null });
+    expect(
+      parseChatCompletion({ choices: [{ message: { content: "done" }, finish_reason: "stop" }] }),
+    ).toMatchObject({ finish_reason: "stop", diagnostic_text: "done" });
+  });
 });
 
 describe("parseModelsList", () => {

--- a/packages/harness-raw-api/src/parse.test.ts
+++ b/packages/harness-raw-api/src/parse.test.ts
@@ -83,15 +83,7 @@ describe("parseChatCompletion", () => {
       },
     });
 
-    for (const error of [
-      null,
-      "failed",
-      [],
-      { code: "502", message: "failed" },
-      { code: 502 },
-      { code: Number.NaN, message: "failed" },
-      { code: Number.POSITIVE_INFINITY, message: "failed" },
-    ]) {
+    for (const error of [null, "failed", [], { code: "502", message: "failed" }, { code: 502 }]) {
       expect(parseChatCompletion({ choices: [{ error }] }).provider_error).toBeNull();
     }
 
@@ -121,6 +113,37 @@ describe("parseChatCompletion", () => {
     expect(
       parseChatCompletion({ choices: [{ message: { content: "done" }, finish_reason: "stop" }] }),
     ).toMatchObject({ finish_reason: "stop", diagnostic_text: "done" });
+  });
+
+  it.each([
+    ["-Number.MAX_VALUE", -Number.MAX_VALUE],
+    ["-1", -1],
+    ["-0", -0],
+    ["0", 0],
+    ["Number.MIN_VALUE", Number.MIN_VALUE],
+    ["0.5", 0.5],
+    ["Number.MAX_VALUE", Number.MAX_VALUE],
+  ] as const)("accepts finite provider error code %s with an empty message", (_label, code) => {
+    const providerError = parseChatCompletion({
+      choices: [{ error: { code, message: "" } }],
+    }).provider_error;
+
+    expect(providerError?.code).toBe(code);
+    expect(providerError).toMatchObject({
+      message: "",
+      error_type: null,
+      provider_code: null,
+    });
+  });
+
+  it.each([
+    ["Number.NEGATIVE_INFINITY", Number.NEGATIVE_INFINITY],
+    ["Number.NaN", Number.NaN],
+    ["Number.POSITIVE_INFINITY", Number.POSITIVE_INFINITY],
+  ] as const)("rejects non-finite provider error code %s", (_label, code) => {
+    expect(
+      parseChatCompletion({ choices: [{ error: { code, message: "" } }] }).provider_error,
+    ).toBeNull();
   });
 });
 

--- a/packages/harness-raw-api/src/parse.test.ts
+++ b/packages/harness-raw-api/src/parse.test.ts
@@ -112,7 +112,14 @@ describe("parseChatCompletion", () => {
       },
     });
 
-    for (const error of [null, "failed", [], { code: "502", message: "failed" }, { code: 502 }]) {
+    for (const error of [
+      null,
+      "failed",
+      [],
+      { code: "502", message: "failed" },
+      { code: 502 },
+      { code: 502, message: 42 },
+    ]) {
       expect(parseChatCompletion({ choices: [{ error }] }).provider_error).toBeNull();
     }
 
@@ -142,6 +149,12 @@ describe("parseChatCompletion", () => {
     expect(
       parseChatCompletion({ choices: [{ message: { content: "done" }, finish_reason: "stop" }] }),
     ).toMatchObject({ finish_reason: "stop", diagnostic_text: "done" });
+    expect(
+      parseChatCompletion({ choices: [{ message: { content: "" }, finish_reason: "error" }] }),
+    ).toMatchObject({ finish_reason: "error", diagnostic_text: "" });
+    expect(
+      parseChatCompletion({ choices: [{ message: { content: "done" }, finish_reason: 42 }] }),
+    ).toMatchObject({ finish_reason: null, diagnostic_text: "done" });
   });
 
   it.each([

--- a/packages/harness-raw-api/src/parse.test.ts
+++ b/packages/harness-raw-api/src/parse.test.ts
@@ -14,6 +14,35 @@ describe("parseChatCompletion", () => {
     expect(r.usage.output_tokens).toBe(34);
   });
 
+  it.each([
+    ["a positive fractional receipt", 0.000_123, 0.000_123],
+    ["an exact zero receipt", 0, 0],
+  ])("preserves %s as a neutral provider cost", (_label, cost, expected) => {
+    const r = parseChatCompletion({
+      model: "openrouter/model",
+      choices: [{ message: { content: "done" } }],
+      usage: { prompt_tokens: 2, completion_tokens: 3, cost },
+    });
+
+    expect(r).toMatchObject({
+      text: "done",
+      model: "openrouter/model",
+      usage: { input_tokens: 2, output_tokens: 3, provider_cost: expected },
+    });
+  });
+
+  it.each([undefined, "0.12", -1, Number.NaN, Number.POSITIVE_INFINITY, null])(
+    "does not preserve an invalid provider cost (%s)",
+    (cost) => {
+      const r = parseChatCompletion({
+        choices: [{ message: { content: "done" } }],
+        usage: { prompt_tokens: 2, completion_tokens: 3, cost },
+      });
+
+      expect(r.usage).toEqual({ input_tokens: 2, output_tokens: 3 });
+    },
+  );
+
   it("handles empty/malformed responses gracefully", () => {
     expect(parseChatCompletion({}).text).toBe("");
     expect(parseChatCompletion({ choices: [] }).model).toBeNull();

--- a/packages/harness-raw-api/src/parse.ts
+++ b/packages/harness-raw-api/src/parse.ts
@@ -1,7 +1,17 @@
 export interface ChatResult {
   text: string;
+  diagnostic_text: string | null;
+  finish_reason: string | null;
+  provider_error: ParsedProviderError | null;
   model: string | null;
   usage: { input_tokens?: number; output_tokens?: number };
+}
+
+export interface ParsedProviderError {
+  code: number;
+  message: string;
+  error_type: string | null;
+  provider_code: string | null;
 }
 
 export interface ParsedModel {
@@ -34,15 +44,38 @@ export function parseModelsList(json: any): ParsedModel[] {
 /** Parse an OpenAI-compatible /chat/completions response. */
 export function parseChatCompletion(json: any): ChatResult {
   const choice = json?.choices?.[0];
-  const text = String(choice?.message?.content ?? "");
+  const content = choice?.message?.content;
+  const text = String(content ?? "");
   const usage = json?.usage ?? {};
   return {
     text,
+    diagnostic_text: typeof content === "string" ? content : null,
+    finish_reason: typeof choice?.finish_reason === "string" ? choice.finish_reason : null,
+    provider_error: parseProviderError(choice?.error),
     model: typeof json?.model === "string" ? json.model : null,
     usage: {
       input_tokens: typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : undefined,
       output_tokens:
         typeof usage.completion_tokens === "number" ? usage.completion_tokens : undefined,
     },
+  };
+}
+
+function parseProviderError(value: unknown): ParsedProviderError | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const error = value as Record<string, unknown>;
+  if (typeof error["code"] !== "number" || !Number.isFinite(error["code"])) return null;
+  if (typeof error["message"] !== "string") return null;
+
+  const metadata =
+    error["metadata"] && typeof error["metadata"] === "object" && !Array.isArray(error["metadata"])
+      ? (error["metadata"] as Record<string, unknown>)
+      : null;
+  return {
+    code: error["code"],
+    message: error["message"],
+    error_type: typeof metadata?.["error_type"] === "string" ? metadata["error_type"] : null,
+    provider_code:
+      typeof metadata?.["provider_code"] === "string" ? metadata["provider_code"] : null,
   };
 }

--- a/packages/harness-raw-api/src/parse.ts
+++ b/packages/harness-raw-api/src/parse.ts
@@ -1,7 +1,7 @@
 export interface ChatResult {
   text: string;
   model: string | null;
-  usage: { input_tokens?: number; output_tokens?: number };
+  usage: { input_tokens?: number; output_tokens?: number; provider_cost?: number };
 }
 
 export interface ParsedModel {
@@ -36,6 +36,10 @@ export function parseChatCompletion(json: any): ChatResult {
   const choice = json?.choices?.[0];
   const text = String(choice?.message?.content ?? "");
   const usage = json?.usage ?? {};
+  const providerCost =
+    typeof usage.cost === "number" && Number.isFinite(usage.cost) && usage.cost >= 0
+      ? usage.cost
+      : undefined;
   return {
     text,
     model: typeof json?.model === "string" ? json.model : null,
@@ -43,6 +47,7 @@ export function parseChatCompletion(json: any): ChatResult {
       input_tokens: typeof usage.prompt_tokens === "number" ? usage.prompt_tokens : undefined,
       output_tokens:
         typeof usage.completion_tokens === "number" ? usage.completion_tokens : undefined,
+      ...(providerCost === undefined ? {} : { provider_cost: providerCost }),
     },
   };
 }

--- a/packages/harness-raw-api/src/providerError.ts
+++ b/packages/harness-raw-api/src/providerError.ts
@@ -1,0 +1,72 @@
+import type { HarnessEvent } from "@claudexor/schema";
+import { redactSecrets } from "@claudexor/util";
+import type { ChatResult } from "./parse.js";
+
+const PROVIDER_DIAGNOSTIC_MAX_CHARS = 500;
+const SERVICE_UNAVAILABLE_ERROR_TYPES = new Set([
+  "provider_overloaded",
+  "provider_unavailable",
+  "server",
+]);
+
+/** An explicit terminal marker or a structurally valid choice error is authoritative. */
+export function isTerminalProviderCompletion(result: ChatResult): boolean {
+  return result.finish_reason === "error" || result.provider_error !== null;
+}
+
+/** Build the adapter-authored terminal event without persisting raw provider metadata. */
+export function providerCompletionErrorEvent(
+  id: string,
+  sessionId: string,
+  ts: string,
+  result: ChatResult,
+): HarnessEvent {
+  const payload: Record<string, unknown> = {};
+  if (result.finish_reason !== null) {
+    payload["finish_reason"] = redactAndBound(result.finish_reason).value;
+  }
+  if (result.provider_error) {
+    const providerError: Record<string, unknown> = {
+      code: result.provider_error.code,
+      message: redactAndBound(result.provider_error.message).value,
+    };
+    if (result.provider_error.error_type !== null) {
+      providerError["error_type"] = redactAndBound(result.provider_error.error_type).value;
+    }
+    if (result.provider_error.provider_code !== null) {
+      providerError["provider_code"] = redactAndBound(result.provider_error.provider_code).value;
+    }
+    payload["provider_error"] = providerError;
+  }
+  if (result.diagnostic_text) {
+    const partialOutput = redactAndBound(result.diagnostic_text);
+    payload["partial_output"] = partialOutput.value;
+    payload["partial_output_truncated"] = partialOutput.truncated;
+  }
+
+  const event: HarnessEvent = {
+    type: "error",
+    session_id: sessionId,
+    ts,
+    error: `${id} provider completion failed`,
+    payload,
+  };
+  const errorType = result.provider_error?.error_type;
+  if (errorType === "rate_limit_exceeded") {
+    event.rate_limit = { resets_at: null, retry_delay_ms: null };
+    event.transient = { kind: "service_unavailable", retry_delay_ms: null };
+  } else if (errorType && SERVICE_UNAVAILABLE_ERROR_TYPES.has(errorType)) {
+    event.transient = { kind: "service_unavailable", retry_delay_ms: null };
+  } else if (errorType === "timeout") {
+    event.transient = { kind: "timeout", retry_delay_ms: null };
+  }
+  return event;
+}
+
+function redactAndBound(value: string): { value: string; truncated: boolean } {
+  const redacted = redactSecrets(value);
+  return {
+    value: redacted.slice(0, PROVIDER_DIAGNOSTIC_MAX_CHARS),
+    truncated: redacted.length > PROVIDER_DIAGNOSTIC_MAX_CHARS,
+  };
+}

--- a/packages/orchestrator/src/attemptUsage.test.ts
+++ b/packages/orchestrator/src/attemptUsage.test.ts
@@ -5,6 +5,8 @@ import {
   AttemptPostStreamError,
   attemptFailureCost,
   attemptFailureRecord,
+  newAttemptUsageCost,
+  observeAttemptUsageEvent,
   settleGrantedAttemptLease,
   withAttemptFailureCost,
 } from "./attemptUsageCost.js";
@@ -210,6 +212,58 @@ describe("processAttemptUsage", () => {
       ),
     );
     expect(ledger.spend()).toBe(0.37);
+    expect(ledger.terminal()).toBeNull();
+  });
+
+  it("settles an explicit zero-cost managed API receipt with exact cash knowledge", () => {
+    const usageCost = newAttemptUsageCost();
+    const ts = new Date().toISOString();
+    let authMode: "local_session" | "api_key" | null = null;
+
+    authMode = observeAttemptUsageEvent(
+      usageCost,
+      {
+        type: "started",
+        session_id: "s",
+        ts,
+        credential_route: "managed_api_key",
+      },
+      authMode,
+    );
+    authMode = observeAttemptUsageEvent(
+      usageCost,
+      {
+        type: "usage",
+        session_id: "s",
+        ts,
+        credential_route: "managed_api_key",
+        usage: { cost_usd: 0 },
+      },
+      authMode,
+    );
+    authMode = observeAttemptUsageEvent(
+      usageCost,
+      { type: "completed", session_id: "s", ts },
+      authMode,
+    );
+
+    expect(usageCost.cashUsd).toBe(0);
+    expect(usageCost.cashEstimated).toBe(false);
+    expect(usageCost.cashKnowledge).toBe("exact");
+
+    const settlement = attemptUsageCostSettlement(0, false, "a01", "raw-api", authMode, usageCost);
+    expect(settlement.cashUsd).toBe(0);
+    expect(settlement.cashKnowledge).toBe("exact");
+
+    const ledger = new BudgetLedger({ kind: "finite", maxUsd: 1 });
+    const lease = ledger.reserve({
+      taskId: "exact-zero-api-receipt",
+      intent: "explain",
+      harnessId: "raw-api",
+    }).lease!;
+    ledger.settle(lease.lease_id, settlement);
+
+    expect(ledger.spend()).toBe(0);
     expect(ledger.terminal()).toBeNull();
   });
 


### PR DESCRIPTION
OpenRouter raw-api runs now preserve a finite non-negative usage.cost, including zero, as an exact USD account charge receipt. Generic raw-api instances continue to treat provider cost as unknown, and cost_details.upstream_inference_cost is not promoted to an account charge.

HTTP 200 completions with finish_reason: "error" or a structurally valid choice error now fail before any message or patch can be accepted. They emit a bounded, redacted typed error followed by usage and completed events, while ordinary stop and length completions remain successful.

Validated locally with the full Node and Swift suites: 288 Vitest files with 3,694 tests and 919 Swift tests, plus builds, type checks, formatting, generated-artifact checks, and focused raw-api regression coverage.

Fixes #134
Fixes #144
