### PR TITLE
Allow journal-heavy daemon cold starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Release history for Claudexor. The current version is declared in the root
 `package.json` (the version SSOT); tags `v*` correspond to GitHub Releases.
 
-- **v3.3.16** (2026-08-14) — The macOS packager now removes the exact
+- **v3.3.16** (2026-08-15) — The macOS packager now removes the exact
   pre-3.3.13 `dist/Claudexor.app` only after a successful Swift build produces
   the release executable; failed or incomplete builds preserve both app paths,
   and unrelated `dist` content survives. Data-root ownership is now explicit by
@@ -17,7 +17,9 @@ Release history for Claudexor. The current version is declared in the root
   results as denied. The built-in OpenRouter route now preserves finite
   non-negative `usage.cost`, including zero, as an exact USD receipt; explicit
   terminal provider-error completions fail with safe typed evidence, while
-  ordinary stop and length completions remain successful.
+  ordinary stop and length completions remain successful. Cold daemon starts
+  now wait up to 90 seconds for large journals instead of reporting failure
+  after 15 seconds while initialization continues in the background.
 
 - **v3.3.15** (2026-08-10) — Mutating delegated codex runs work again on
   macOS. Codex canonicalizes its `CODEX_HOME` at startup, and the Seatbelt

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalDaemonReconciler.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalDaemonReconciler.swift
@@ -1,5 +1,12 @@
 import Foundation
 
