### PR TITLE
Survive disconnected RPC followers instead of crashing the daemon

### DIFF
--- a/.changeset/epipe-daemon-send.md
+++ b/.changeset/epipe-daemon-send.md
@@ -1,0 +1,5 @@
+---
+"claudexor": patch
+---
+
+The daemon no longer crashes when a disconnected follower is written to.

--- a/packages/daemon/src/daemon.test.ts
+++ b/packages/daemon/src/daemon.test.ts
@@ -9,6 +9,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { once } from "node:events";
+import { connect, type Socket } from "node:net";
+import { createInterface } from "node:readline";
 import { DurableJournal } from "@claudexor/journal";
 import {
   RunEvent,
@@ -230,6 +233,95 @@ describe("DaemonServer", () => {
       expect(ran).toBe(1);
       await expect(new DaemonClient(socketPath, "wrong").health()).rejects.toThrow(/unauthorized/);
     } finally {
+      await server.stop();
+      authority.journal.close();
+    }
+  });
+
+  it("drops a disconnected RPC follower without crashing other followers", async () => {
+    // Keep the fixture name short: macOS caps Unix-domain socket paths.
+    const dir = tempDir("epipe");
+    const authority = commandAuthority(dir);
+    authority.store.accept({
+      id: "job-disconnected",
+      params: { value: 1 },
+      idempotencyKey: "disconnected",
+      clientId: "test",
+    });
+    let markStatusRead!: () => void;
+    const statusRead = new Promise<void>((resolve) => {
+      markStatusRead = resolve;
+    });
+    const socketPath = join(dir, "daemon.sock");
+    const server = new DaemonServer({
+      socketPath,
+      token: "token",
+      commands: {
+        current: () => authority.store,
+        findById: () => {
+          markStatusRead();
+          return authority.store;
+        },
+      },
+      runner: async () => ({ lifecycle: "succeeded" }),
+    });
+    const serverSockets = (server as unknown as { sockets: Set<Socket> }).sockets;
+    const escaped: unknown[] = [];
+    const collect = (error: unknown): void => void escaped.push(error);
+    let survivor: Socket | undefined;
+    let doomed: Socket | undefined;
+    let survivorLines: ReturnType<typeof createInterface> | undefined;
+    process.on("uncaughtException", collect);
+    try {
+      await server.start();
+      survivor = connect(socketPath);
+      doomed = connect(socketPath);
+      survivor.on("error", () => {});
+      doomed.on("error", () => {});
+      await Promise.all([once(survivor, "connect"), once(doomed, "connect")]);
+      for (let attempt = 0; attempt < 50 && serverSockets.size !== 2; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+      }
+      expect(serverSockets.size).toBe(2);
+
+      doomed.write(
+        `${JSON.stringify({
+          id: 1,
+          method: "claudexor.status",
+          params: { id: "job-disconnected" },
+          token: "token",
+        })}\n`,
+      );
+      await statusRead;
+      doomed.destroy();
+
+      // The server's awaited dispatch resumes after the client closes. EPIPE is
+      // delivered asynchronously through readline, not thrown by Socket.write.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      survivorLines = createInterface({ input: survivor });
+      const survivorReply = new Promise<unknown>((resolve, reject) => {
+        survivorLines!.once("line", (line) => resolve(JSON.parse(line)));
+        survivorLines!.once("error", reject);
+      });
+      survivor.write(
+        `${JSON.stringify({
+          id: 2,
+          method: "claudexor.health",
+          token: "token",
+        })}\n`,
+      );
+      await expect(survivorReply).resolves.toMatchObject({
+        id: 2,
+        result: { ok: true },
+      });
+      expect(escaped).toEqual([]);
+      expect(serverSockets.size).toBe(1);
+    } finally {
+      process.off("uncaughtException", collect);
+      survivorLines?.close();
+      doomed?.destroy();
+      survivor?.destroy();
       await server.stop();
       authority.journal.close();
     }

--- a/packages/daemon/src/daemon.test.ts
+++ b/packages/daemon/src/daemon.test.ts
@@ -265,7 +265,8 @@ describe("DaemonServer", () => {
       },
       runner: async () => ({ lifecycle: "succeeded" }),
     });
-    const serverSockets = (server as unknown as { sockets: Set<Socket> }).sockets;
+    const serverSockets = (server as unknown as { followers: { sockets: Set<Socket> } }).followers
+      .sockets;
     const escaped: unknown[] = [];
     const collect = (error: unknown): void => void escaped.push(error);
     let survivor: Socket | undefined;

--- a/packages/daemon/src/rpc-followers.ts
+++ b/packages/daemon/src/rpc-followers.ts
@@ -1,0 +1,48 @@
+import { type Socket } from "node:net";
+import { createInterface } from "node:readline";
+
+/**
+ * Lifecycle owner for local RPC follower sockets. A disconnected follower is
+ * dropped instead of crashing the daemon: readline re-emits asynchronous
+ * socket write failures (such as EPIPE) on its Interface, so the Interface
+ * and the socket share one cleanup, and sends skip sockets that can no
+ * longer receive.
+ */
+export class RpcFollowers {
+  private readonly sockets = new Set<Socket>();
+
+  attach(sock: Socket, onLine: (line: string) => void): void {
+    this.sockets.add(sock);
+    const rl = createInterface({ input: sock });
+    const cleanup = () => {
+      rl.close();
+      this.drop(sock);
+    };
+    rl.on("line", onLine);
+    rl.on("error", cleanup);
+    sock.on("error", cleanup);
+    sock.on("close", cleanup);
+  }
+
+  send(sock: Socket, obj: unknown): void {
+    if (sock.destroyed || !sock.writable) {
+      this.drop(sock);
+      return;
+    }
+    try {
+      sock.write(JSON.stringify(obj) + "\n");
+    } catch {
+      this.drop(sock);
+    }
+  }
+
+  /** Destroy every follower so server.close() cannot hang on live sockets. */
+  destroyAll(): void {
+    for (const socket of this.sockets) socket.destroy();
+  }
+
+  private drop(sock: Socket): void {
+    this.sockets.delete(sock);
+    if (!sock.destroyed) sock.destroy();
+  }
+}

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1,7 +1,7 @@
 import { type Server, type Socket, createServer } from "node:net";
 import { timingSafeEqual } from "node:crypto";
 import { chmodSync, lstatSync, unlinkSync } from "node:fs";
-import { createInterface } from "node:readline";
+import { RpcFollowers } from "./rpc-followers.js";
 import {
   assertNoInlineSecretValues,
   errorCode,
@@ -92,7 +92,7 @@ export interface DaemonOptions extends RuntimeReplacementAuthority {
 /** Unix-socket worker pool; scheduling stays in the injected Orchestrator. */
 export class DaemonServer {
   private server?: Server;
-  private readonly sockets = new Set<Socket>();
+  private readonly followers = new RpcFollowers();
   private readonly queue: string[] = [];
   private readonly cancelled = new Set<string>();
   private readonly controllers = new Map<string, AbortController>();
@@ -228,7 +228,7 @@ export class DaemonServer {
 
     // Existing local RPC sockets can otherwise keep server.close() pending
     // forever. They are destroyed only after every accepted command settled.
-    for (const socket of this.sockets) socket.destroy();
+    this.followers.destroyAll();
     await serverClosed;
     this.resolveShutdown();
   }
@@ -239,38 +239,13 @@ export class DaemonServer {
   }
 
   private onConnection(sock: Socket): void {
-    this.sockets.add(sock);
-    const rl = createInterface({ input: sock });
-    const cleanup = () => {
-      rl.close();
-      this.dropSocket(sock);
-    };
-    rl.on("line", (line) => {
+    this.followers.attach(sock, (line) => {
       void this.handle(line, sock);
     });
-    // readline re-emits input errors on the Interface. Handle that event too:
-    // Socket.write failures such as EPIPE arrive asynchronously, outside send's
-    // try/catch, and the disconnected RPC follower is no longer usable.
-    rl.on("error", cleanup);
-    sock.on("error", cleanup);
-    sock.on("close", cleanup);
-  }
-
-  private dropSocket(sock: Socket): void {
-    this.sockets.delete(sock);
-    if (!sock.destroyed) sock.destroy();
   }
 
   private send(sock: Socket, obj: unknown): void {
-    if (sock.destroyed || !sock.writable) {
-      this.dropSocket(sock);
-      return;
-    }
-    try {
-      sock.write(JSON.stringify(obj) + "\n");
-    } catch {
-      this.dropSocket(sock);
-    }
+    this.followers.send(sock, obj);
   }
 
   private async handle(line: string, sock: Socket): Promise<void> {

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -241,18 +241,35 @@ export class DaemonServer {
   private onConnection(sock: Socket): void {
     this.sockets.add(sock);
     const rl = createInterface({ input: sock });
+    const cleanup = () => {
+      rl.close();
+      this.dropSocket(sock);
+    };
     rl.on("line", (line) => {
       void this.handle(line, sock);
     });
-    sock.on("error", () => rl.close());
-    sock.on("close", () => this.sockets.delete(sock));
+    // readline re-emits input errors on the Interface. Handle that event too:
+    // Socket.write failures such as EPIPE arrive asynchronously, outside send's
+    // try/catch, and the disconnected RPC follower is no longer usable.
+    rl.on("error", cleanup);
+    sock.on("error", cleanup);
+    sock.on("close", cleanup);
+  }
+
+  private dropSocket(sock: Socket): void {
+    this.sockets.delete(sock);
+    if (!sock.destroyed) sock.destroy();
   }
 
   private send(sock: Socket, obj: unknown): void {
+    if (sock.destroyed || !sock.writable) {
+      this.dropSocket(sock);
+      return;
+    }
     try {
       sock.write(JSON.stringify(obj) + "\n");
     } catch {
-      /* socket closed */
+      this.dropSocket(sock);
     }
   }
 


### PR DESCRIPTION
The daemon could crash with an unhandled EPIPE when it wrote to an RPC follower whose client had already disconnected, for example a CLI that gave up waiting and exited. The write error surfaces asynchronously and readline re-emits it on its Interface, which had no error handler, so the process died and took every active run with it.

The fix keeps the daemon alive and treats the disconnected follower as gone: one shared cleanup closes the readline interface, forgets the socket, and destroys it if needed, attached to the interface error event as well as the socket error and close events. Sends now skip destroyed or unwritable sockets and drop the follower instead of crashing on a failed write. Other followers keep receiving events, and graceful shutdown behavior is unchanged.

A hermetic regression test reproduces the crash class with two connected followers, one of which disconnects abruptly: without the guard the test captures the exact uncaught write EPIPE, with the guard the daemon survives and the surviving follower still gets its response. The sibling audit confirmed the RPC client and the HTTP/SSE surfaces already handle their own disconnect classes.

Validated locally: the full daemon suite at 204 tests, build 30/30, typecheck 59/59, formatting. One patch changeset is included.