+@usableFromInline
+enum LocalDaemonBootPolicy {
+    /// A large recovered journal can keep the daemon below handshake readiness
+    /// for more than 30 seconds even though startup is making healthy progress.
+    @usableFromInline static let handshakeTimeout: TimeInterval = 90
+}
+
 enum LocalDaemonReconciliationDeferral: Sendable, Equatable {
     case busy
     case activityUnknown
@@ -106,7 +113,7 @@ actor LocalDaemonReconciler {
             DaemonLauncher.resolvedRuntime()
         },
         handshakePollInterval: TimeInterval = 0.5,
-        handshakePollTimeout: TimeInterval = 30
+        handshakePollTimeout: TimeInterval = LocalDaemonBootPolicy.handshakeTimeout
     ) {
         self.daemon = daemon
         self.lifecycleOwner = lifecycleOwner

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/RuntimeInstallCoordinator.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/RuntimeInstallCoordinator.swift
@@ -149,7 +149,7 @@ public actor RuntimeInstallCoordinator {
         lifecycleOwner: LocalRuntimeLifecycleOwner,
         rollbackSelection: @escaping @Sendable () -> LocalRuntimeClosureSelection? = { nil },
         handshakePollInterval: TimeInterval = 0.5,
-        handshakePollTimeout: TimeInterval = 30,
+        handshakePollTimeout: TimeInterval = LocalDaemonBootPolicy.handshakeTimeout,
         onPhase: @escaping @Sendable (RuntimeInstallPhase) -> Void = { _ in }
     ) {
         self.installer = installer

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonReconcilerTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonReconcilerTests.swift
@@ -100,6 +100,10 @@ private final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked S
     private let old = RuntimeClosureIdentity(version: "3.1.2", buildSha: String(repeating: "a", count: 40))
     private let target = RuntimeClosureIdentity(version: "3.2.0", buildSha: String(repeating: "b", count: 40))
 
+    @Test func bootPolicyCoversJournalHeavyColdStarts() {
+        #expect(LocalDaemonBootPolicy.handshakeTimeout == 90)
+    }
+
     private func reconciler(
         _ daemon: ReconciliationDaemonStub,
         lifecycleOwner: LocalRuntimeLifecycleOwner = LocalRuntimeLifecycleOwner(),

--- a/packages/cli/src/daemon-run.test.ts
+++ b/packages/cli/src/daemon-run.test.ts
@@ -9,12 +9,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CliError } from "./cli-error.js";
 import { ENGINE_STOP_REMEDY, observedEngineSkew, recordEngineSkew } from "./engine-skew.js";
 import {
+  DAEMON_START_READY_TIMEOUT_MS,
   connectDaemonIfRunning,
   daemonOutcomeSummary,
   ensureDaemon,
   enqueueAndAwait,
   exitCodeForState,
   mergeDaemonRunOutcome,
+  waitForDaemonReady,
 } from "./daemon-run.js";
 
 afterEach(() => vi.unstubAllGlobals());
@@ -403,6 +405,7 @@ describe("absence vs refusal discrimination (#93)", () => {
   });
 
   afterEach(async () => {
+    vi.useRealTimers();
     if (socketServer) await new Promise<void>((r) => socketServer!.close(() => r()));
     if (httpServer) await new Promise<void>((r) => httpServer!.close(() => r()));
     socketServer = null;
@@ -430,6 +433,20 @@ describe("absence vs refusal discrimination (#93)", () => {
 
   it("connectDaemonIfRunning: absence (no daemon at all) is null, never a spawn", async () => {
     expect(await connectDaemonIfRunning()).toBeNull();
+  });
+
+  it("waitForDaemonReady: the default budget covers a journal-heavy cold start", async () => {
+    vi.useFakeTimers();
+    let settled = false;
+    const pending = waitForDaemonReady().finally(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(DAEMON_START_READY_TIMEOUT_MS - 15_000);
+    expect(await pending).toBeNull();
   });
 
   it("connectDaemonIfRunning: healthz connect-refused is null and clears the skew record", async () => {

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -26,6 +26,12 @@ export { projectRunOutcomeFacts, mergeDaemonRunOutcome } from "./daemon-outcome.
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+// A real journal-heavy default data root can spend tens of seconds replaying
+// and recovering before the socket and control API are ready. Both explicit
+// `daemon start` and acting-command auto-start use this one bounded budget so
+// neither reports a false failure while the detached daemon is still starting.
+export const DAEMON_START_READY_TIMEOUT_MS = 90_000;
+
 /** Is something accepting on the daemon socket right now? (cheap reachability probe). */
 async function daemonReachable(client: DaemonClientType): Promise<boolean> {
   return client.health().then(
@@ -74,7 +80,7 @@ async function controlApiReachable(): Promise<{
  * race to a foreign daemon (macOS app relaunch) this CLI then handshakes (#93).
  */
 export async function ensureDaemon(
-  timeoutMs = 30_000,
+  timeoutMs = DAEMON_START_READY_TIMEOUT_MS,
 ): Promise<{ client: DaemonClientType; addr: ControlApiAddress; engine: EngineIdentity }> {
   const token = ensureToken();
   const socketPath = defaultSocketPath();
@@ -164,7 +170,7 @@ export async function connectDaemonIfRunning(): Promise<{
  * propagates — waiting cannot fix an incompatible daemon (#93).
  */
 export async function waitForDaemonReady(
-  timeoutMs = 15_000,
+  timeoutMs = DAEMON_START_READY_TIMEOUT_MS,
 ): Promise<{ client: DaemonClientType; addr: ControlApiAddress } | null> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -42,7 +42,7 @@ import {
   printUsageError,
   statusGlyph,
 } from "./cli-io.js";
-import { ensureDaemon, waitForDaemonReady } from "./daemon-run.js";
+import { DAEMON_START_READY_TIMEOUT_MS, ensureDaemon, waitForDaemonReady } from "./daemon-run.js";
 import { controlApiFetch } from "./live.js";
 import { streamDurableCodexLogin, terminalLoginFallback } from "./setup-login-inline.js";
 
@@ -131,14 +131,14 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
     // Block until the daemon (socket + control API) is actually ready, so a
     // follow-up `status`/run can't race the spawn. Fail loudly (exit 1) if it
     // never comes up.
-    const ready = await waitForDaemonReady(15_000);
+    const ready = await waitForDaemonReady(DAEMON_START_READY_TIMEOUT_MS);
     if (json) {
       printJson({ pid: child.pid ?? null, socket: defaultSocketPath(), ready: ready !== null });
     } else if (ready) {
       print(`claudexord ready (pid ${child.pid}); socket ${defaultSocketPath()}`);
     } else {
       print(
-        `claudexord started (pid ${child.pid}) but did not become ready within 15s; check \`claudexor daemon logs\``,
+        `claudexord started (pid ${child.pid}) but did not become ready within ${Math.round(DAEMON_START_READY_TIMEOUT_MS / 1000)}s; check \`claudexor daemon logs\``,
       );
     }
     return ready ? 0 : 1;


### PR DESCRIPTION
A journal-heavy default data root consistently needed about 50 seconds to finish daemon recovery and become ready. The explicit start command gave up after 15 seconds, acting-command auto-start gave up after 30 seconds, and the macOS runtime handoff used the same too-short 30-second window even though the detached daemon continued starting normally.

This gives fresh daemon starts one shared 90-second readiness budget across the CLI and both macOS runtime handoff paths. The short settle window for an already-live daemon is unchanged.

Validated with the focused CLI tests, LocalDaemonReconcilerTests, RuntimeInstallCoordinatorTests, CLI typecheck and build, docs:check, release workflow checks, and formatting. The unrelated full-gate timeout also passed immediately when rerun in isolation.
