### PR TITLE
Two-stage daemon startup with root authority and in-process recovery reopen

### DIFF
--- a/.changeset/issue-165-shared-root-recovery.md
+++ b/.changeset/issue-165-shared-root-recovery.md
@@ -1,0 +1,5 @@
+---
+"claudexor": minor
+---
+
+Protect shared data roots with a persistent root-authority barrier (writer epoch + proven serving-version floor) and start the daemon in two stages: transport comes up recovery-only with product routes typed-refused, destructive recovery runs only after the read-only journal verdict and floor advance, and the handshake reports servingMode so the macOS app keeps Connecting instead of adopting a recovering daemon. Pre-fix runtimes can no longer seize a fixed root or reap live runs before journal readiness.

--- a/.changeset/zombie-writer-lease-recovery.md
+++ b/.changeset/zombie-writer-lease-recovery.md
@@ -1,0 +1,5 @@
+---
+"claudexor": patch
+---
+
+Recover automatically from Linux zombie daemon writer leases while keeping live or uncertain owners fail-closed and fencing concurrent stale takeovers by lease generation.

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+ConnectionHydration.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+ConnectionHydration.swift
@@ -1,0 +1,79 @@
+import Foundation
+import ClaudexorKit
+
+// MARK: - Connection-bound projection hydration
+
+// These owners capture both the exact gateway and its generation before I/O.
+// A manual reconnect can therefore retire a delayed success or failure without
+// allowing the previous daemon to repaint the successor's projections.
+extension AppModel {
+    func refreshSecrets(locationID requestedLocationID: ExecutionLocationID? = nil) async {
+        let locationID = requestedLocationID ?? activeExecutionLocation
+        guard let requestClient = gateway(for: locationID) else { return }
+        let requestGeneration = locationID == .local
+            ? connectionGeneration
+            : executionLocationGeneration(for: locationID)
+        let requestIsCurrent = {
+            let currentGeneration = locationID == .local
+                ? self.connectionGeneration
+                : self.executionLocationGeneration(for: locationID)
+            return currentGeneration == requestGeneration
+                && self.isCurrentGateway(requestClient, at: locationID)
+        }
+        do {
+            let response = try await requestClient.listSecrets()
+            guard requestIsCurrent() else { return }
+            if locationID == .local {
+                secretBackend = response.backend
+                storedSecrets = response.secrets
+            } else {
+                remoteSecretBackends[locationID] = response.backend
+                remoteStoredSecrets[locationID] = response.secrets
+            }
+        } catch {
+            guard requestIsCurrent() else { return }
+            if locationID == .local {
+                secretBackend = "unknown"
+            } else {
+                remoteSecretBackends[locationID] = "unknown"
+            }
+        }
+    }
+
+    /// Returns true when the list now REFLECTS server truth (incl. the honest
+    /// 501 empty state); false on transport failure (last-known rows kept) so
+    /// the ping watermark can surrender instead of dropping future pings.
+    @discardableResult
+    func refreshThreads() async -> Bool {
+        guard let requestClient = client else { return false }
+        let requestGeneration = connectionGeneration
+        let requestIsCurrent = {
+            self.connectionGeneration == requestGeneration && self.client === requestClient
+        }
+        do {
+            let list = try await requestClient.listThreads()
+            guard requestIsCurrent() else { return false }
+            threads = list.threads
+            projectListingProblems = list.problems
+            if list.droppedThreads > 0 {
+                // Per-row salvage disclosed: the store carried rows this
+                // app build cannot decode, so disclose it instead of hiding it.
+                threadStatus = "\(list.droppedThreads) thread(s) could not be decoded by this app version and are hidden."
+            } else if threadStatus?.contains("could not be decoded") == true {
+                threadStatus = nil
+            }
+            return true
+        } catch let GatewayError.http(status, _) where status == 501 {
+            guard requestIsCurrent() else { return false }
+            threads = []
+            projectListingProblems = []
+            return true
+        } catch {
+            guard requestIsCurrent() else { return false }
+            // A transport/decode failure is not an empty thread list: retain
+            // last-known rows and surface the failure.
+            threadStatus = "Could not refresh threads: \(userMessage(for: error))"
+            return false
+        }
+    }
+}

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+LocalConnection.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+LocalConnection.swift
@@ -7,34 +7,23 @@ extension AppModel {
     func connect() async {
         connectionGeneration += 1
         let generation = connectionGeneration
-        var attemptedLaunch = false
-        while !Task.isCancelled, generation == connectionGeneration {
-            health = .connecting
-            cancelAllStreams()
-            let attempt = await tryConnect()
-            if attempt == .connected {
-                while !Task.isCancelled, generation == connectionGeneration {
-                    try? await Task.sleep(for: .seconds(3))
-                    guard generation == connectionGeneration, client != nil else { break }
-                    guard await pollEngineIdentity() else { break }
-                }
-            } else if attempt == .reconnect {
-                // Reconciliation already launched and identity-verified the exact
-                // selected closure. Re-read discovery/token/client state; never
-                // run the fallback launcher or hydrate through the old client.
-                attemptedLaunch = true
-                continue
-            } else if attempt == .unavailable,
-                !attemptedLaunch, DaemonLauncher.startIfNeeded()
-            {
-                attemptedLaunch = true
-                try? await Task.sleep(for: .seconds(3))
-                continue
-            }
-            guard generation == connectionGeneration else { return }
-            enterHardOffline()
-            try? await Task.sleep(for: .seconds(3))
-        }
+        let recovery = LocalConnectionRecoveryLoop(
+            generation: generation,
+            currentGeneration: { self.connectionGeneration },
+            lifecycleOwner: localRuntimeLifecycleOwner,
+            prepareProbe: {
+                self.health = .connecting
+                self.cancelAllStreams()
+            },
+            probe: { await self.tryConnect() },
+            pollConnected: {
+                guard self.client != nil else { return false }
+                return await self.pollEngineIdentity()
+            },
+            startDaemon: { DaemonLauncher.startIfNeeded() },
+            enterOffline: { self.enterHardOffline() },
+            pause: { try? await Task.sleep(for: .seconds(3)) })
+        await recovery.run()
     }
 
     /// Drop every daemon-owned projection when the engine is unreachable. The
@@ -136,13 +125,6 @@ extension AppModel {
         deferredOverflow.removeAll()
     }
 
-    private enum LocalConnectAttempt: Equatable {
-        case connected
-        case reconnect
-        case unavailable
-        case lifecycleFailed
-    }
-
     private func daemonReconciliationOwner() -> LocalDaemonReconciler {
         if let localDaemonReconciler { return localDaemonReconciler }
         let reconciler = LocalDaemonReconciler(
@@ -171,7 +153,7 @@ extension AppModel {
         return LocalDaemonReconciliationPolicy(result)
     }
 
-    private func tryConnect() async -> LocalConnectAttempt {
+    private func tryConnect() async -> LocalConnectionProbeResult {
         do {
             let discovery = try ControlApiDiscovery.load()
             let candidate = try discovery.makeClient()

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+LocalConnection.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+LocalConnection.swift
@@ -7,6 +7,15 @@ extension AppModel {
     func connect() async {
         connectionGeneration += 1
         let generation = connectionGeneration
+        // Retire the previous exact client synchronously, before the new
+        // generation's first suspension. Every projection owner can now reject
+        // an old response by client identity even while discovery/handshake for
+        // the successor is still in flight.
+        client = nil
+        endpoint = ""
+        engineIdentity = nil
+        health = .connecting
+        cancelAllStreams()
         let recovery = LocalConnectionRecoveryLoop(
             generation: generation,
             currentGeneration: { self.connectionGeneration },
@@ -15,10 +24,10 @@ extension AppModel {
                 self.health = .connecting
                 self.cancelAllStreams()
             },
-            probe: { await self.tryConnect() },
+            probe: { await self.tryConnect(generation: generation) },
             pollConnected: {
-                guard self.client != nil else { return false }
-                return await self.pollEngineIdentity()
+                guard self.client != nil else { return .unavailable }
+                return await self.pollLocalConnection(generation: generation)
             },
             startDaemon: { DaemonLauncher.startIfNeeded() },
             enterOffline: { self.enterHardOffline() },
@@ -144,44 +153,99 @@ extension AppModel {
     /// unstampable identity is deliberately passed as nil and reduced to a safe,
     /// visible keep-compatible policy before any lifecycle work.
     func localDaemonPolicy(
-        for engine: EngineBuildIdentity?
+        for engine: EngineBuildIdentity?,
+        generation: Int? = nil
     ) async -> LocalDaemonReconciliationPolicy {
         let serving = engine.flatMap {
             AppRuntimeDaemonControl.runtimeIdentity(version: $0.version, buildSha: $0.sha)
         }
-        let result = await daemonReconciliationOwner().reconcile(serving: serving)
+        let result = await daemonReconciliationOwner().reconcile(
+            serving: serving,
+            isCurrent: { @MainActor [weak self] in
+                guard let generation else { return true }
+                guard let self else { return false }
+                return !Task.isCancelled && self.connectionGeneration == generation
+            })
+        if let generation, !localConnectionGenerationIsCurrent(generation) {
+            return .superseded
+        }
         return LocalDaemonReconciliationPolicy(result)
     }
 
-    private func tryConnect() async -> LocalConnectionProbeResult {
+    private func tryConnect(generation: Int) async -> LocalConnectionProbeResult {
         do {
             let discovery = try ControlApiDiscovery.load()
             let candidate = try discovery.makeClient()
-            endpoint = "\(discovery.host):\(discovery.port)"
-            adoptClientForReconnect(candidate)
+            return await tryConnect(
+                candidate: candidate,
+                endpoint: "\(discovery.host):\(discovery.port)",
+                generation: generation)
+        } catch {
+            return localConnectionGenerationIsCurrent(generation)
+                ? .unavailable : .superseded
+        }
+    }
+
+    /// Injected candidate seam for deterministic connection-generation tests.
+    /// Discovery and candidate construction remain side-effect-free; this method
+    /// owns the first handshake and the single generation-bound adoption point.
+    func tryConnect(
+        candidate: GatewayClient,
+        endpoint candidateEndpoint: String,
+        generation: Int
+    ) async -> LocalConnectionProbeResult {
+        do {
             // One handshake serves both the connectivity verdict AND the engine
             // build identity (QA-002): retain what the daemon discloses instead
             // of a bare Bool that drops version/sha on the floor.
             let outcome = try await candidate.handshake()
+            guard localConnectionGenerationIsCurrent(generation) else {
+                return .superseded
+            }
             if outcome.ok {
-                switch await localDaemonPolicy(for: outcome.engine) {
+                switch await localDaemonPolicy(for: outcome.engine, generation: generation) {
                 case let .useCompatible(notice):
-                    guard client === candidate else { return .unavailable }
+                    guard localConnectionGenerationIsCurrent(generation) else {
+                        return .superseded
+                    }
+                    endpoint = candidateEndpoint
+                    adoptClientForReconnect(candidate)
                     setLocalDaemonReconciliationNotice(notice)
                     engineIdentity = outcome.engine
                     health = .connected
                     await refreshRuns()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     await refreshSettings()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     await refreshSecrets()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     await refreshThreads()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     await refreshProjects()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     // The full Accounts snapshot is intentionally explicit-only.
                     // Connect hydrates the cached harness + registry owners.
                     _ = await refreshHarnesses()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     // QA-065: resolve credential-profile DISPLAY NAMES on connect, not
                     // only when the accounts popover opens — otherwise the sessions
                     // footer shows raw profile ids by default until that popover loads.
                     await refreshCredentialProfiles()
+                    guard localConnectionLeaseIsCurrent(generation, candidate) else {
+                        return .superseded
+                    }
                     // A popover may survive a transient reconnect. Its existing
                     // subscriber does not re-run onAppear, so resume exactly one
                     // cheap display read against the replacement gateway.
@@ -189,6 +253,9 @@ extension AppModel {
                     startGlobalStream()
                     return .connected
                 case .reconnect:
+                    guard localConnectionGenerationIsCurrent(generation) else {
+                        return .superseded
+                    }
                     setLocalDaemonReconciliationNotice(nil)
                     client = nil
                     endpoint = ""
@@ -196,16 +263,23 @@ extension AppModel {
                     health = .connecting
                     return .reconnect
                 case let .failOffline(notice):
+                    guard localConnectionGenerationIsCurrent(generation) else {
+                        return .superseded
+                    }
                     setLocalDaemonReconciliationNotice(notice)
                     client = nil
                     engineIdentity = nil
                     return .lifecycleFailed
+                case .superseded:
+                    return .superseded
+                case .retry:
+                    return .retryWithoutLaunch
                 }
             }
         } catch {
             // fall through to caller (offline / auto-start path)
         }
-        return .unavailable
+        return localConnectionGenerationIsCurrent(generation) ? .unavailable : .superseded
     }
 
     /// One steady-state connectivity poll (round-4 #5 / QA-002): re-HANDSHAKE
@@ -215,26 +289,71 @@ extension AppModel {
     /// false → the caller falls to the reconnect path.
     @discardableResult
     func pollEngineIdentity() async -> Bool {
+        await pollLocalConnection() == .connected
+    }
+
+    /// Typed steady-state poll. The recovery loop must distinguish an ordinary
+    /// transport loss (which earns one outage launch) from reconciliation that
+    /// already launched, or attempted to launch, the selected closure.
+    func pollLocalConnection(generation: Int? = nil) async -> LocalConnectionProbeResult {
         guard let current = client, let outcome = try? await current.handshake(), outcome.ok else {
-            return false
+            return requestedConnectionGenerationIsCurrent(generation)
+                ? .unavailable : .superseded
         }
-        switch await localDaemonPolicy(for: outcome.engine) {
+        guard requestedConnectionGenerationIsCurrent(generation) else {
+            return .superseded
+        }
+        switch await localDaemonPolicy(for: outcome.engine, generation: generation) {
         case let .useCompatible(notice):
-            guard client === current else { return false }
+            guard requestedConnectionGenerationIsCurrent(generation), client === current else {
+                return .superseded
+            }
             setLocalDaemonReconciliationNotice(notice)
             engineIdentity = outcome.engine
-            return true
+            return .connected
         case .reconnect:
+            guard requestedConnectionGenerationIsCurrent(generation) else {
+                return .superseded
+            }
             // The old handshake and the replacement's internal proof are both
             // deliberately unpublished. The connect owner reacquires discovery,
             // handshakes again, then hydrates the new daemon as one coherent unit.
             setLocalDaemonReconciliationNotice(nil)
+            client = nil
+            endpoint = ""
             engineIdentity = nil
-            return false
+            health = .connecting
+            cancelAllStreams()
+            return .reconnect
         case let .failOffline(notice):
+            guard requestedConnectionGenerationIsCurrent(generation) else {
+                return .superseded
+            }
             setLocalDaemonReconciliationNotice(notice)
+            client = nil
             engineIdentity = nil
-            return false
+            cancelAllStreams()
+            return .lifecycleFailed
+        case .superseded:
+            return .superseded
+        case .retry:
+            return .retryWithoutLaunch
         }
+    }
+
+    private func localConnectionGenerationIsCurrent(_ generation: Int) -> Bool {
+        !Task.isCancelled && connectionGeneration == generation
+    }
+
+    private func localConnectionLeaseIsCurrent(
+        _ generation: Int,
+        _ requestClient: GatewayClient
+    ) -> Bool {
+        localConnectionGenerationIsCurrent(generation) && client === requestClient
+    }
+
+    private func requestedConnectionGenerationIsCurrent(_ generation: Int?) -> Bool {
+        guard let generation else { return !Task.isCancelled }
+        return localConnectionGenerationIsCurrent(generation)
     }
 }

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+LocalConnection.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+LocalConnection.swift
@@ -203,6 +203,12 @@ extension AppModel {
                 return .superseded
             }
             if outcome.ok {
+                // Issue #165 D5: a recovery-only daemon owns the endpoint but
+                // keeps product admission closed. Stay in the existing
+                // Connecting behavior — no adoption, no hydration, no
+                // reconciliation lifecycle, no fallback launch — and keep
+                // polling the handshake until normal admission opens.
+                if outcome.recoveryOnly { return .retryWithoutLaunch }
                 switch await localDaemonPolicy(for: outcome.engine, generation: generation) {
                 case let .useCompatible(notice):
                     guard localConnectionGenerationIsCurrent(generation) else {
@@ -303,6 +309,10 @@ extension AppModel {
         guard requestedConnectionGenerationIsCurrent(generation) else {
             return .superseded
         }
+        // A connected daemon that re-enters recovery (restart into a
+        // recovery-needed root) closes product admission: fall back to the
+        // Connecting discovery loop without inventing an outage launch.
+        if outcome.recoveryOnly { return .retryWithoutLaunch }
         switch await localDaemonPolicy(for: outcome.engine, generation: generation) {
         case let .useCompatible(notice):
             guard requestedConnectionGenerationIsCurrent(generation), client === current else {

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+Projects.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+Projects.swift
@@ -14,11 +14,16 @@ extension AppModel {
     /// Best-effort — the path MRU still drives selection; this never blocks.
     @discardableResult
     func refreshProjects() async -> Bool {
-        guard let client else { return false }
-        guard let list = try? await client.listProjects() else {
+        guard let requestClient = client else { return false }
+        let requestGeneration = connectionGeneration
+        guard let list = try? await requestClient.listProjects() else {
+            guard connectionGeneration == requestGeneration,
+                  client === requestClient else { return false }
             registeredProjects.removeAll()
             return false
         }
+        guard connectionGeneration == requestGeneration,
+              client === requestClient else { return false }
         registeredProjects = list.projects
         return true
     }

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+Remote.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel+Remote.swift
@@ -261,9 +261,14 @@ extension AppModel {
                 expectedRuntime: activeBootstrap.runtime,
                 requiresActivationCommit: activationLease != nil)
             let outcome = try await activeClient.handshake()
-            guard outcome.ok, publicationGate.acceptHandshake(outcome.engine) else {
+            // Issue #165 C7b: publication requires NORMAL serving — a
+            // recovery-only remote daemon must not be adopted (absent
+            // servingMode = a pre-#165 daemon serving normally).
+            guard outcome.ok, !outcome.recoveryOnly,
+                  publicationGate.acceptHandshake(outcome.engine)
+            else {
                 throw SSHConnectionError.unavailable(
-                    "remote daemon handshake does not match the bootstrapped runtime")
+                    "remote daemon handshake does not match the bootstrapped runtime or is serving recovery only")
             }
             guard remoteConnectionGenerations[id] == generation else {
                 throw CancellationError()

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel.swift
@@ -606,27 +606,6 @@ final class AppModel {
         return url.path
     }
 
-    func refreshSecrets(locationID requestedLocationID: ExecutionLocationID? = nil) async {
-        let locationID = requestedLocationID ?? activeExecutionLocation
-        guard let requestClient = gateway(for: locationID) else { return }
-        do {
-            let response = try await requestClient.listSecrets()
-            if locationID == .local {
-                secretBackend = response.backend
-                storedSecrets = response.secrets
-            } else {
-                remoteSecretBackends[locationID] = response.backend
-                remoteStoredSecrets[locationID] = response.secrets
-            }
-        } catch {
-            if locationID == .local {
-                secretBackend = "unknown"
-            } else {
-                remoteSecretBackends[locationID] = "unknown"
-            }
-        }
-    }
-
     /// Model-internal busy bracket for turn-start paths that live in other
     /// files (retryTurn in AppModelTrust.swift): `turnSubmitting` keeps its
     /// private(set) so views can never write it directly.
@@ -805,38 +784,6 @@ final class AppModel {
     }
 
     // MARK: Threads (chat/session-first)
-
-    /// Returns true when the list now REFLECTS server truth (incl. the honest
-    /// 501 empty state); false on transport failure (last-known rows kept) so
-    /// the ping watermark can surrender instead of dropping future pings.
-    @discardableResult
-    func refreshThreads() async -> Bool {
-        guard let client else { return false }
-        do {
-            let list = try await client.listThreads()
-            threads = list.threads
-            projectListingProblems = list.problems
-            if list.droppedThreads > 0 {
-                // Per-row salvage disclosed: the store carried rows this
-                // app build cannot decode — say so instead of hiding them.
-                threadStatus = "\(list.droppedThreads) thread(s) could not be decoded by this app version and are hidden."
-            } else if threadStatus?.contains("could not be decoded") == true {
-                // The condition is gone; a stale warning must not linger.
-                threadStatus = nil
-            }
-            return true
-        } catch let GatewayError.http(status, _) where status == 501 {
-            // Engine builds without thread support: honestly empty.
-            threads = []
-            projectListingProblems = []
-            return true
-        } catch {
-            // A transport/decode failure is NOT an empty thread list: keep the
-            // last-known rows and surface the error.
-            threadStatus = "Could not refresh threads: \(userMessage(for: error))"
-            return false
-        }
-    }
 
     /// The thread the conversation is currently showing (detail preferred — it is
     /// the freshest copy after a PATCH/turn — falling back to the list summary).

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalConnectionRecovery.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalConnectionRecovery.swift
@@ -4,7 +4,9 @@ enum LocalConnectionProbeResult: Equatable {
     case connected
     case reconnect
     case unavailable
+    case retryWithoutLaunch
     case lifecycleFailed
+    case superseded
 }
 
 /// Owns the bounded local-daemon start allowance for one connection generation.
@@ -18,7 +20,7 @@ struct LocalConnectionRecoveryLoop {
     private let lifecycleOwner: LocalRuntimeLifecycleOwner
     private let prepareProbe: @MainActor () -> Void
     private let probe: @MainActor () async -> LocalConnectionProbeResult
-    private let pollConnected: @MainActor () async -> Bool
+    private let pollConnected: @MainActor () async -> LocalConnectionProbeResult
     private let startDaemon: @MainActor () -> Bool
     private let enterOffline: @MainActor () -> Void
     private let pause: @MainActor () async -> Void
@@ -29,7 +31,7 @@ struct LocalConnectionRecoveryLoop {
         lifecycleOwner: LocalRuntimeLifecycleOwner,
         prepareProbe: @escaping @MainActor () -> Void,
         probe: @escaping @MainActor () async -> LocalConnectionProbeResult,
-        pollConnected: @escaping @MainActor () async -> Bool,
+        pollConnected: @escaping @MainActor () async -> LocalConnectionProbeResult,
         startDaemon: @escaping @MainActor () -> Bool,
         enterOffline: @escaping @MainActor () -> Void,
         pause: @escaping @MainActor () async -> Void
@@ -57,12 +59,35 @@ struct LocalConnectionRecoveryLoop {
             switch result {
             case .connected:
                 launchAvailable = true
-                while isCurrent {
+                connected: while isCurrent {
                     await pause()
                     guard isCurrent else { return }
-                    let stillConnected = await pollConnected()
+                    let pollResult = await pollConnected()
                     guard isCurrent else { return }
-                    if !stillConnected { break }
+                    switch pollResult {
+                    case .connected:
+                        continue
+                    case .unavailable:
+                        break connected
+                    case .retryWithoutLaunch:
+                        break connected
+                    case .reconnect:
+                        // The reconciler already launched and identity-proved a
+                        // successor. The next discovery pass must not launch it
+                        // again merely because the old client disconnected.
+                        launchAvailable = false
+                        break connected
+                    case .lifecycleFailed:
+                        // A stop/start lifecycle was admitted but did not reach
+                        // the exact target. Consume this outage's fallback and
+                        // keep polling for external/manual recovery.
+                        launchAvailable = false
+                        enterOffline()
+                        await pause()
+                        break connected
+                    case .superseded:
+                        return
+                    }
                 }
 
             case .reconnect:
@@ -89,9 +114,19 @@ struct LocalConnectionRecoveryLoop {
                 enterOffline()
                 await pause()
 
+            case .retryWithoutLaunch:
+                // A coalesced predecessor retired before destructive lifecycle
+                // admission. Retry discovery without inventing an outage start
+                // and without consuming the still-valid allowance.
+                await pause()
+
             case .lifecycleFailed:
+                launchAvailable = false
                 enterOffline()
                 await pause()
+
+            case .superseded:
+                return
             }
         }
     }

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalConnectionRecovery.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalConnectionRecovery.swift
@@ -51,6 +51,10 @@ struct LocalConnectionRecoveryLoop {
         var launchAvailable = true
         while isCurrent {
             prepareProbe()
+            // A lifecycle can replace or install the successor while this
+            // handshake is suspended. Its completion must make a negative
+            // result stale rather than authorize a second fallback launch.
+            let lifecycleSnapshot = lifecycleOwner.completionSnapshot()
             let result = await probe()
             // Manual Reconnect advances the generation while discovery or a
             // handshake is suspended. Its predecessor may publish nothing.
@@ -97,9 +101,18 @@ struct LocalConnectionRecoveryLoop {
                 launchAvailable = false
 
             case .unavailable:
-                if launchAvailable,
-                    let lease = lifecycleOwner.claim(.outageRecovery)
-                {
+                if launchAvailable {
+                    guard let lease = lifecycleOwner.claim(
+                        .outageRecovery,
+                        ifNoCompletionSince: lifecycleSnapshot)
+                    else {
+                        // Busy and completed-since-snapshot are deliberately
+                        // the same recovery decision: preserve the allowance
+                        // and require a fresh probe before any launch.
+                        enterOffline()
+                        await pause()
+                        continue
+                    }
                     // Consume before start, including a synchronous false.
                     launchAvailable = false
                     let started = startDaemon()

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalConnectionRecovery.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalConnectionRecovery.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+enum LocalConnectionProbeResult: Equatable {
+    case connected
+    case reconnect
+    case unavailable
+    case lifecycleFailed
+}
+
+/// Owns the bounded local-daemon start allowance for one connection generation.
+/// A confirmed connection rearms one later outage; a start attempt consumes the
+/// allowance before the synchronous launcher runs. The shared lifecycle lease
+/// keeps outage recovery from overlapping installation or reconciliation.
+@MainActor
+struct LocalConnectionRecoveryLoop {
+    private let generation: Int
+    private let currentGeneration: @MainActor () -> Int
+    private let lifecycleOwner: LocalRuntimeLifecycleOwner
+    private let prepareProbe: @MainActor () -> Void
+    private let probe: @MainActor () async -> LocalConnectionProbeResult
+    private let pollConnected: @MainActor () async -> Bool
+    private let startDaemon: @MainActor () -> Bool
+    private let enterOffline: @MainActor () -> Void
+    private let pause: @MainActor () async -> Void
+
+    init(
+        generation: Int,
+        currentGeneration: @escaping @MainActor () -> Int,
+        lifecycleOwner: LocalRuntimeLifecycleOwner,
+        prepareProbe: @escaping @MainActor () -> Void,
+        probe: @escaping @MainActor () async -> LocalConnectionProbeResult,
+        pollConnected: @escaping @MainActor () async -> Bool,
+        startDaemon: @escaping @MainActor () -> Bool,
+        enterOffline: @escaping @MainActor () -> Void,
+        pause: @escaping @MainActor () async -> Void
+    ) {
+        self.generation = generation
+        self.currentGeneration = currentGeneration
+        self.lifecycleOwner = lifecycleOwner
+        self.prepareProbe = prepareProbe
+        self.probe = probe
+        self.pollConnected = pollConnected
+        self.startDaemon = startDaemon
+        self.enterOffline = enterOffline
+        self.pause = pause
+    }
+
+    func run() async {
+        var launchAvailable = true
+        while isCurrent {
+            prepareProbe()
+            let result = await probe()
+            // Manual Reconnect advances the generation while discovery or a
+            // handshake is suspended. Its predecessor may publish nothing.
+            guard isCurrent else { return }
+
+            switch result {
+            case .connected:
+                launchAvailable = true
+                while isCurrent {
+                    await pause()
+                    guard isCurrent else { return }
+                    let stillConnected = await pollConnected()
+                    guard isCurrent else { return }
+                    if !stillConnected { break }
+                }
+
+            case .reconnect:
+                // Reconciliation already started and identity-verified the
+                // selected closure. Suppress a second fallback start until a
+                // later confirmed connection creates a new outage allowance.
+                launchAvailable = false
+
+            case .unavailable:
+                if launchAvailable,
+                    let lease = lifecycleOwner.claim(.outageRecovery)
+                {
+                    // Consume before start, including a synchronous false.
+                    launchAvailable = false
+                    let started = startDaemon()
+                    lifecycleOwner.release(lease)
+                    if started {
+                        // Preserve the existing Connecting boot window. A
+                        // synchronous launch failure instead publishes Offline.
+                        await pause()
+                        continue
+                    }
+                }
+                enterOffline()
+                await pause()
+
+            case .lifecycleFailed:
+                enterOffline()
+                await pause()
+            }
+        }
+    }
+
+    private var isCurrent: Bool {
+        !Task.isCancelled && generation == currentGeneration()
+    }
+}

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalDaemonReconciler.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/LocalDaemonReconciler.swift
@@ -35,6 +35,9 @@ enum LocalDaemonReconciliationResult: Sendable, Equatable {
         target: RuntimeClosureIdentity)
     case deferredForLifecycle
     case failed(LocalDaemonReconciliationFailure)
+    /// The requesting connection generation retired before destructive
+    /// lifecycle admission. No stop or start was attempted.
+    case supersededBeforeLifecycle
 }
 
 /// The AppModel-facing policy for a reconciliation result. Keeping this
@@ -50,6 +53,11 @@ enum LocalDaemonReconciliationPolicy: Sendable, Equatable {
     /// A lifecycle transition began but did not finish with the exact target.
     /// The previous client is no longer safe to use.
     case failOffline(notice: String)
+    /// A coalesced older generation retired before lifecycle admission. The
+    /// current caller should re-probe without launching a fallback.
+    case retry
+    /// A newer connection generation owns every subsequent publication.
+    case superseded
 
     init(_ result: LocalDaemonReconciliationResult) {
         switch result {
@@ -86,6 +94,8 @@ enum LocalDaemonReconciliationPolicy: Sendable, Equatable {
         case .failed(.postStartUnreachable):
             self = .failOffline(
                 notice: "The refreshed engine did not come online. Reconnecting.")
+        case .supersededBeforeLifecycle:
+            self = .retry
         }
     }
 }
@@ -125,8 +135,12 @@ actor LocalDaemonReconciler {
     /// `serving` should normally be the identity from the handshake that made
     /// the app consider the local daemon connected. Passing nil asks the port to
     /// re-read discovery and handshake; inability to prove it fails closed.
-    func reconcile(serving: RuntimeClosureIdentity? = nil) async -> LocalDaemonReconciliationResult {
+    func reconcile(
+        serving: RuntimeClosureIdentity? = nil,
+        isCurrent: @escaping @Sendable () async -> Bool = { true }
+    ) async -> LocalDaemonReconciliationResult {
         if let inFlight { return await inFlight.value }
+        guard await isCurrent() else { return .supersededBeforeLifecycle }
         // Exact session admission precedes target resolution and the first await.
         // It excludes RuntimeInstallCoordinator's independent actor from the same
         // stop/start lifecycle rather than relying on a sampled UI boolean.
@@ -141,7 +155,8 @@ actor LocalDaemonReconciler {
         let task = Task {
             await Self.perform(
                 daemon: daemon, targetClosure: targetClosure, serving: serving,
-                handshakePollInterval: pollInterval, handshakePollTimeout: pollTimeout)
+                handshakePollInterval: pollInterval, handshakePollTimeout: pollTimeout,
+                isCurrent: isCurrent)
         }
         inFlight = task
         let result = await task.value
@@ -155,7 +170,8 @@ actor LocalDaemonReconciler {
         targetClosure: @Sendable () -> LocalRuntimeClosureSelection?,
         serving suppliedServing: RuntimeClosureIdentity?,
         handshakePollInterval: TimeInterval,
-        handshakePollTimeout: TimeInterval
+        handshakePollTimeout: TimeInterval,
+        isCurrent: @escaping @Sendable () async -> Bool
     ) async -> LocalDaemonReconciliationResult {
         guard let selected = targetClosure() else { return .failed(.targetScriptUnavailable) }
         let expected: RuntimeClosureIdentity?
@@ -201,6 +217,13 @@ actor LocalDaemonReconciler {
         case false:
             break
         }
+
+        // Everything above this point is side-effect-free observation. This is
+        // the generation-bound admission point for the destructive lifecycle:
+        // a request superseded before it stops the daemon performs no mutation.
+        // Once stop is invoked the exact stop/start/proof transaction must run
+        // to a safe terminal state even if a newer connect begins meanwhile.
+        guard await isCurrent() else { return .supersededBeforeLifecycle }
 
         do {
             try await daemon.stopForRuntimeReplacement(expectedIdentity: serving)

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/RuntimeInstallCoordinator.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/RuntimeInstallCoordinator.swift
@@ -56,18 +56,44 @@ public struct LocalRuntimeLifecycleLease: Sendable, Equatable {
     public let operation: LocalRuntimeLifecycleOperation
 }
 
+/// Opaque process-local receipt for lifecycle completions. A caller snapshots
+/// it before suspending work, then uses the owner to atomically prove that no
+/// lifecycle finished before it claims a follow-up action.
+struct LocalRuntimeLifecycleCompletionSnapshot: Sendable, Equatable {
+    fileprivate let sequence: UInt64
+}
+
 public final class LocalRuntimeLifecycleOwner: @unchecked Sendable {
     private let lock = NSLock()
     private var current: LocalRuntimeLifecycleLease?
+    private var completionSequence: UInt64 = 0
 
     public init() {}
 
     public func claim(_ operation: LocalRuntimeLifecycleOperation) -> LocalRuntimeLifecycleLease? {
         lock.withLock {
-            guard current == nil else { return nil }
-            let lease = LocalRuntimeLifecycleLease(id: UUID(), operation: operation)
-            current = lease
-            return lease
+            claimWhileLocked(operation)
+        }
+    }
+
+    /// Snapshot immediately before an awaited observation whose result could be
+    /// stale by the time it returns.
+    func completionSnapshot() -> LocalRuntimeLifecycleCompletionSnapshot {
+        lock.withLock {
+            LocalRuntimeLifecycleCompletionSnapshot(sequence: completionSequence)
+        }
+    }
+
+    /// Atomically claim only when the owner is idle and no lifecycle completed
+    /// since `snapshot`. Returning nil changes neither fact, so a recovery caller
+    /// can retain its launch allowance and obtain a fresh observation.
+    func claim(
+        _ operation: LocalRuntimeLifecycleOperation,
+        ifNoCompletionSince snapshot: LocalRuntimeLifecycleCompletionSnapshot
+    ) -> LocalRuntimeLifecycleLease? {
+        lock.withLock {
+            guard completionSequence == snapshot.sequence else { return nil }
+            return claimWhileLocked(operation)
         }
     }
 
@@ -75,7 +101,17 @@ public final class LocalRuntimeLifecycleOwner: @unchecked Sendable {
         lock.withLock {
             guard current == lease else { return }
             current = nil
+            completionSequence += 1
         }
+    }
+
+    private func claimWhileLocked(
+        _ operation: LocalRuntimeLifecycleOperation
+    ) -> LocalRuntimeLifecycleLease? {
+        guard current == nil else { return nil }
+        let lease = LocalRuntimeLifecycleLease(id: UUID(), operation: operation)
+        current = lease
+        return lease
     }
 }
 

--- a/apps/macos/ClaudexorApp/Sources/ClaudexorApp/RuntimeInstallCoordinator.swift
+++ b/apps/macos/ClaudexorApp/Sources/ClaudexorApp/RuntimeInstallCoordinator.swift
@@ -48,6 +48,7 @@ public struct RuntimeClosureIdentity: Sendable, Equatable {
 public enum LocalRuntimeLifecycleOperation: Sendable, Equatable {
     case reconciliation
     case installation
+    case outageRecovery
 }
 
 public struct LocalRuntimeLifecycleLease: Sendable, Equatable {

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalConnectionRecoveryTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalConnectionRecoveryTests.swift
@@ -210,6 +210,35 @@ private final class LocalConnectionRecoveryHarness {
         #expect(sut.probeCount >= 3)
     }
 
+    @Test func lifecycleCompletionSnapshotAndConditionalClaimAreAtomicAndTokenBound() throws {
+        let owner = LocalRuntimeLifecycleOwner()
+        let initial = owner.completionSnapshot()
+        let installation = try #require(owner.claim(.installation))
+
+        // Being busy refuses without fabricating a completion.
+        #expect(owner.claim(
+            .outageRecovery, ifNoCompletionSince: initial) == nil)
+        #expect(owner.completionSnapshot() == initial)
+
+        owner.release(installation)
+        let completed = owner.completionSnapshot()
+        #expect(completed != initial)
+        // The stale observation cannot claim even though the owner is idle.
+        #expect(owner.claim(
+            .outageRecovery, ifNoCompletionSince: initial) == nil)
+
+        let recovery = try #require(owner.claim(
+            .outageRecovery, ifNoCompletionSince: completed))
+        owner.release(installation)
+        // A stale token neither clears the current owner nor advances receipt.
+        #expect(owner.completionSnapshot() == completed)
+        #expect(owner.claim(.reconciliation) == nil)
+
+        owner.release(recovery)
+        #expect(owner.completionSnapshot() != completed)
+        #expect(owner.claim(.reconciliation) != nil)
+    }
+
     @MainActor
     @Test func exhaustedAllowanceKeepsPollingAndExternalRecoveryRearmsIt() async {
         let sut = LocalConnectionRecoveryHarness(

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalConnectionRecoveryTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalConnectionRecoveryTests.swift
@@ -35,7 +35,7 @@ private final class LocalConnectionRecoveryHarness {
     let lifecycleOwner: LocalRuntimeLifecycleOwner
     var generation = 1
     var probeResults: [LocalConnectionProbeResult]
-    var pollResults: [Bool]
+    var pollResults: [LocalConnectionProbeResult]
     var startResults: [Bool]
     var probeOverride: (@MainActor () async -> LocalConnectionProbeResult)?
     var pauseActions: [Int: @MainActor () -> Void] = [:]
@@ -50,7 +50,7 @@ private final class LocalConnectionRecoveryHarness {
     init(
         lifecycleOwner: LocalRuntimeLifecycleOwner = LocalRuntimeLifecycleOwner(),
         probes: [LocalConnectionProbeResult],
-        polls: [Bool] = [],
+        polls: [LocalConnectionProbeResult] = [],
         starts: [Bool] = []
     ) {
         self.lifecycleOwner = lifecycleOwner
@@ -83,9 +83,9 @@ private final class LocalConnectionRecoveryHarness {
         return probeResults.removeFirst()
     }
 
-    private func nextPoll() async -> Bool {
+    private func nextPoll() async -> LocalConnectionProbeResult {
         pollCount += 1
-        return pollResults.isEmpty ? false : pollResults.removeFirst()
+        return pollResults.isEmpty ? .unavailable : pollResults.removeFirst()
     }
 
     private func nextStart() -> Bool {
@@ -127,7 +127,7 @@ private final class LocalConnectionRecoveryHarness {
     @Test func confirmedConnectionThenPollLossGetsOneSuccessorAttempt() async {
         let sut = LocalConnectionRecoveryHarness(
             probes: [.unavailable, .connected, .unavailable, .unavailable],
-            polls: [false])
+            polls: [.unavailable])
 
         await sut.run()
 
@@ -154,7 +154,7 @@ private final class LocalConnectionRecoveryHarness {
                 .connected, .unavailable,
                 .connected, .unavailable, .unavailable,
             ],
-            polls: [false, false])
+            polls: [.unavailable, .unavailable])
 
         await sut.run()
 
@@ -166,7 +166,7 @@ private final class LocalConnectionRecoveryHarness {
     @Test func reconciliationReconnectSuppressesFallbackUntilConfirmedConnection() async {
         let sut = LocalConnectionRecoveryHarness(
             probes: [.reconnect, .unavailable, .connected, .unavailable],
-            polls: [false])
+            polls: [.unavailable])
 
         await sut.run()
 
@@ -214,7 +214,7 @@ private final class LocalConnectionRecoveryHarness {
     @Test func exhaustedAllowanceKeepsPollingAndExternalRecoveryRearmsIt() async {
         let sut = LocalConnectionRecoveryHarness(
             probes: [.unavailable, .unavailable, .connected, .unavailable],
-            polls: [false], starts: [false, true])
+            polls: [.unavailable], starts: [false, true])
 
         await sut.run()
 
@@ -245,5 +245,67 @@ private final class LocalConnectionRecoveryHarness {
         await sut.run(generation: sut.generation)
 
         #expect(sut.startCount == 1)
+    }
+
+    @MainActor
+    @Test func steadyReplacementConsumesTheOutageFallback() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.connected, .unavailable, .unavailable],
+            polls: [.reconnect])
+
+        await sut.run()
+
+        #expect(sut.pollCount == 1)
+        #expect(sut.startCount == 0)
+        #expect(sut.probeCount >= 3)
+    }
+
+    @MainActor
+    @Test func steadyPostStartFailureConsumesTheOutageFallback() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.connected, .unavailable, .unavailable],
+            polls: [.lifecycleFailed])
+
+        await sut.run()
+
+        #expect(sut.pollCount == 1)
+        #expect(sut.startCount == 0)
+        #expect(sut.offlineCount >= 1)
+    }
+
+    @MainActor
+    @Test func supersededTypedPollTerminatesWithoutFallbackOrOfflinePublication() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.connected], polls: [.superseded])
+
+        await sut.run()
+
+        #expect(sut.pollCount == 1)
+        #expect(sut.startCount == 0)
+        #expect(sut.offlineCount == 0)
+    }
+
+    @MainActor
+    @Test func preLifecycleRetryPreservesAllowanceForOneRealOutage() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.connected, .unavailable, .unavailable],
+            polls: [.retryWithoutLaunch])
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.offlineCount == 1)
+    }
+
+    @MainActor
+    @Test func confirmedRecoveryAfterLifecycleFailureRearmsOneLaterOutage() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.connected, .connected, .unavailable, .unavailable],
+            polls: [.lifecycleFailed, .unavailable])
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.pollCount == 2)
     }
 }

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalConnectionRecoveryTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalConnectionRecoveryTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+import Testing
+@testable import ClaudexorApp
+
+private actor SuspendedRecoveryProbe {
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+    }
+}
+
+@MainActor
+private final class LocalConnectionRecoveryHarness {
+    let lifecycleOwner: LocalRuntimeLifecycleOwner
+    var generation = 1
+    var probeResults: [LocalConnectionProbeResult]
+    var pollResults: [Bool]
+    var startResults: [Bool]
+    var probeOverride: (@MainActor () async -> LocalConnectionProbeResult)?
+    var pauseActions: [Int: @MainActor () -> Void] = [:]
+
+    private(set) var prepareCount = 0
+    private(set) var probeCount = 0
+    private(set) var pollCount = 0
+    private(set) var startCount = 0
+    private(set) var offlineCount = 0
+    private(set) var pauseCount = 0
+
+    init(
+        lifecycleOwner: LocalRuntimeLifecycleOwner = LocalRuntimeLifecycleOwner(),
+        probes: [LocalConnectionProbeResult],
+        polls: [Bool] = [],
+        starts: [Bool] = []
+    ) {
+        self.lifecycleOwner = lifecycleOwner
+        probeResults = probes
+        pollResults = polls
+        startResults = starts
+    }
+
+    func run(generation runGeneration: Int? = nil) async {
+        let loop = LocalConnectionRecoveryLoop(
+            generation: runGeneration ?? generation,
+            currentGeneration: { self.generation },
+            lifecycleOwner: lifecycleOwner,
+            prepareProbe: { self.prepareCount += 1 },
+            probe: { await self.nextProbe() },
+            pollConnected: { await self.nextPoll() },
+            startDaemon: { self.nextStart() },
+            enterOffline: { self.offlineCount += 1 },
+            pause: { await self.pause() })
+        await loop.run()
+    }
+
+    private func nextProbe() async -> LocalConnectionProbeResult {
+        probeCount += 1
+        if let probeOverride { return await probeOverride() }
+        guard !probeResults.isEmpty else {
+            generation += 1
+            return .unavailable
+        }
+        return probeResults.removeFirst()
+    }
+
+    private func nextPoll() async -> Bool {
+        pollCount += 1
+        return pollResults.isEmpty ? false : pollResults.removeFirst()
+    }
+
+    private func nextStart() -> Bool {
+        startCount += 1
+        return startResults.isEmpty ? true : startResults.removeFirst()
+    }
+
+    private func pause() async {
+        pauseCount += 1
+        pauseActions.removeValue(forKey: pauseCount)?()
+        await Task.yield()
+    }
+}
+
+@Suite(.serialized) struct LocalConnectionRecoveryTests {
+    @MainActor
+    @Test func initialUnavailableConsumesAtMostOneLaunch() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.unavailable, .unavailable, .unavailable])
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.pauseCount == 3)
+    }
+
+    @MainActor
+    @Test func falseStartConsumesTheAttemptBeforeCallingTheStarter() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.unavailable, .unavailable], starts: [false, true])
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.offlineCount == 2)
+    }
+
+    @MainActor
+    @Test func confirmedConnectionThenPollLossGetsOneSuccessorAttempt() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.unavailable, .connected, .unavailable, .unavailable],
+            polls: [false])
+
+        await sut.run()
+
+        #expect(sut.startCount == 2)
+        #expect(sut.pollCount == 1)
+    }
+
+    @MainActor
+    @Test func repeatedUnavailablePollsNeverAddAttemptsWithinOneOutage() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: Array(repeating: .unavailable, count: 5))
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.prepareCount == 6)
+    }
+
+    @MainActor
+    @Test func everySecondConfirmedConnectionRearmsExactlyOneFurtherOutage() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [
+                .unavailable,
+                .connected, .unavailable,
+                .connected, .unavailable, .unavailable,
+            ],
+            polls: [false, false])
+
+        await sut.run()
+
+        #expect(sut.startCount == 3)
+        #expect(sut.pollCount == 2)
+    }
+
+    @MainActor
+    @Test func reconciliationReconnectSuppressesFallbackUntilConfirmedConnection() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.reconnect, .unavailable, .connected, .unavailable],
+            polls: [false])
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.probeCount >= 4)
+    }
+
+    @MainActor
+    @Test func staleGenerationAfterAwaitedProbeCannotLaunchOrPublishOffline() async {
+        let gate = SuspendedRecoveryProbe()
+        let sut = LocalConnectionRecoveryHarness(probes: [])
+        sut.probeOverride = {
+            await gate.wait()
+            return .unavailable
+        }
+        let oldGeneration = sut.generation
+
+        let task = Task { await sut.run(generation: oldGeneration) }
+        await gate.waitUntilEntered()
+        sut.generation += 1
+        await gate.release()
+        await task.value
+
+        #expect(sut.startCount == 0)
+        #expect(sut.offlineCount == 0)
+        #expect(sut.pauseCount == 0)
+    }
+
+    @MainActor
+    @Test func busyLifecycleDefersWithoutConsumingThenLaunchesOnceReleased() async throws {
+        let owner = LocalRuntimeLifecycleOwner()
+        let busyLease = try #require(owner.claim(.installation))
+        let sut = LocalConnectionRecoveryHarness(
+            lifecycleOwner: owner,
+            probes: [.unavailable, .unavailable, .unavailable])
+        sut.pauseActions[1] = { owner.release(busyLease) }
+
+        await sut.run()
+
+        #expect(sut.startCount == 1)
+        #expect(sut.probeCount >= 3)
+    }
+
+    @MainActor
+    @Test func exhaustedAllowanceKeepsPollingAndExternalRecoveryRearmsIt() async {
+        let sut = LocalConnectionRecoveryHarness(
+            probes: [.unavailable, .unavailable, .connected, .unavailable],
+            polls: [false], starts: [false, true])
+
+        await sut.run()
+
+        #expect(sut.startCount == 2)
+        #expect(sut.pollCount == 1)
+        #expect(sut.prepareCount == 5)
+    }
+
+    @MainActor
+    @Test func manualReconnectRetiresOldGenerationAndFreshGenerationCanLaunch() async {
+        let gate = SuspendedRecoveryProbe()
+        let sut = LocalConnectionRecoveryHarness(probes: [])
+        sut.probeOverride = {
+            await gate.wait()
+            return .unavailable
+        }
+        let oldGeneration = sut.generation
+
+        let oldTask = Task { await sut.run(generation: oldGeneration) }
+        await gate.waitUntilEntered()
+        sut.generation += 1
+        await gate.release()
+        await oldTask.value
+        #expect(sut.startCount == 0)
+
+        sut.probeOverride = nil
+        sut.probeResults = [.unavailable]
+        await sut.run(generation: sut.generation)
+
+        #expect(sut.startCount == 1)
+    }
+}

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonGenerationFenceTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonGenerationFenceTests.swift
@@ -71,6 +71,122 @@ private final class GenerationFenceURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
+private final class LostCompletionHandshakeGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var entered = false
+    private var released = false
+
+    var hasEntered: Bool { condition.withLock { entered } }
+
+    func block() {
+        condition.lock()
+        entered = true
+        condition.broadcast()
+        while !released { condition.wait() }
+        condition.unlock()
+    }
+
+    func release() {
+        condition.withLock {
+            released = true
+            condition.broadcast()
+        }
+    }
+}
+
+/// Production-shaped unavailable handshake: the first `/v2/handshake` can be
+/// held across another lifecycle completion, then every attempt fails through
+/// the real `GatewayClient`/`AppModel.tryConnect` path.
+private final class LostCompletionURLProtocol: URLProtocol {
+    private static let stateLock = NSLock()
+    nonisolated(unsafe) private static var firstHandshakeGate:
+        LostCompletionHandshakeGate?
+    nonisolated(unsafe) private static var handshakeAttempts = 0
+
+    static func reset(gate: LostCompletionHandshakeGate?) {
+        stateLock.withLock {
+            firstHandshakeGate = gate
+            handshakeAttempts = 0
+        }
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        switch request.url?.path {
+        case "/healthz":
+            respond(status: 200, body: #"{"ok":true}"#)
+        case "/v2/handshake":
+            let (attempt, gate) = Self.stateLock.withLock {
+                Self.handshakeAttempts += 1
+                return (Self.handshakeAttempts, Self.firstHandshakeGate)
+            }
+            if attempt == 1 { gate?.block() }
+            respond(status: 503, body: #"{"error":"booting"}"#)
+        default:
+            client?.urlProtocol(self, didFailWithError: GenerationFenceTestError.unexpectedRequest)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private func respond(status: Int, body: String) {
+        let response = generationFenceResponse(request, status: status)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data(body.utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+}
+
+@MainActor
+private final class LostCompletionRecoveryHarness {
+    let model: AppModel
+    let candidate: GatewayClient
+    private(set) var probeCount = 0
+    private(set) var fallbackStartsAtProbe: [Int] = []
+    private(set) var pauseCount = 0
+
+    init() {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [LostCompletionURLProtocol.self]
+        candidate = GatewayClient(
+            baseURL: URL(string: "http://127.0.0.1:41180")!, token: "test",
+            session: URLSession(configuration: config))
+        model = AppModel(client: nil, requestNotificationAuthorization: false)
+        model.connectionGeneration = 1
+    }
+
+    var owner: LocalRuntimeLifecycleOwner { model.localRuntimeLifecycleOwner }
+
+    func run() async {
+        let loop = LocalConnectionRecoveryLoop(
+            generation: 1,
+            currentGeneration: { self.model.connectionGeneration },
+            lifecycleOwner: owner,
+            prepareProbe: {},
+            probe: {
+                self.probeCount += 1
+                return await self.model.tryConnect(
+                    candidate: self.candidate,
+                    endpoint: "127.0.0.1:41180",
+                    generation: 1)
+            },
+            pollConnected: { .unavailable },
+            startDaemon: {
+                self.fallbackStartsAtProbe.append(self.probeCount)
+                return true
+            },
+            enterOffline: {},
+            pause: {
+                self.pauseCount += 1
+                if self.pauseCount == 2 { self.model.connectionGeneration = 2 }
+                await Task.yield()
+            })
+        await loop.run()
+    }
+}
+
 private func generationFenceGateway(port: Int) -> GatewayClient {
     let config = URLSessionConfiguration.ephemeral
     config.protocolClasses = [GenerationFenceURLProtocol.self]
@@ -96,6 +212,15 @@ private func waitForGenerationFence(
     let deadline = ContinuousClock.now.advanced(by: .seconds(5))
     while counter.count == 0, ContinuousClock.now < deadline { await Task.yield() }
     try #require(counter.count > 0, Comment(rawValue: message))
+}
+
+@MainActor
+private func waitForLostCompletionHandshake(
+    _ gate: LostCompletionHandshakeGate
+) async throws {
+    let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+    while !gate.hasEntered, ContinuousClock.now < deadline { await Task.yield() }
+    try #require(gate.hasEntered, "unavailable handshake never suspended")
 }
 
 @MainActor
@@ -220,6 +345,74 @@ private func seedSuccessorProjections(_ model: AppModel) throws {
         #expect(await currentTask.value == .replaced(target))
         #expect(daemon.stops == 1)
         #expect(daemon.starts == 1)
+    }
+
+    @MainActor
+    @Test func unavailableHandshakeCannotDuplicateACompletedReconciliationLaunch() async throws {
+        let handshakeGate = LostCompletionHandshakeGate()
+        LostCompletionURLProtocol.reset(gate: handshakeGate)
+        defer {
+            handshakeGate.release()
+            LostCompletionURLProtocol.reset(gate: nil)
+        }
+        let recovery = LostCompletionRecoveryHarness()
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let stopGate = SuspendedReconciliationEffect()
+        daemon.stopGate = stopGate
+        let reconciler = LocalDaemonReconciler(
+            daemon: daemon,
+            lifecycleOwner: recovery.owner,
+            targetClosure: {
+                LocalRuntimeClosureSelection(
+                    scriptURL: self.script, authority: .bundledStampedProbe)
+            },
+            handshakePollInterval: 0.001,
+            handshakePollTimeout: 0.1)
+
+        let reconciliation = Task { await reconciler.reconcile(serving: old) }
+        await stopGate.waitUntilEntered()
+        let recoveryTask = Task { @MainActor in await recovery.run() }
+        try await waitForLostCompletionHandshake(handshakeGate)
+
+        await stopGate.release()
+        #expect(await reconciliation.value == .replaced(target))
+        #expect(daemon.starts == 1)
+        #expect(recovery.fallbackStartsAtProbe.isEmpty)
+
+        handshakeGate.release()
+        await recoveryTask.value
+
+        // The stale first handshake cannot launch. The still-live allowance is
+        // consumed only after the next independent unavailable handshake.
+        #expect(recovery.probeCount == 2)
+        #expect(recovery.fallbackStartsAtProbe == [2])
+        #expect(recovery.pauseCount == 2)
+        #expect(daemon.starts == 1)
+    }
+
+    @MainActor
+    @Test func unavailableHandshakeCannotDuplicateACompletedInstallationLifecycle() async throws {
+        let handshakeGate = LostCompletionHandshakeGate()
+        LostCompletionURLProtocol.reset(gate: handshakeGate)
+        defer {
+            handshakeGate.release()
+            LostCompletionURLProtocol.reset(gate: nil)
+        }
+        let recovery = LostCompletionRecoveryHarness()
+        let installation = try #require(recovery.owner.claim(.installation))
+        let recoveryTask = Task { @MainActor in await recovery.run() }
+        try await waitForLostCompletionHandshake(handshakeGate)
+
+        recovery.owner.release(installation)
+        #expect(recovery.fallbackStartsAtProbe.isEmpty)
+        handshakeGate.release()
+        await recoveryTask.value
+
+        #expect(recovery.probeCount == 2)
+        #expect(recovery.fallbackStartsAtProbe == [2])
+        #expect(recovery.pauseCount == 2)
     }
 
     @MainActor

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonGenerationFenceTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonGenerationFenceTests.swift
@@ -1,0 +1,356 @@
+import Foundation
+import Testing
+import ClaudexorKit
+@testable import ClaudexorApp
+
+actor SuspendedReconciliationEffect {
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        entered = true
+        let waiters = enteredWaiters
+        enteredWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+        guard !released else { return }
+        await withCheckedContinuation { releaseWaiters.append($0) }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else { return }
+        await withCheckedContinuation { enteredWaiters.append($0) }
+    }
+
+    func release() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters { waiter.resume() }
+    }
+}
+
+private actor ReconciliationGenerationValidity {
+    private var current = true
+
+    func isCurrent() -> Bool { current }
+    func supersede() { current = false }
+}
+
+private enum GenerationFenceTestError: Error { case unexpectedRequest }
+
+private final class GenerationFenceCallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+    func increment() { lock.withLock { value += 1 } }
+    var count: Int { lock.withLock { value } }
+}
+
+private final class GenerationFenceURLProtocol: URLProtocol, @unchecked Sendable {
+    nonisolated(unsafe) static var handler:
+        ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        DispatchQueue.global().async { [self] in
+            do {
+                guard let handler = Self.handler else {
+                    throw GenerationFenceTestError.unexpectedRequest
+                }
+                let (response, data) = try handler(request)
+                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocolDidFinishLoading(self)
+            } catch {
+                client?.urlProtocol(self, didFailWithError: error)
+            }
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private func generationFenceGateway(port: Int) -> GatewayClient {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [GenerationFenceURLProtocol.self]
+    return GatewayClient(
+        baseURL: URL(string: "http://127.0.0.1:\(port)")!, token: "test",
+        session: URLSession(configuration: config))
+}
+
+private func generationFenceResponse(
+    _ request: URLRequest,
+    status: Int = 200
+) -> HTTPURLResponse {
+    HTTPURLResponse(
+        url: request.url!, statusCode: status, httpVersion: "HTTP/1.1",
+        headerFields: ["Content-Type": "application/json"])!
+}
+
+@MainActor
+private func waitForGenerationFence(
+    _ counter: GenerationFenceCallCounter,
+    message: String
+) async throws {
+    let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+    while counter.count == 0, ContinuousClock.now < deadline { await Task.yield() }
+    try #require(counter.count > 0, Comment(rawValue: message))
+}
+
+@MainActor
+private func seedSuccessorProjections(_ model: AppModel) throws {
+    let thread = try JSONDecoder().decode(ThreadSummary.self, from: Data(#"{"id":"new-thread","title":"New","repoRoot":"/tmp/new","mode":null,"workspaceMode":"in_place","authPreference":null,"primaryHarness":null,"eligibleHarnesses":[],"state":"active","trashedAt":null,"purgeAfter":null,"runIds":[],"headRunId":null,"needsHuman":false,"createdAt":"2026-08-13T00:00:00Z","updatedAt":"2026-08-13T00:00:00Z"}"#.utf8))
+    let project = try JSONDecoder().decode(RegisteredProject.self, from: Data(#"{"schemaVersion":1,"id":"new-project","root":"/tmp/new","createdAt":"2026-08-13T00:00:00Z","updatedAt":"2026-08-13T00:00:00Z","nesting":[]}"#.utf8))
+    let secret = try JSONDecoder().decode(SecretInfo.self, from: Data(#"{"name":"new-secret","backend":"keychain","present":true}"#.utf8))
+    model.threads = [thread]
+    model.registeredProjects = [project]
+    model.secretBackend = "keychain"
+    model.storedSecrets = [secret]
+}
+
+@Suite(.serialized) struct LocalDaemonGenerationFenceTests {
+    private let script = URL(fileURLWithPath: "/selected/claudexord.bundle.cjs")
+    private let old = RuntimeClosureIdentity(
+        version: "3.1.2", buildSha: String(repeating: "a", count: 40))
+    private let target = RuntimeClosureIdentity(
+        version: "3.2.0", buildSha: String(repeating: "b", count: 40))
+
+    private func reconciler(_ daemon: ReconciliationDaemonStub) -> LocalDaemonReconciler {
+        LocalDaemonReconciler(
+            daemon: daemon,
+            lifecycleOwner: LocalRuntimeLifecycleOwner(),
+            targetClosure: {
+                LocalRuntimeClosureSelection(
+                    scriptURL: script, authority: .bundledStampedProbe)
+            },
+            handshakePollInterval: 0.001,
+            handshakePollTimeout: 0.1)
+    }
+
+    @Test func supersededGenerationBeforeStopAdmissionPerformsNoLifecycleMutation() async {
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let gate = SuspendedReconciliationEffect()
+        daemon.busyGate = gate
+        let validity = ReconciliationGenerationValidity()
+
+        let task = Task {
+            await reconciler(daemon).reconcile(
+                serving: old, isCurrent: { await validity.isCurrent() })
+        }
+        await gate.waitUntilEntered()
+        await validity.supersede()
+        await gate.release()
+
+        #expect(await task.value == .supersededBeforeLifecycle)
+        #expect(daemon.stops == 0)
+        #expect(daemon.starts == 0)
+    }
+
+    @Test func admittedStopFinishesExactRecoveryAfterGenerationIsSuperseded() async {
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let gate = SuspendedReconciliationEffect()
+        daemon.stopGate = gate
+        let validity = ReconciliationGenerationValidity()
+
+        let task = Task {
+            await reconciler(daemon).reconcile(
+                serving: old, isCurrent: { await validity.isCurrent() })
+        }
+        await gate.waitUntilEntered()
+        await validity.supersede()
+        await gate.release()
+
+        #expect(await task.value == .replaced(target))
+        #expect(daemon.stops == 1)
+        #expect(daemon.starts == 1)
+    }
+
+    @Test func currentGenerationRetriesAfterCoalescedPreStopSupersession() async {
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let gate = SuspendedReconciliationEffect()
+        daemon.busyGate = gate
+        let validity = ReconciliationGenerationValidity()
+        let sut = reconciler(daemon)
+
+        let oldTask = Task {
+            await sut.reconcile(
+                serving: old, isCurrent: { await validity.isCurrent() })
+        }
+        await gate.waitUntilEntered()
+        let currentTask = Task {
+            await sut.reconcile(serving: old, isCurrent: { true })
+        }
+        await Task.yield()
+        await validity.supersede()
+        await gate.release()
+
+        #expect(await oldTask.value == .supersededBeforeLifecycle)
+        #expect(await currentTask.value == .supersededBeforeLifecycle)
+        #expect(daemon.stops == 0)
+        #expect(daemon.starts == 0)
+
+        daemon.busyGate = nil
+        #expect(await sut.reconcile(serving: old) == .replaced(target))
+        #expect(daemon.stops == 1)
+        #expect(daemon.starts == 1)
+    }
+
+    @Test func currentGenerationCoalescesWithCommittedReplacementWithoutSecondStart() async {
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let gate = SuspendedReconciliationEffect()
+        daemon.stopGate = gate
+        let sut = reconciler(daemon)
+
+        let oldTask = Task { await sut.reconcile(serving: old) }
+        await gate.waitUntilEntered()
+        let currentTask = Task { await sut.reconcile(serving: old) }
+        await Task.yield()
+        await gate.release()
+
+        #expect(await oldTask.value == .replaced(target))
+        #expect(await currentTask.value == .replaced(target))
+        #expect(daemon.stops == 1)
+        #expect(daemon.starts == 1)
+    }
+
+    @MainActor
+    @Test func delayedOldHydrationSuccessCannotOverwriteNewConnectionProjections() async throws {
+        defer { GenerationFenceURLProtocol.handler = nil }
+        let model = AppModel(
+            client: generationFenceGateway(port: 41160), requestNotificationAuthorization: false)
+        model.connectionGeneration = 1
+        try seedSuccessorProjections(model)
+
+        for (index, path) in ["/v2/secrets", "/v2/threads", "/v2/projects"].enumerated() {
+            let arrived = GenerationFenceCallCounter()
+            GenerationFenceURLProtocol.handler = { request in
+                guard request.url?.path == path else {
+                    throw GenerationFenceTestError.unexpectedRequest
+                }
+                arrived.increment()
+                Thread.sleep(forTimeInterval: 0.12)
+                let body: String = switch path {
+                case "/v2/secrets": #"{"backend":"file","secrets":[]}"#
+                case "/v2/threads": #"{"threads":[]}"#
+                default: #"{"projects":[]}"#
+                }
+                return (generationFenceResponse(request), Data(body.utf8))
+            }
+            let request: Task<Void, Never> = switch path {
+            case "/v2/secrets": Task { await model.refreshSecrets() }
+            case "/v2/threads": Task { _ = await model.refreshThreads() }
+            default: Task { _ = await model.refreshProjects() }
+            }
+            try await waitForGenerationFence(
+                arrived, message: "old hydration success never started")
+            model.connectionGeneration += 1
+            model.adoptClientForReconnect(generationFenceGateway(port: 41161 + index))
+            await request.value
+        }
+
+        #expect(model.secretBackend == "keychain")
+        #expect(model.storedSecrets.map(\.name) == ["new-secret"])
+        #expect(model.threads.map(\.id) == ["new-thread"])
+        #expect(model.registeredProjects.map(\.id) == ["new-project"])
+    }
+
+    @MainActor
+    @Test func delayedOldHydrationFailureCannotClearNewConnectionProjections() async throws {
+        defer { GenerationFenceURLProtocol.handler = nil }
+        let model = AppModel(
+            client: generationFenceGateway(port: 41164), requestNotificationAuthorization: false)
+        model.connectionGeneration = 1
+        try seedSuccessorProjections(model)
+        model.threadStatus = "new status"
+
+        for (index, path) in ["/v2/secrets", "/v2/threads", "/v2/projects"].enumerated() {
+            let arrived = GenerationFenceCallCounter()
+            GenerationFenceURLProtocol.handler = { request in
+                guard request.url?.path == path else {
+                    throw GenerationFenceTestError.unexpectedRequest
+                }
+                arrived.increment()
+                Thread.sleep(forTimeInterval: 0.12)
+                return (generationFenceResponse(request, status: 503), Data("{}".utf8))
+            }
+            let request: Task<Void, Never> = switch path {
+            case "/v2/secrets": Task { await model.refreshSecrets() }
+            case "/v2/threads": Task { _ = await model.refreshThreads() }
+            default: Task { _ = await model.refreshProjects() }
+            }
+            try await waitForGenerationFence(
+                arrived, message: "old hydration failure never started")
+            model.connectionGeneration += 1
+            model.adoptClientForReconnect(generationFenceGateway(port: 41165 + index))
+            await request.value
+        }
+
+        #expect(model.secretBackend == "keychain")
+        #expect(model.storedSecrets.map(\.name) == ["new-secret"])
+        #expect(model.threads.map(\.id) == ["new-thread"])
+        #expect(model.threadStatus == "new status")
+        #expect(model.registeredProjects.map(\.id) == ["new-project"])
+    }
+
+    @MainActor
+    @Test func generationChangeMidConnectStopsAllLaterHydrationAndStreamAdmission() async throws {
+        defer { GenerationFenceURLProtocol.handler = nil }
+        let candidate = generationFenceGateway(port: 41170)
+        let successor = generationFenceGateway(port: 41171)
+        let model = AppModel(client: nil, requestNotificationAuthorization: false)
+        model.connectionGeneration = 1
+        model.localDaemonReconciler = LocalDaemonReconciler(
+            daemon: AppRuntimeDaemonControl(isBusyProbe: { nil }),
+            lifecycleOwner: model.localRuntimeLifecycleOwner,
+            targetClosure: { nil })
+        let calls = GenerationFenceCallCounter()
+        let runsArrived = GenerationFenceCallCounter()
+        let releaseRuns = DispatchSemaphore(value: 0)
+        defer { releaseRuns.signal() }
+        GenerationFenceURLProtocol.handler = { request in
+            calls.increment()
+            switch request.url?.path {
+            case "/healthz":
+                return (generationFenceResponse(request), Data(#"{"ok":true}"#.utf8))
+            case "/v2/handshake":
+                return (generationFenceResponse(request), Data(#"{"protocolMajor":3,"compatible":true,"operationsPath":"/v2/operations","engine":{"version":"3.3.15","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","entry":"/candidate/daemon.js"}}"#.utf8))
+            case "/v2/runs":
+                runsArrived.increment()
+                releaseRuns.wait()
+                return (generationFenceResponse(request), Data(#"{"runs":[]}"#.utf8))
+            default:
+                throw GenerationFenceTestError.unexpectedRequest
+            }
+        }
+
+        let task = Task { @MainActor in
+            await model.tryConnect(
+                candidate: candidate, endpoint: "127.0.0.1:41170", generation: 1)
+        }
+        try await waitForGenerationFence(
+            runsArrived, message: "connect hydration never reached runs")
+        model.connectionGeneration = 2
+        model.adoptClientForReconnect(successor)
+        model.endpoint = "127.0.0.1:41171"
+        model.health = .connecting
+        releaseRuns.signal()
+
+        #expect(await task.value == .superseded)
+        #expect(model.client === successor)
+        #expect(model.endpoint == "127.0.0.1:41171")
+        #expect(model.health == .connecting)
+        #expect(model.globalStreamTask == nil)
+        #expect(calls.count == 3)
+    }
+}

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonGenerationFenceTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonGenerationFenceTests.swift
@@ -47,7 +47,7 @@ private final class GenerationFenceCallCounter: @unchecked Sendable {
     var count: Int { lock.withLock { value } }
 }
 
-private final class GenerationFenceURLProtocol: URLProtocol, @unchecked Sendable {
+private final class GenerationFenceURLProtocol: URLProtocol {
     nonisolated(unsafe) static var handler:
         ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
@@ -55,18 +55,16 @@ private final class GenerationFenceURLProtocol: URLProtocol, @unchecked Sendable
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        DispatchQueue.global().async { [self] in
-            do {
-                guard let handler = Self.handler else {
-                    throw GenerationFenceTestError.unexpectedRequest
-                }
-                let (response, data) = try handler(request)
-                client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: data)
-                client?.urlProtocolDidFinishLoading(self)
-            } catch {
-                client?.urlProtocol(self, didFailWithError: error)
+        do {
+            guard let handler = Self.handler else {
+                throw GenerationFenceTestError.unexpectedRequest
             }
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
         }
     }
 

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonReconcilerTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonReconcilerTests.swift
@@ -34,6 +34,8 @@ private final class DaemonHandshakeURLProtocol: URLProtocol {
     nonisolated(unsafe) static var engine = EngineBuildIdentity(
         version: "3.1.2", sha: String(repeating: "a", count: 40), entry: "/old/daemon.js")
     nonisolated(unsafe) static var gate: ReconciliationHandshakeGate?
+    /// Issue #165: optional handshake servingMode ("recovery_only"/"normal").
+    nonisolated(unsafe) static var servingMode: String?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -50,7 +52,8 @@ private final class DaemonHandshakeURLProtocol: URLProtocol {
             data = Data(#"{"ok":true}"#.utf8)
         case "/v2/handshake":
             let engine = Self.engine
-            data = Data(#"{"protocolMajor":3,"compatible":true,"operationsPath":"/v2/operations","engine":{"version":"\#(engine.version)","sha":"\#(engine.sha)","entry":"\#(engine.entry)"}}"#.utf8)
+            let mode = Self.servingMode.map { #","servingMode":"\#($0)""# } ?? ""
+            data = Data(#"{"protocolMajor":3,"compatible":true,"operationsPath":"/v2/operations","engine":{"version":"\#(engine.version)","sha":"\#(engine.sha)","entry":"\#(engine.entry)"}\#(mode)}"#.utf8)
         default:
             client?.urlProtocol(self, didFailWithError: ReconciliationTestError())
             return
@@ -428,6 +431,63 @@ final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked Sendable 
         #expect(model.engineIdentity == nil)
         #expect(model.localDaemonReconciliationNotice
             == "The refreshed engine identity did not match the selected runtime. Reconnecting.")
+    }
+
+    @MainActor
+    @Test func recoveryOnlyHandshakeKeepsConnectingWithoutAdoptionOrReconciliation() async {
+        // Issue #165 D5: a recovery-only daemon proves transport but keeps
+        // product admission closed. tryConnect must NOT adopt the candidate,
+        // hydrate, run the reconciliation lifecycle, or earn a fallback
+        // launch — it stays in the Connecting loop (.retryWithoutLaunch).
+        DaemonHandshakeURLProtocol.servingMode = "recovery_only"
+        defer { DaemonHandshakeURLProtocol.servingMode = nil }
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        let model = appModel(daemon)
+        model.connectionGeneration = 1
+        let previousClient = model.client
+        let previousEndpoint = model.endpoint
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [DaemonHandshakeURLProtocol.self]
+        let candidate = GatewayClient(
+            baseURL: URL(string: "http://127.0.0.1:4321")!, token: "test",
+            session: URLSession(configuration: config))
+
+        let result = await model.tryConnect(
+            candidate: candidate, endpoint: "127.0.0.1:4321", generation: 1)
+
+        #expect(result == .retryWithoutLaunch)
+        #expect(model.client === previousClient)
+        #expect(model.endpoint == previousEndpoint)
+        #expect(model.engineIdentity == nil)
+        #expect(daemon.busyProbes == 0)
+        #expect(daemon.stops == 0)
+        #expect(daemon.starts == 0)
+    }
+
+    @MainActor
+    @Test func connectedPollFallsBackToConnectingWhenDaemonReentersRecovery() async {
+        // A daemon RESTARTED into a recovery-needed root re-answers the
+        // steady-state poll with recovery_only: the poll returns
+        // .retryWithoutLaunch (no outage launch, no reconciliation) and
+        // leaves the published state for the recovery loop to unwind.
+        DaemonHandshakeURLProtocol.servingMode = "recovery_only"
+        defer { DaemonHandshakeURLProtocol.servingMode = nil }
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let model = appModel(daemon)
+        model.connectionGeneration = 1
+        model.engineIdentity = DaemonHandshakeURLProtocol.engine
+
+        let result = await model.pollLocalConnection(generation: 1)
+
+        #expect(result == .retryWithoutLaunch)
+        #expect(model.client != nil)
+        #expect(model.engineIdentity?.sha == DaemonHandshakeURLProtocol.engine.sha)
+        #expect(daemon.busyProbes == 0)
+        #expect(daemon.stops == 0)
+        #expect(daemon.starts == 0)
     }
 
     @MainActor

--- a/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonReconcilerTests.swift
+++ b/apps/macos/ClaudexorApp/Tests/ClaudexorAppTests/LocalDaemonReconcilerTests.swift
@@ -5,14 +5,45 @@ import ClaudexorKit
 
 private struct ReconciliationTestError: Error {}
 
+private final class ReconciliationHandshakeGate: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var entered = false
+    private var released = false
+
+    var hasEntered: Bool {
+        condition.withLock { entered }
+    }
+
+    func block() {
+        condition.lock()
+        entered = true
+        condition.broadcast()
+        while !released { condition.wait() }
+        condition.unlock()
+    }
+
+    func release() {
+        condition.withLock {
+            released = true
+            condition.broadcast()
+        }
+    }
+}
+
 private final class DaemonHandshakeURLProtocol: URLProtocol {
     nonisolated(unsafe) static var engine = EngineBuildIdentity(
         version: "3.1.2", sha: String(repeating: "a", count: 40), entry: "/old/daemon.js")
+    nonisolated(unsafe) static var gate: ReconciliationHandshakeGate?
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        Self.gate?.block()
+        respond()
+    }
+
+    private func respond() {
         let data: Data
         switch request.url?.path {
         case "/healthz":
@@ -35,13 +66,15 @@ private final class DaemonHandshakeURLProtocol: URLProtocol {
     override func stopLoading() {}
 }
 
-private final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked Sendable {
+final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked Sendable {
     private let lock = NSLock()
     var busy: Bool? = false
     var targetIdentity: RuntimeClosureIdentity?
     var runningIdentity: RuntimeClosureIdentity?
     var handshakeNilCount = 0
     var busyDelayNanoseconds: UInt64 = 0
+    var busyGate: SuspendedReconciliationEffect?
+    var stopGate: SuspendedReconciliationEffect?
     var stopThrows = false
     var replacementStopRefusal: RuntimeReplacementStopError?
     var startThrows = false
@@ -52,18 +85,24 @@ private final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked S
     private(set) var stoppedIdentities: [RuntimeClosureIdentity] = []
 
     func isBusy() async -> Bool? {
-        let delay = lock.withLock { busyProbes += 1; return busyDelayNanoseconds }
+        let (delay, gate) = lock.withLock {
+            busyProbes += 1
+            return (busyDelayNanoseconds, busyGate)
+        }
         if delay > 0 { try? await Task.sleep(nanoseconds: delay) }
+        await gate?.wait()
         return lock.withLock { busy }
     }
 
     func stopForRuntimeReplacement(expectedIdentity: RuntimeClosureIdentity) async throws {
-        try lock.withLock {
+        let gate = try lock.withLock {
             stops += 1
             stoppedIdentities.append(expectedIdentity)
             if let replacementStopRefusal { throw replacementStopRefusal }
             if stopThrows { throw ReconciliationTestError() }
+            return stopGate
         }
+        await gate?.wait()
     }
 
     func start() throws {
@@ -329,6 +368,7 @@ private final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked S
         #expect(LocalDaemonReconciliationPolicy(.failed(.startFailed))
             == .failOffline(notice: "Engine refresh stopped the previous engine but could not start the selected runtime. Reconnecting."))
         #expect(LocalDaemonReconciliationPolicy(.replaced(target)) == .reconnect)
+        #expect(LocalDaemonReconciliationPolicy(.supersededBeforeLifecycle) == .retry)
     }
 
     @MainActor
@@ -388,6 +428,97 @@ private final class ReconciliationDaemonStub: RuntimeDaemonControl, @unchecked S
         #expect(model.engineIdentity == nil)
         #expect(model.localDaemonReconciliationNotice
             == "The refreshed engine identity did not match the selected runtime. Reconnecting.")
+    }
+
+    @MainActor
+    @Test func stalePollBeforeStopAdmissionCannotLaunchOrPublish() async {
+        DaemonHandshakeURLProtocol.engine = EngineBuildIdentity(
+            version: old.version, sha: old.buildSha, entry: "/old/daemon.js")
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let gate = SuspendedReconciliationEffect()
+        daemon.busyGate = gate
+        let model = appModel(daemon)
+        model.connectionGeneration = 1
+        model.engineIdentity = DaemonHandshakeURLProtocol.engine
+
+        let task = Task { @MainActor in
+            await model.pollLocalConnection(generation: 1)
+        }
+        await gate.waitUntilEntered()
+        model.connectionGeneration = 2
+        await gate.release()
+
+        #expect(await task.value == .superseded)
+        #expect(daemon.stops == 0)
+        #expect(daemon.starts == 0)
+        #expect(model.engineIdentity?.sha == old.buildSha)
+    }
+
+    @MainActor
+    @Test func delayedInitialHandshakeCannotAdoptAfterManualReconnect() async {
+        let gate = ReconciliationHandshakeGate()
+        DaemonHandshakeURLProtocol.gate = gate
+        defer { DaemonHandshakeURLProtocol.gate = nil }
+        DaemonHandshakeURLProtocol.engine = EngineBuildIdentity(
+            version: old.version, sha: old.buildSha, entry: "/old/daemon.js")
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = old
+        let model = appModel(daemon)
+        model.connectionGeneration = 1
+        let oldCandidate = try! #require(model.client)
+        let successor = appModel(ReconciliationDaemonStub()).client!
+
+        let task = Task { @MainActor in
+            await model.tryConnect(
+                candidate: oldCandidate, endpoint: "127.0.0.1:old", generation: 1)
+        }
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while !gate.hasEntered, ContinuousClock.now < deadline { await Task.yield() }
+        #expect(gate.hasEntered)
+        model.connectionGeneration = 2
+        model.adoptClientForReconnect(successor)
+        model.endpoint = "127.0.0.1:new"
+        model.health = .connected
+        model.engineIdentity = EngineBuildIdentity(
+            version: target.version, sha: target.buildSha, entry: "/new/daemon.js")
+        gate.release()
+
+        #expect(await task.value == .superseded)
+        #expect(model.client === successor)
+        #expect(model.endpoint == "127.0.0.1:new")
+        #expect(model.health == .connected)
+        #expect(model.engineIdentity?.sha == target.buildSha)
+        #expect(daemon.busyProbes == 0)
+        #expect(daemon.stops == 0)
+        #expect(daemon.starts == 0)
+    }
+
+    @MainActor
+    @Test func admittedPollRecoveryFinishesButStaleCallerPublishesNothing() async {
+        DaemonHandshakeURLProtocol.engine = EngineBuildIdentity(
+            version: old.version, sha: old.buildSha, entry: "/old/daemon.js")
+        let daemon = ReconciliationDaemonStub()
+        daemon.targetIdentity = target
+        daemon.runningIdentity = target
+        let gate = SuspendedReconciliationEffect()
+        daemon.stopGate = gate
+        let model = appModel(daemon)
+        model.connectionGeneration = 1
+        model.engineIdentity = DaemonHandshakeURLProtocol.engine
+
+        let task = Task { @MainActor in
+            await model.pollLocalConnection(generation: 1)
+        }
+        await gate.waitUntilEntered()
+        model.connectionGeneration = 2
+        await gate.release()
+
+        #expect(await task.value == .superseded)
+        #expect(daemon.stops == 1)
+        #expect(daemon.starts == 1)
+        #expect(model.engineIdentity?.sha == old.buildSha)
     }
 
     @MainActor

--- a/apps/macos/ClaudexorKit/Sources/ClaudexorKit/GatewayProtocol.swift
+++ b/apps/macos/ClaudexorKit/Sources/ClaudexorKit/GatewayProtocol.swift
@@ -12,10 +12,18 @@ import FoundationNetworking
 public struct GatewayHandshakeOutcome: Sendable, Equatable {
     public let ok: Bool
     public let engine: EngineBuildIdentity?
+    /// Serving/admission fact from the handshake (issue #165 D5). Decoded
+    /// leniently: absent (older daemons) means normal product admission.
+    public let servingMode: String?
 
-    public init(ok: Bool, engine: EngineBuildIdentity?) {
+    /// True when the daemon serves ONLY the recovery plane: transport is up
+    /// but product routes are typed-refused until journal recovery completes.
+    public var recoveryOnly: Bool { servingMode == "recovery_only" }
+
+    public init(ok: Bool, engine: EngineBuildIdentity?, servingMode: String? = nil) {
         self.ok = ok
         self.engine = engine
+        self.servingMode = servingMode
     }
 }
 
@@ -47,7 +55,8 @@ func gatewayHandshake(baseURL: URL, token: String, session: URLSession) async th
     // Retain the typed build identity for the About panel. Decoded leniently so a
     // missing/older `engine` object never demotes a healthy connection.
     let engine = (try? JSONDecoder().decode(ControlHandshakeResponse.self, from: data))?.engine
-    return GatewayHandshakeOutcome(ok: true, engine: engine)
+    return GatewayHandshakeOutcome(
+        ok: true, engine: engine, servingMode: json["servingMode"] as? String)
 }
 
 func gatewayHealth(baseURL: URL, token: String, session: URLSession) async throws -> Bool {

--- a/apps/macos/ClaudexorKit/Sources/ClaudexorKit/WireDTOs.swift
+++ b/apps/macos/ClaudexorKit/Sources/ClaudexorKit/WireDTOs.swift
@@ -34,12 +34,23 @@ public struct ControlHandshakeResponse: Codable, Sendable, Equatable {
     public let compatible: Bool
     public let operationsPath: String
     public let engine: EngineBuildIdentity
+    /// Product admission (issue #165 D5): "recovery_only" keeps product routes
+    /// closed while recovery control stays reachable. Absent (older daemons)
+    /// means "normal" — decode stays lenient, never a dropped connection.
+    public let servingMode: String?
 
-    public init(protocolMajor: Int, compatible: Bool, operationsPath: String, engine: EngineBuildIdentity) {
+    public init(
+        protocolMajor: Int,
+        compatible: Bool,
+        operationsPath: String,
+        engine: EngineBuildIdentity,
+        servingMode: String? = nil
+    ) {
         self.protocolMajor = protocolMajor
         self.compatible = compatible
         self.operationsPath = operationsPath
         self.engine = engine
+        self.servingMode = servingMode
     }
 }
 

--- a/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/ClaudexorKitTests.swift
+++ b/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/ClaudexorKitTests.swift
@@ -2104,6 +2104,49 @@ import Testing
         #expect(noEngine.engine == nil)
     }
 
+    @Test func gatewayHandshakeCarriesServingModeAndRecoveryOnlyFact() async throws {
+        // Issue #165 D5: a recovery-only daemon reports servingMode in the
+        // handshake so the app can stay in Connecting instead of adopting a
+        // client whose product routes are typed-refused. Absent servingMode
+        // (older daemons) must keep meaning normal admission.
+        defer { RequestStubURLProtocol.handler = nil }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [RequestStubURLProtocol.self]
+        let client = GatewayClient(
+            baseURL: URL(string: "http://127.0.0.1:1234")!, token: "t",
+            session: URLSession(configuration: config)
+        )
+        func stub(handshakeBody: String) {
+            RequestStubURLProtocol.handler = { request in
+                switch (request.httpMethod, request.url?.path) {
+                case ("GET", "/healthz"):
+                    return (Self.response(for: request), Data(#"{"ok":true}"#.utf8))
+                case ("POST", "/v2/handshake"):
+                    return (Self.response(for: request), Data(handshakeBody.utf8))
+                default:
+                    throw TestTransportError.badRequest(request.url?.absoluteString ?? "nil")
+                }
+            }
+        }
+
+        stub(handshakeBody: #"{"protocolMajor":3,"compatible":true,"operationsPath":"/v2/operations","servingMode":"recovery_only"}"#)
+        let recovering = try await client.handshake()
+        #expect(recovering.ok)
+        #expect(recovering.servingMode == "recovery_only")
+        #expect(recovering.recoveryOnly)
+
+        stub(handshakeBody: #"{"protocolMajor":3,"compatible":true,"operationsPath":"/v2/operations","servingMode":"normal"}"#)
+        let serving = try await client.handshake()
+        #expect(serving.servingMode == "normal")
+        #expect(!serving.recoveryOnly)
+
+        // Pre-#165 daemons omit the field entirely: normal admission.
+        stub(handshakeBody: #"{"protocolMajor":3,"compatible":true,"operationsPath":"/v2/operations"}"#)
+        let legacy = try await client.handshake()
+        #expect(legacy.servingMode == nil)
+        #expect(!legacy.recoveryOnly)
+    }
+
     @Test func gatewayUploadsExactBytesAndFinalizesDigestBeforeReturningReference() async throws {
         defer { RequestStubURLProtocol.handler = nil }
         let config = URLSessionConfiguration.ephemeral

--- a/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/Fixtures/wire/handshake-response-recovery-only.json
+++ b/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/Fixtures/wire/handshake-response-recovery-only.json
@@ -1,0 +1,14 @@
+{
+  "schema": "ControlHandshakeResponse",
+  "value": {
+    "protocolMajor": 3,
+    "compatible": true,
+    "operationsPath": "/v2/operations",
+    "engine": {
+      "version": "3.4.0",
+      "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "entry": "/opt/claudexor/daemon.js"
+    },
+    "servingMode": "recovery_only"
+  }
+}

--- a/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/Fixtures/wire/manifest.json
+++ b/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/Fixtures/wire/manifest.json
@@ -1,6 +1,7 @@
 {
   "handshake-response": "ControlHandshakeResponse",
   "handshake-response-unknown-sha": "ControlHandshakeResponse",
+  "handshake-response-recovery-only": "ControlHandshakeResponse",
   "problem-minimal": "ControlProblem",
   "problem-maximal": "ControlProblem",
   "thread-minimal": "ControlThread",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1397,10 +1397,14 @@ verdict, no truncation), the socket + Control API come up serving
 `recovery_only` — health, handshake, shutdown, and the `/recovery/*` surface
 stay reachable while every product route/RPC is refused with a typed
 `daemon_recovery_only` 503 — and only after transport is provably up does the
-daemon advance the floor, run destructive recovery (activation truncation,
-crash GC, orphan/debris sweeps, retention), and open normal admission. A root
+daemon revalidate every read-only preparation, and only on all-green advance
+the floor, run destructive recovery (activation truncation, crash GC,
+orphan/debris sweeps, retention), and open normal admission. A root
 with a recovery-needed partition keeps the floor unchanged and destructive
-work off, staying online recovery-only instead of dying dark. The handshake
+work off, staying online recovery-only instead of dying dark — the control
+API binds for that plane even under `CLAUDEXOR_NO_CONTROL_API=1`, and a
+successful `/recovery/*` quarantine re-runs the admission completion in
+process, so the daemon transitions to normal serving without a restart. The handshake
 discloses `servingMode` (`normal`/`recovery_only`; absent means a pre-fix
 daemon, treated as normal); the macOS app maps `recovery_only` to its
 existing Connecting loop — no adoption, no hydration, no reconciliation, no

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1376,6 +1376,36 @@ by pid and a digest of its token, then preserves that tombstone so a delayed
 contender cannot quarantine a live successor. Acquisition is the only
 quarantine mutator and tombstones have no automatic GC.
 
+Above the per-socket lease sits a PERSISTENT root authority for the shared
+data root. Before any journal work the daemon validates/installs a permanent
+barrier at the canonical default writer address: the lease directory carries
+`root-authority-v2.json` and no top-level owner record, so a pre-fix claimant's
+owner parse fails closed forever (it can neither adopt nor quarantine the
+address), while fixed runtimes contend on a nested `active` slot inside the
+barrier. First migration of an owned flat generation is an in-place atomic
+owner replacement (owner record swapped for an unparseable migration sentinel,
+marker published, sentinel retired), so the address is never absent and never
+carries a dead parseable owner; an already-live pre-fix owner still refuses the
+candidate through the shared lease machinery and cannot be retroactively
+revoked. The barrier record persists two separate facts, both refused typed
+and fail-closed: the writer protocol epoch (foreign epochs refused) and the
+semantic-version floor of the last runtime that PROVED it could serve
+(strictly lower versions refused; equal versions contend normally). The
+barrier survives clean shutdown and is never automatically removed. Startup
+itself is two-stage: after authority, the journal is prepared READ-ONLY (scan/
+verdict, no truncation), the socket + Control API come up serving
+`recovery_only` — health, handshake, shutdown, and the `/recovery/*` surface
+stay reachable while every product route/RPC is refused with a typed
+`daemon_recovery_only` 503 — and only after transport is provably up does the
+daemon advance the floor, run destructive recovery (activation truncation,
+crash GC, orphan/debris sweeps, retention), and open normal admission. A root
+with a recovery-needed partition keeps the floor unchanged and destructive
+work off, staying online recovery-only instead of dying dark. The handshake
+discloses `servingMode` (`normal`/`recovery_only`; absent means a pre-fix
+daemon, treated as normal); the macOS app maps `recovery_only` to its
+existing Connecting loop — no adoption, no hydration, no reconciliation, no
+fallback launch — until admission opens.
+
 Termination, local and remote runtime replacement, and the real-harness
 battery consume the same strict owner classification. They recheck the exact
 generation at the action boundary; classification alone never grants signal

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1364,7 +1364,28 @@ Explicit operator shutdown keeps its forceful semantics. The daemon records its
 birth identity in the writer lease at startup; `claudexor daemon stop` then CONFIRMS death
 (released lease, gone pid, or identity-verified SIGKILL escalation — a
 recycled pid is never signalled) before reporting success, so scripts and
-test disposers can trust its exit code. Stdio bridges (`mcp serve`/`acp
+test disposers can trust its exit code. The lease is acquired before the
+daemon publishes its socket or Control descriptor, so a present lease without
+a reachable socket remains a protected startup window unless its owner is
+proven stale. That proof is deliberately narrow: a missing pid, a birth-identity
+mismatch, or exact Linux `/proc` state `Z` is stale; a matching non-zombie
+owner, malformed or unreadable authority, and any unavailable identity/state
+proof remain fail-closed. Recovery never signals the stale owner. Acquisition
+moves the exact stale generation to a deterministic, nonempty tombstone keyed
+by pid and a digest of its token, then preserves that tombstone so a delayed
+contender cannot quarantine a live successor. Acquisition is the only
+quarantine mutator and tombstones have no automatic GC.
+
+Termination, local and remote runtime replacement, and the real-harness
+battery consume the same strict owner classification. They recheck the exact
+generation at the action boundary; classification alone never grants signal
+authority, and only an explicitly pinned, identity-matching capable owner may
+be escalated. Socket-unreachable plus an absent or proven-stale lease may prove
+an idempotent stopped state, while capable or uncertain ownership blocks. The
+battery may start through a stale lease because normal acquisition heals it,
+but cleanup succeeds only after the main lease is physically absent.
+
+Stdio bridges (`mcp serve`/`acp
 serve`) bound their life to their host's with a reparent watchdog — a dead
 host whose pipe stays open (inherited fds) no longer leaves an idle bridge.
 No-project command state, setup, and the project registry

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -801,7 +801,7 @@ always preferred.
 | `CLAUDEXOR_RAWAPI_BASE_URL` / `CLAUDEXOR_RAWAPI_KEY` / `CLAUDEXOR_RAWAPI_MODEL` | raw-api adapter | OpenAI-compatible endpoint, key, and model for the raw-API route. |
 | `CLAUDEXOR_OPENROUTER_BASE_URL` / `CLAUDEXOR_OPENROUTER_MODEL` | openrouter route | Base URL and default model for the built-in OpenRouter raw-API instance (key: `OPENROUTER_API_KEY`). |
 | `CLAUDEXOR_CONTROL_PORT` | daemon | Pin the control-API port (default: OS-assigned loopback port). |
-| `CLAUDEXOR_NO_CONTROL_API` | daemon | Start the daemon without the HTTP control API (socket only). |
+| `CLAUDEXOR_NO_CONTROL_API` | daemon | Start the daemon without the HTTP control API (socket only). A recovery-required startup verdict overrides it and binds the control API anyway — the `/recovery/*` surface is the recovery plane's point — and the override is disclosed in the daemon log. |
 | `CLAUDEXOR_DAEMON_SOCK` | daemon | Override the daemon's UNIX socket path. |
 | `CLAUDEXOR_DAEMON_ENTRY` | remote runtime wrapper | Internal path to the bundled daemon entrypoint used by `claudexor remote bootstrap`; release-built wrappers set it, users do not. |
 | `CLAUDEXOR_DAEMON_LAUNCH_SOURCE` | daemon (internal child env) | Launch-provenance marker (`cli_ensure_daemon` / `cli_explicit_start`) the CLI stamps into the environment of a detached daemon it spawns, so a running daemon process discloses which caller launched it. Never set by hand. |

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -804,6 +804,7 @@ always preferred.
 | `CLAUDEXOR_NO_CONTROL_API` | daemon | Start the daemon without the HTTP control API (socket only). |
 | `CLAUDEXOR_DAEMON_SOCK` | daemon | Override the daemon's UNIX socket path. |
 | `CLAUDEXOR_DAEMON_ENTRY` | remote runtime wrapper | Internal path to the bundled daemon entrypoint used by `claudexor remote bootstrap`; release-built wrappers set it, users do not. |
+| `CLAUDEXOR_DAEMON_LAUNCH_SOURCE` | daemon (internal child env) | Launch-provenance marker (`cli_ensure_daemon` / `cli_explicit_start`) the CLI stamps into the environment of a detached daemon it spawns, so a running daemon process discloses which caller launched it. Never set by hand. |
 | `CLAUDEXOR_REMOTE_RUNTIME` | remote runtime wrapper / core | Internal `1` marker set by signed remote-runtime wrappers. It adds the app-owned remote vendor CLI directory to harness discovery ahead of inherited PATH entries; users do not set it. |
 | `CLAUDEXOR_DOCTOR_TTL_MS` / `CLAUDEXOR_DOCTOR_NON_OK_TTL_MS` | doctor | Cache TTLs for ok / non-ok doctor probes. |
 | `CLAUDEXOR_CLI_PATH` / `CLAUDEXOR_NODE_PATH` | plugins | Paths baked into generated host-plugin MCP configs (set by the installer, rarely by hand). |

--- a/packages/cli/src/claudexord-entry.ts
+++ b/packages/cli/src/claudexord-entry.ts
@@ -1,12 +1,26 @@
 import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { engineBuildIdentity } from "@claudexor/util";
 
 /**
  * Side-effect-free dispatch for the daemon executable's alternate belt role.
  * Kept outside claudexord.ts so the daemon owner remains below its readability
  * ratchet and the entry decision can be tested without daemon initialization.
  */
+/** Handle `claudexord --probe`: print the engine build identity as ONE JSON line
+ * ({version, buildSha}) and exit WITHOUT any durable startup — no writer lease,
+ * no socket bind, no journal open, no runtime root. This is the pre-swap
+ * handshake the macOS installer's RuntimeInstallCoordinator.probeVersion runs
+ * against a freshly-unpacked closure with the app-bundled Node (D-2). Returns
+ * true when the probe handled the invocation. */
+export function runProbeIfRequested(argv: readonly string[]): boolean {
+  if (!argv.includes("--probe")) return false;
+  const id = engineBuildIdentity();
+  process.stdout.write(`${JSON.stringify({ version: id.version, buildSha: id.sha })}\n`);
+  return true;
+}
+
 export function isBeltServeInvocation(argv: readonly string[]): boolean {
   return argv.length === 2 && argv[0] === "mcp" && argv[1] === "serve-belt";
 }

--- a/packages/cli/src/claudexord-launch-provenance.test.ts
+++ b/packages/cli/src/claudexord-launch-provenance.test.ts
@@ -1,0 +1,122 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * C8 (sol SCOPE-06 + grok G-DIAG-01): claudexord owns the private
+ * post-authority diagnostic file. A started daemon must write structured
+ * records with full launch provenance (launch source, runtime version, build
+ * sha, entry path, pid, data root) into the canonical claudexord.log —
+ * that is what `claudexor daemon logs` and incident forensics read.
+ */
+
+const daemonEntry = resolve(import.meta.dirname, "../dist/claudexord.js");
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const dispose of cleanups.splice(0)) dispose();
+});
+
+function freshRoot(): string {
+  const root = realpathSync(mkdtempSync(join(realpathSync("/tmp"), "cx-prov-")));
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  return join(root, "config");
+}
+
+function spawnDaemon(config: string, extraEnv: Record<string, string> = {}): ChildProcess {
+  const child = spawn(process.execPath, [daemonEntry], {
+    stdio: ["ignore", "ignore", "pipe"],
+    env: {
+      HOME: process.env.HOME ?? "/tmp",
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      CLAUDEXOR_CONFIG_DIR: config,
+      ...extraEnv,
+    },
+  });
+  cleanups.push(() => {
+    if (child.exitCode === null) child.kill("SIGKILL");
+  });
+  return child;
+}
+
+async function waitFor<T>(probe: () => T | null, what: string, timeoutMs = 20_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = probe();
+    if (value !== null) return value;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
+function diagnosticRecords(config: string): Array<Record<string, unknown>> {
+  const path = join(config, "daemon", "claudexord.log");
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .flatMap((line) => {
+      try {
+        const value = JSON.parse(line) as Record<string, unknown>;
+        return value && typeof value === "object" ? [value] : [];
+      } catch {
+        return []; // human logLine rows interleave with the structured records
+      }
+    });
+}
+
+describe("daemon startup diagnostics ownership (C8)", () => {
+  it("a started daemon writes private diagnostic records with full launch provenance", async () => {
+    const config = freshRoot();
+    const daemon = spawnDaemon(config, {
+      CLAUDEXOR_DAEMON_LAUNCH_SOURCE: "cli_ensure_daemon",
+    });
+    await waitFor(
+      () =>
+        daemon.exitCode === null && existsSync(join(config, "daemon", "control-api.json"))
+          ? true
+          : null,
+      "the daemon to come up",
+    );
+    const records = await waitFor(
+      () => {
+        const found = diagnosticRecords(config);
+        return found.length > 0 ? found : null;
+      },
+      "structured diagnostic records in claudexord.log",
+    );
+    const provenance = records.find((record) => record.launchSource === "cli_ensure_daemon");
+    expect(provenance, "no record carries the launch source").toBeDefined();
+    expect(provenance).toMatchObject({
+      launchSource: "cli_ensure_daemon",
+      pid: daemon.pid,
+      stage: expect.stringMatching(/^[a-z0-9][a-z0-9._-]*$/) as unknown,
+    });
+    expect(typeof provenance?.runtimeVersion).toBe("string");
+    expect(typeof provenance?.buildSha).toBe("string");
+    expect(typeof provenance?.entryPath).toBe("string");
+    expect(typeof provenance?.dataRoot).toBe("string");
+    daemon.kill("SIGTERM");
+  }, 40_000);
+
+  it("an unset launch source records as 'unknown' instead of failing startup", async () => {
+    const config = freshRoot();
+    const daemon = spawnDaemon(config);
+    await waitFor(
+      () =>
+        daemon.exitCode === null && existsSync(join(config, "daemon", "control-api.json"))
+          ? true
+          : null,
+      "the daemon to come up",
+    );
+    const records = await waitFor(
+      () => {
+        const found = diagnosticRecords(config);
+        return found.length > 0 ? found : null;
+      },
+      "structured diagnostic records in claudexord.log",
+    );
+    expect(records.some((record) => record.launchSource === "unknown")).toBe(true);
+    daemon.kill("SIGTERM");
+  }, 40_000);
+});

--- a/packages/cli/src/claudexord-launch-provenance.test.ts
+++ b/packages/cli/src/claudexord-launch-provenance.test.ts
@@ -78,13 +78,10 @@ describe("daemon startup diagnostics ownership (C8)", () => {
           : null,
       "the daemon to come up",
     );
-    const records = await waitFor(
-      () => {
-        const found = diagnosticRecords(config);
-        return found.length > 0 ? found : null;
-      },
-      "structured diagnostic records in claudexord.log",
-    );
+    const records = await waitFor(() => {
+      const found = diagnosticRecords(config);
+      return found.length > 0 ? found : null;
+    }, "structured diagnostic records in claudexord.log");
     const provenance = records.find((record) => record.launchSource === "cli_ensure_daemon");
     expect(provenance, "no record carries the launch source").toBeDefined();
     expect(provenance).toMatchObject({
@@ -109,13 +106,10 @@ describe("daemon startup diagnostics ownership (C8)", () => {
           : null,
       "the daemon to come up",
     );
-    const records = await waitFor(
-      () => {
-        const found = diagnosticRecords(config);
-        return found.length > 0 ? found : null;
-      },
-      "structured diagnostic records in claudexord.log",
-    );
+    const records = await waitFor(() => {
+      const found = diagnosticRecords(config);
+      return found.length > 0 ? found : null;
+    }, "structured diagnostic records in claudexord.log");
     expect(records.some((record) => record.launchSource === "unknown")).toBe(true);
     daemon.kill("SIGTERM");
   }, 40_000);

--- a/packages/cli/src/claudexord-probe.test.ts
+++ b/packages/cli/src/claudexord-probe.test.ts
@@ -2,10 +2,12 @@ import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+import { type DaemonWriterLeaseStatus } from "@claudexor/daemon";
 import { CLAUDEXOR_VERSION } from "@claudexor/util";
 import { runProbeIfRequested } from "./claudexord.js";
 import {
   admitAndAwaitRuntimeReplacementStop,
+  decideRuntimeReplacementWithoutControl,
   runStopIfRequested,
 } from "./runtime-replacement-stop.js";
 
@@ -13,6 +15,64 @@ const EXPECTED_VERSION = "3.4.0";
 const EXPECTED_BUILD_SHA = "b".repeat(40);
 const STOP_ARGS = ["--stop", EXPECTED_VERSION, EXPECTED_BUILD_SHA];
 const LEASE_OWNER = { pid: 4242, token: "lease-owner" };
+const KNOWN_OBSERVATION = {
+  identity: {
+    status: "known",
+    pid: LEASE_OWNER.pid,
+    platform: "linux",
+    source: "procfs_stat",
+    startToken: "linux:4242",
+    processGroupId: LEASE_OWNER.pid,
+  },
+  linuxState: "S",
+} as const;
+const CAPABLE_LEASE = {
+  status: "owned",
+  path: "/tmp/test-daemon.sock.writer",
+  owner: LEASE_OWNER,
+  capability: {
+    status: "capable",
+    reason: "legacy_process_present",
+    observation: KNOWN_OBSERVATION,
+  },
+} satisfies DaemonWriterLeaseStatus;
+const STALE_LEASE = {
+  status: "owned",
+  path: "/tmp/test-daemon.sock.writer",
+  owner: LEASE_OWNER,
+  capability: {
+    status: "proven_stale",
+    reason: "linux_zombie",
+    observation: { ...KNOWN_OBSERVATION, linuxState: "Z" },
+  },
+} satisfies DaemonWriterLeaseStatus;
+const ABSENT_LEASE = {
+  status: "absent",
+  path: "/tmp/test-daemon.sock.writer",
+} satisfies DaemonWriterLeaseStatus;
+const UNKNOWN_LEASE = {
+  status: "unknown",
+  path: "/tmp/test-daemon.sock.writer",
+  reason: "owner_malformed",
+} satisfies DaemonWriterLeaseStatus;
+const UNKNOWN_ACTIVITY_LEASE = {
+  status: "owned",
+  path: "/tmp/test-daemon.sock.writer",
+  owner: LEASE_OWNER,
+  capability: {
+    status: "unknown",
+    reason: "identity_unavailable",
+    observation: {
+      identity: {
+        status: "unknown",
+        pid: LEASE_OWNER.pid,
+        platform: "linux",
+        reason: "permission_denied",
+      },
+      linuxState: null,
+    },
+  },
+} satisfies DaemonWriterLeaseStatus;
 
 describe("claudexord --probe (D-2 install probe)", () => {
   it("handles --probe and ignores a normal argv", () => {
@@ -43,6 +103,20 @@ describe("claudexord --probe (D-2 install probe)", () => {
 });
 
 describe("claudexord --stop (runtime replacement admission)", () => {
+  it.each([
+    [false, ABSENT_LEASE, "already_stopped"],
+    [false, STALE_LEASE, "already_stopped"],
+    [false, CAPABLE_LEASE, "activity_unknown"],
+    [false, UNKNOWN_ACTIVITY_LEASE, "activity_unknown"],
+    [false, UNKNOWN_LEASE, "activity_unknown"],
+    [true, ABSENT_LEASE, "activity_unknown"],
+  ] satisfies readonly (readonly [boolean, DaemonWriterLeaseStatus, string])[])(
+    "shares the strict no-Control matrix for reachable=%s and lease=%s",
+    (reachable, lease, expected) => {
+      expect(decideRuntimeReplacementWithoutControl(reachable, lease).status).toBe(expected);
+    },
+  );
+
   it("projects a typed busy refusal without waiting for termination", async () => {
     const previousExitCode = process.exitCode;
     const output: string[] = [];
@@ -53,7 +127,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => "test-token",
         socketAlive: async () => true,
-        leaseOwner: () => LEASE_OWNER,
+        inspectLease: () => CAPABLE_LEASE,
         client: () => ({
           shutdownForRuntimeReplacement: async () => {
             throw Object.assign(new Error("work became active"), {
@@ -94,7 +168,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => "test-token",
         socketAlive: async () => true,
-        leaseOwner: () => LEASE_OWNER,
+        inspectLease: () => CAPABLE_LEASE,
         client: () => ({
           shutdownForRuntimeReplacement: async () => {
             throw new Error("daemon connection closed");
@@ -131,7 +205,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => "test-token",
         socketAlive: async () => true,
-        leaseOwner: () => LEASE_OWNER,
+        inspectLease: () => CAPABLE_LEASE,
         client: () => ({
           shutdownForRuntimeReplacement: async () => {
             throw new Error("unknown method: claudexor.shutdownForRuntimeReplacement");
@@ -166,7 +240,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => "test-token",
         socketAlive: async () => true,
-        leaseOwner: () => LEASE_OWNER,
+        inspectLease: () => CAPABLE_LEASE,
         client: () => ({
           shutdownForRuntimeReplacement: async (expected) => {
             expect(expected).toEqual({
@@ -250,7 +324,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => null,
         socketAlive: async () => true,
-        leaseOwner: () => LEASE_OWNER,
+        inspectLease: () => CAPABLE_LEASE,
         client: () => {
           clients += 1;
           throw new Error("must not construct a client");
@@ -284,7 +358,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => null,
         socketAlive: async () => false,
-        leaseOwner: () => null,
+        inspectLease: () => ABSENT_LEASE,
         client: () => {
           throw new Error("must not construct a client");
         },
@@ -294,6 +368,61 @@ describe("claudexord --stop (runtime replacement admission)", () => {
 
       expect(process.exitCode).toBeUndefined();
       expect(JSON.parse(output.join(""))).toEqual({ stopped: true, alreadyStopped: true });
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("treats an unreachable proven-stale lease as idempotently stopped without targeting it", async () => {
+    const previousExitCode = process.exitCode;
+    const output: string[] = [];
+    let clients = 0;
+    try {
+      process.exitCode = undefined;
+      await runStopIfRequested(STOP_ARGS, {
+        socketPath: () => "/tmp/test-daemon.sock",
+        readToken: () => "unused",
+        socketAlive: async () => false,
+        inspectLease: () => STALE_LEASE,
+        client: () => {
+          clients += 1;
+          throw new Error("must not construct a client");
+        },
+        awaitTermination: async () => ({ outcome: "still_alive", detail: "unused" }),
+        write: (line) => output.push(line),
+      });
+
+      expect(clients).toBe(0);
+      expect(process.exitCode).toBeUndefined();
+      expect(JSON.parse(output.join(""))).toEqual({ stopped: true, alreadyStopped: true });
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("refuses malformed writer-lease authority while the socket is unreachable", async () => {
+    const previousExitCode = process.exitCode;
+    const output: string[] = [];
+    try {
+      process.exitCode = undefined;
+      await runStopIfRequested(STOP_ARGS, {
+        socketPath: () => "/tmp/test-daemon.sock",
+        readToken: () => "unused",
+        socketAlive: async () => false,
+        inspectLease: () => UNKNOWN_LEASE,
+        client: () => {
+          throw new Error("must not construct a client");
+        },
+        awaitTermination: async () => ({ outcome: "exited", detail: "unused" }),
+        write: (line) => output.push(line),
+      });
+
+      expect(process.exitCode).toBe(1);
+      expect(JSON.parse(output.join(""))).toMatchObject({
+        stopped: false,
+        code: "runtime_activity_unknown",
+        retryable: true,
+      });
     } finally {
       process.exitCode = previousExitCode;
     }
@@ -310,7 +439,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
         socketPath: () => "/tmp/test-daemon.sock",
         readToken: () => "test-token",
         socketAlive: async () => false,
-        leaseOwner: () => LEASE_OWNER,
+        inspectLease: () => CAPABLE_LEASE,
         client: () => {
           clients += 1;
           throw new Error("must not construct a client");
@@ -335,6 +464,37 @@ describe("claudexord --stop (runtime replacement admission)", () => {
     }
   });
 
+  it("refuses a reachable socket whose fresh strict writer owner is proven stale", async () => {
+    const previousExitCode = process.exitCode;
+    const output: string[] = [];
+    let clients = 0;
+    try {
+      process.exitCode = undefined;
+      await runStopIfRequested(STOP_ARGS, {
+        socketPath: () => "/tmp/test-daemon.sock",
+        readToken: () => "test-token",
+        socketAlive: async () => true,
+        inspectLease: () => STALE_LEASE,
+        client: () => {
+          clients += 1;
+          throw new Error("must not construct a client");
+        },
+        awaitTermination: async () => ({ outcome: "exited", detail: "unused" }),
+        write: (line) => output.push(line),
+      });
+
+      expect(clients).toBe(0);
+      expect(process.exitCode).toBe(1);
+      expect(JSON.parse(output.join(""))).toMatchObject({
+        stopped: false,
+        code: "runtime_activity_unknown",
+        retryable: true,
+      });
+    } finally {
+      process.exitCode = previousExitCode;
+    }
+  });
+
   it("rejects a stop invocation without exact identity before probing daemon state", async () => {
     const previousExitCode = process.exitCode;
     const output: string[] = [];
@@ -348,7 +508,7 @@ describe("claudexord --stop (runtime replacement admission)", () => {
           socketChecks += 1;
           return false;
         },
-        leaseOwner: () => null,
+        inspectLease: () => ABSENT_LEASE,
         client: () => {
           throw new Error("must not construct a client");
         },

--- a/packages/cli/src/claudexord-probe.test.ts
+++ b/packages/cli/src/claudexord-probe.test.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { type DaemonWriterLeaseStatus } from "@claudexor/daemon";
 import { CLAUDEXOR_VERSION } from "@claudexor/util";
-import { runProbeIfRequested } from "./claudexord.js";
+import { runProbeIfRequested } from "./claudexord-entry.js";
 import {
   admitAndAwaitRuntimeReplacementStop,
   decideRuntimeReplacementWithoutControl,

--- a/packages/cli/src/claudexord-recovery-reopen.test.ts
+++ b/packages/cli/src/claudexord-recovery-reopen.test.ts
@@ -23,17 +23,22 @@ import { afterEach, describe, expect, it } from "vitest";
  */
 
 const daemonEntry = resolve(import.meta.dirname, "../dist/claudexord.js");
-const cleanups: Array<() => void> = [];
+const cleanups: Array<() => void | Promise<void>> = [];
 
-afterEach(() => {
-  for (const dispose of cleanups.splice(0)) dispose();
+// Dispose in REVERSE registration order so a spawned daemon is killed and
+// REAPED before its root is removed: a SIGTERMed daemon still writes during
+// shutdown, and a recursive rm racing those writes fails ENOTEMPTY on Linux.
+afterEach(async () => {
+  for (const dispose of cleanups.splice(0).reverse()) await dispose();
 });
 
 function corruptGlobalRoot(): string {
   // A SHORT real root (belt-entry convention): the daemon binds a Unix socket
   // under it, and the darwin per-user tmpdir would blow the 104-char limit.
   const root = realpathSync(mkdtempSync(join(realpathSync("/tmp"), "cx-reopen-")));
-  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  cleanups.push(() =>
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }),
+  );
   const config = join(root, "config");
   const partitionDir = journalPartitionDirectory(join(config, "daemon", "journal"), "global");
   mkdirSync(partitionDir, { recursive: true });
@@ -52,7 +57,9 @@ async function seedRegisteredProjects(
   count: number,
 ): Promise<{ config: string; projectIds: string[] }> {
   const root = realpathSync(mkdtempSync(join(realpathSync("/tmp"), "cx-mixed-")));
-  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  cleanups.push(() =>
+    rmSync(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 }),
+  );
   const config = join(root, "config");
   mkdirSync(config, { recursive: true });
   chmodSync(config, 0o700);
@@ -180,8 +187,13 @@ function spawnDaemon(
   child.stderr?.on("data", (chunk) => {
     stderr += String(chunk);
   });
-  cleanups.push(() => {
-    if (child.exitCode === null) child.kill("SIGKILL");
+  cleanups.push(async () => {
+    if (child.exitCode !== null) return;
+    child.kill("SIGKILL");
+    await waitFor(
+      () => (child.exitCode === null && child.signalCode === null ? null : true),
+      "the daemon to be reaped",
+    );
   });
   return Object.assign(child, { stderrText: () => stderr });
 }

--- a/packages/cli/src/claudexord-recovery-reopen.test.ts
+++ b/packages/cli/src/claudexord-recovery-reopen.test.ts
@@ -45,6 +45,124 @@ function corruptGlobalRoot(): string {
   return config;
 }
 
+/** Mixed-root fixture (S2-CR1): a HEALTHY global journal with `count`
+ * registered projects, built by a real seed daemon so the registry and the
+ * project partitions carry genuine bytes. The caller corrupts partitions. */
+async function seedRegisteredProjects(
+  count: number,
+): Promise<{ config: string; projectIds: string[] }> {
+  const root = realpathSync(mkdtempSync(join(realpathSync("/tmp"), "cx-mixed-")));
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  const config = join(root, "config");
+  mkdirSync(config, { recursive: true });
+  chmodSync(config, 0o700);
+  const daemon = spawnDaemon(config);
+  const addr = await waitFor(
+    () => (daemon.exitCode !== null ? null : controlAddress(config)),
+    "the seed daemon control API pointer",
+  );
+  try {
+    await waitForServingMode(addr, "normal");
+  } catch (error) {
+    let log = "";
+    try {
+      log = readFileSync(join(config, "daemon", "claudexord.log"), "utf8").slice(-1500);
+    } catch {}
+    throw new Error(
+      `seed daemon never reached normal: ${error instanceof Error ? error.message : String(error)}; exitCode=${daemon.exitCode}; stderr=${daemon.stderrText().slice(-1000)}; log=${log}`,
+    );
+  }
+  const projectIds: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const projectRoot = join(root, `project-${index}`);
+    mkdirSync(projectRoot, { recursive: true });
+    const response = await fetch(`${addr.base}/v2/projects`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${addr.token}`,
+        "x-claudexor-protocol-major": "3",
+        "content-type": "application/json",
+        "idempotency-key": randomUUID(),
+      },
+      body: JSON.stringify({ root: projectRoot }),
+    });
+    expect(response.status, await response.clone().text()).toBe(200);
+    projectIds.push(((await response.json()) as { id: string }).id);
+  }
+  daemon.kill("SIGTERM");
+  await waitFor(() => (daemon.exitCode === null ? null : true), "the seed daemon to exit");
+  // Drop the seed daemon's control pointer so the daemon under test cannot be
+  // probed through a stale address before it publishes its own.
+  rmSync(join(config, "daemon", "control-api.json"), { force: true });
+  return { config, projectIds };
+}
+
+function corruptProjectPartition(config: string, projectId: string): void {
+  const partitionDir = journalPartitionDirectory(
+    join(config, "daemon", "journal"),
+    `project:${projectId}`,
+  );
+  writeFileSync(join(partitionDir, "journal.bin"), "GARBAGE-NOT-A-JOURNAL-FRAME", {
+    mode: 0o600,
+  });
+}
+
+async function waitForServingMode(
+  addr: { base: string; token: string },
+  expected: string,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let servingMode = "";
+  while (Date.now() < deadline) {
+    servingMode = String((await handshake(addr)).servingMode ?? "");
+    if (servingMode === expected) return;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  expect(servingMode, `handshake never reported ${expected} serving`).toBe(expected);
+}
+
+async function inspectPartition(
+  addr: { base: string; token: string },
+  partition: string,
+): Promise<{ fingerprint: string; status: string }> {
+  const response = await fetch(
+    `${addr.base}/v2/recovery/partitions/${encodeURIComponent(partition)}`,
+    {
+      headers: {
+        authorization: `Bearer ${addr.token}`,
+        "x-claudexor-protocol-major": "3",
+      },
+    },
+  );
+  expect(response.status, await response.clone().text()).toBe(200);
+  return (await response.json()) as { fingerprint: string; status: string };
+}
+
+async function quarantinePartition(
+  addr: { base: string; token: string },
+  partition: string,
+  expectedFingerprint: string,
+): Promise<void> {
+  const response = await fetch(
+    `${addr.base}/v2/recovery/partitions/${encodeURIComponent(partition)}/quarantine`,
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${addr.token}`,
+        "x-claudexor-protocol-major": "3",
+        "content-type": "application/json",
+        "idempotency-key": randomUUID(),
+      },
+      body: JSON.stringify({
+        expectedFingerprint,
+        confirmation: "quarantine_and_start_fresh",
+      }),
+    },
+  );
+  expect(response.status, await response.clone().text()).toBe(200);
+}
+
 function spawnDaemon(
   config: string,
   extraEnv: Record<string, string> = {},
@@ -186,4 +304,81 @@ describe("recovery plane availability and in-process reopen (C6)", () => {
     expect(existsSync(join(config, "daemon", "journal-quarantine"))).toBe(true);
     daemon.kill("SIGTERM");
   }, 60_000);
+
+  it("quarantining a corrupt PROJECT partition never poisons the healthy global sibling (S2-CR1)", async () => {
+    const { config, projectIds } = await seedRegisteredProjects(1);
+    const partition = `project:${projectIds[0]}`;
+    corruptProjectPartition(config, projectIds[0]!);
+    const daemon = spawnDaemon(config);
+    const daemonPid = await waitFor(() => daemon.pid ?? null, "daemon pid");
+    const addr = await waitFor(
+      () => (daemon.exitCode !== null ? null : controlAddress(config)),
+      "the control API pointer",
+    ).catch((error: unknown) => {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`,
+      );
+    });
+    expect((await handshake(addr)).servingMode).toBe("recovery_only");
+    expect((await inspectPartition(addr, "global")).status).toBe("ready");
+    const projectInspection = await inspectPartition(addr, partition);
+    expect(projectInspection.status).toBe("recovery_required");
+
+    await quarantinePartition(addr, partition, projectInspection.fingerprint);
+
+    // The healthy global sibling was NEVER flipped to recovery_required by
+    // the project quarantine's recovery-operations infrastructure write.
+    expect((await inspectPartition(addr, "global")).status).toBe("ready");
+    // The SAME process reaches normal serving without a restart.
+    await waitForServingMode(addr, "normal");
+    expect((await inspectPartition(addr, "global")).status).toBe("ready");
+    expect(daemon.pid).toBe(daemonPid);
+    expect(daemon.exitCode).toBeNull();
+    daemon.kill("SIGTERM");
+  }, 90_000);
+
+  it("reopens in process after quarantining TWO broken project partitions in sequence (S2-CR1)", async () => {
+    const { config, projectIds } = await seedRegisteredProjects(2);
+    const [firstPartition, secondPartition] = projectIds.map((id) => `project:${id}`) as [
+      string,
+      string,
+    ];
+    corruptProjectPartition(config, projectIds[0]!);
+    corruptProjectPartition(config, projectIds[1]!);
+    const daemon = spawnDaemon(config);
+    const daemonPid = await waitFor(() => daemon.pid ?? null, "daemon pid");
+    const addr = await waitFor(
+      () => (daemon.exitCode !== null ? null : controlAddress(config)),
+      "the control API pointer",
+    ).catch((error: unknown) => {
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`,
+      );
+    });
+    expect((await handshake(addr)).servingMode).toBe("recovery_only");
+    const firstInspection = await inspectPartition(addr, firstPartition);
+    expect(firstInspection.status).toBe("recovery_required");
+    await quarantinePartition(addr, firstPartition, firstInspection.fingerprint);
+
+    // Still protected: the live re-verdict lists EXACTLY the second broken
+    // partition — the first reopened in place and global stays healthy.
+    expect((await handshake(addr)).servingMode).toBe("recovery_only");
+    expect((await inspectPartition(addr, firstPartition)).status).toBe("ready");
+    expect((await inspectPartition(addr, "global")).status).toBe("ready");
+    const log = readFileSync(join(config, "daemon", "claudexord.log"), "utf8");
+    const verdicts = [
+      ...log.matchAll(/serving recovery only [^(]*\(recovery required: ([^)]+)\)/g),
+    ];
+    expect(verdicts.at(-1)?.[1]).toBe(secondPartition);
+
+    const secondInspection = await inspectPartition(addr, secondPartition);
+    expect(secondInspection.status).toBe("recovery_required");
+    await quarantinePartition(addr, secondPartition, secondInspection.fingerprint);
+
+    await waitForServingMode(addr, "normal");
+    expect((await inspectPartition(addr, "global")).status).toBe("ready");
+    expect(daemon.pid).toBe(daemonPid);
+    expect(daemon.exitCode).toBeNull();
+    daemon.kill("SIGTERM");
+  }, 120_000);
 });

--- a/packages/cli/src/claudexord-recovery-reopen.test.ts
+++ b/packages/cli/src/claudexord-recovery-reopen.test.ts
@@ -377,11 +377,17 @@ describe("recovery plane availability and in-process reopen (C6)", () => {
     expect((await handshake(addr)).servingMode).toBe("recovery_only");
     expect((await inspectPartition(addr, firstPartition)).status).toBe("ready");
     expect((await inspectPartition(addr, "global")).status).toBe("ready");
-    const log = readFileSync(join(config, "daemon", "claudexord.log"), "utf8");
-    const verdicts = [
-      ...log.matchAll(/serving recovery only [^(]*\(recovery required: ([^)]+)\)/g),
-    ];
-    expect(verdicts.at(-1)?.[1]).toBe(secondPartition);
+    // The re-verdict log line lands asynchronously after the quarantine
+    // response, so poll for it instead of racing a single read.
+    const lastVerdict = await waitFor(() => {
+      const log = readFileSync(join(config, "daemon", "claudexord.log"), "utf8");
+      const verdicts = [
+        ...log.matchAll(/serving recovery only [^(]*\(recovery required: ([^)]+)\)/g),
+      ];
+      const last = verdicts.at(-1)?.[1] ?? null;
+      return last === secondPartition ? last : null;
+    }, `the post-quarantine re-verdict listing exactly ${secondPartition}`);
+    expect(lastVerdict).toBe(secondPartition);
 
     const secondInspection = await inspectPartition(addr, secondPartition);
     expect(secondInspection.status).toBe("recovery_required");

--- a/packages/cli/src/claudexord-recovery-reopen.test.ts
+++ b/packages/cli/src/claudexord-recovery-reopen.test.ts
@@ -10,7 +10,6 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { journalPartitionDirectory } from "@claudexor/journal";
 import { afterEach, describe, expect, it } from "vitest";

--- a/packages/cli/src/claudexord-recovery-reopen.test.ts
+++ b/packages/cli/src/claudexord-recovery-reopen.test.ts
@@ -111,7 +111,9 @@ describe("recovery plane availability and in-process reopen (C6)", () => {
       () => (daemon.exitCode !== null ? null : controlAddress(config)),
       "the recovery-plane control API pointer",
     ).catch((error: unknown) => {
-      throw new Error(`${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`);
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`,
+      );
     });
     const hello = await handshake(addr);
     expect(hello.servingMode).toBe("recovery_only");
@@ -129,7 +131,9 @@ describe("recovery plane availability and in-process reopen (C6)", () => {
       () => (daemon.exitCode !== null ? null : controlAddress(config)),
       "the control API pointer",
     ).catch((error: unknown) => {
-      throw new Error(`${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`);
+      throw new Error(
+        `${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`,
+      );
     });
     expect((await handshake(addr)).servingMode).toBe("recovery_only");
     const authed = {

--- a/packages/cli/src/claudexord-recovery-reopen.test.ts
+++ b/packages/cli/src/claudexord-recovery-reopen.test.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { journalPartitionDirectory } from "@claudexor/journal";
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * C6 (sol SCOPE-04 + grok G-REC-01), proven against the BUILT daemon entry:
+ * (a) a recovery-required startup verdict binds the control API even under
+ * CLAUDEXOR_NO_CONTROL_API=1 — the recovery surface IS the point of the
+ * recovery plane; (b) a successful recovery-route quarantine re-runs the
+ * admission completion IN PROCESS, so product routes open without a restart.
+ */
+
+const daemonEntry = resolve(import.meta.dirname, "../dist/claudexord.js");
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  for (const dispose of cleanups.splice(0)) dispose();
+});
+
+function corruptGlobalRoot(): string {
+  // A SHORT real root (belt-entry convention): the daemon binds a Unix socket
+  // under it, and the darwin per-user tmpdir would blow the 104-char limit.
+  const root = realpathSync(mkdtempSync(join(realpathSync("/tmp"), "cx-reopen-")));
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+  const config = join(root, "config");
+  const partitionDir = journalPartitionDirectory(join(config, "daemon", "journal"), "global");
+  mkdirSync(partitionDir, { recursive: true });
+  for (const dir of [config, join(config, "daemon"), join(config, "daemon", "journal")]) {
+    chmodSync(dir, 0o700);
+  }
+  chmodSync(partitionDir, 0o700);
+  writeFileSync(join(partitionDir, "journal.bin"), "GARBAGE-NOT-A-JOURNAL-FRAME", { mode: 0o600 });
+  return config;
+}
+
+function spawnDaemon(
+  config: string,
+  extraEnv: Record<string, string> = {},
+): ChildProcess & { stderrText: () => string } {
+  const child = spawn(process.execPath, [daemonEntry], {
+    stdio: ["ignore", "ignore", "pipe"],
+    env: {
+      HOME: process.env.HOME ?? "/tmp",
+      PATH: process.env.PATH ?? "/usr/bin:/bin",
+      CLAUDEXOR_CONFIG_DIR: config,
+      ...extraEnv,
+    },
+  });
+  let stderr = "";
+  child.stderr?.on("data", (chunk) => {
+    stderr += String(chunk);
+  });
+  cleanups.push(() => {
+    if (child.exitCode === null) child.kill("SIGKILL");
+  });
+  return Object.assign(child, { stderrText: () => stderr });
+}
+
+async function waitFor<T>(probe: () => T | null, what: string, timeoutMs = 20_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = probe();
+    if (value !== null) return value;
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
+
+function controlAddress(config: string): { base: string; token: string } | null {
+  const pointer = join(config, "daemon", "control-api.json");
+  const tokenPath = join(config, "daemon", "token");
+  if (!existsSync(pointer) || !existsSync(tokenPath)) return null;
+  try {
+    const addr = JSON.parse(readFileSync(pointer, "utf8")) as { host: string; port: number };
+    return {
+      base: `http://${addr.host}:${addr.port}`,
+      token: readFileSync(tokenPath, "utf8").trim(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function handshake(addr: { base: string; token: string }): Promise<Record<string, unknown>> {
+  const response = await fetch(`${addr.base}/v2/handshake`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${addr.token}`, "content-type": "application/json" },
+    body: JSON.stringify({ protocolMajor: 3, client: "reopen-test" }),
+  });
+  expect(response.ok).toBe(true);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+describe("recovery plane availability and in-process reopen (C6)", () => {
+  it("binds the control API on a recovery-required verdict even under CLAUDEXOR_NO_CONTROL_API=1", async () => {
+    const config = corruptGlobalRoot();
+    const daemon = spawnDaemon(config, { CLAUDEXOR_NO_CONTROL_API: "1" });
+    const addr = await waitFor(
+      () => (daemon.exitCode !== null ? null : controlAddress(config)),
+      "the recovery-plane control API pointer",
+    ).catch((error: unknown) => {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`);
+    });
+    const hello = await handshake(addr);
+    expect(hello.servingMode).toBe("recovery_only");
+    // The override is disclosed in the daemon log.
+    const log = readFileSync(join(config, "daemon", "claudexord.log"), "utf8");
+    expect(log).toContain("CLAUDEXOR_NO_CONTROL_API=1");
+    daemon.kill("SIGTERM");
+  }, 40_000);
+
+  it("opens product routes in process after a recovery-route quarantine (no restart)", async () => {
+    const config = corruptGlobalRoot();
+    const daemon = spawnDaemon(config);
+    const daemonPid = await waitFor(() => daemon.pid ?? null, "daemon pid");
+    const addr = await waitFor(
+      () => (daemon.exitCode !== null ? null : controlAddress(config)),
+      "the control API pointer",
+    ).catch((error: unknown) => {
+      throw new Error(`${error instanceof Error ? error.message : String(error)}; daemon stderr: ${daemon.stderrText().slice(-500)}`);
+    });
+    expect((await handshake(addr)).servingMode).toBe("recovery_only");
+    const authed = {
+      authorization: `Bearer ${addr.token}`,
+      "x-claudexor-protocol-major": "3",
+    };
+    // Product routes are typed-closed on the recovery plane.
+    const closed = await fetch(`${addr.base}/v2/threads`, { headers: authed });
+    expect(closed.status).toBe(503);
+    expect(((await closed.json()) as { code?: string }).code).toBe("daemon_recovery_only");
+
+    // Operator recovery: inspect the corrupt partition, then quarantine it.
+    const inspected = await fetch(`${addr.base}/v2/recovery/partitions/global`, {
+      headers: authed,
+    });
+    expect(inspected.status).toBe(200);
+    const inspection = (await inspected.json()) as { fingerprint: string; status: string };
+    expect(inspection.status).toBe("recovery_required");
+    const quarantined = await fetch(`${addr.base}/v2/recovery/partitions/global/quarantine`, {
+      method: "POST",
+      headers: {
+        ...authed,
+        "content-type": "application/json",
+        "idempotency-key": randomUUID(),
+      },
+      body: JSON.stringify({
+        expectedFingerprint: inspection.fingerprint,
+        confirmation: "quarantine_and_start_fresh",
+      }),
+    });
+    expect(quarantined.status, await quarantined.clone().text()).toBe(200);
+
+    // The SAME process must transition to normal serving: handshake reports
+    // normal and product routes answer, without any restart.
+    const deadline = Date.now() + 20_000;
+    let servingMode = "";
+    while (Date.now() < deadline) {
+      servingMode = String((await handshake(addr)).servingMode ?? "");
+      if (servingMode === "normal") break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    expect(servingMode, "handshake never reported normal serving after the quarantine").toBe(
+      "normal",
+    );
+    const open = await fetch(`${addr.base}/v2/threads`, { headers: authed });
+    expect(open.status, await open.clone().text()).toBe(200);
+    expect(daemon.pid).toBe(daemonPid);
+    expect(daemon.exitCode).toBeNull();
+    // The quarantined bytes were preserved, never deleted.
+    expect(existsSync(join(config, "daemon", "journal-quarantine"))).toBe(true);
+    daemon.kill("SIGTERM");
+  }, 60_000);
+});

--- a/packages/cli/src/claudexord-zombie-writer-lease.test.ts
+++ b/packages/cli/src/claudexord-zombie-writer-lease.test.ts
@@ -398,11 +398,16 @@ it.runIf(process.platform === "linux")(
       expect(holderExit).toEqual({ code: 0, signal: null });
       const finalIdentity = await waitForValue(
         () => defaultProcessIdentityService.read(victimPid!),
-        (identity) => compareProcessIdentity(victimIdentity!, identity) !== "same",
+        (identity) => {
+          const comparison = compareProcessIdentity(victimIdentity!, identity);
+          return comparison === "missing" || comparison === "different";
+        },
         3_000,
         "zombie reap",
       );
-      expect(compareProcessIdentity(victimIdentity, finalIdentity)).not.toBe("same");
+      expect(["missing", "different"]).toContain(
+        compareProcessIdentity(victimIdentity, finalIdentity),
+      );
     } catch (error) {
       failure = error;
     } finally {

--- a/packages/cli/src/claudexord-zombie-writer-lease.test.ts
+++ b/packages/cli/src/claudexord-zombie-writer-lease.test.ts
@@ -1,0 +1,453 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import {
+  compareProcessIdentity,
+  defaultProcessIdentityService,
+  defaultProcessObservationReader,
+  type KnownProcessIdentity,
+  type ProcessObservation,
+} from "@claudexor/core";
+import {
+  inspectDaemonWriterLease,
+  socketAlive,
+  writerLeasePath,
+  writerLeaseTombstonePath,
+  type DaemonLeaseOwner,
+  type DaemonWriterLeaseStatus,
+} from "@claudexor/daemon";
+import { expect, it } from "vitest";
+import { CONTROL_PROTOCOL_MAJOR, controlApiFetch, handshakeControlApi } from "./live.js";
+
+const HOLDER_SCRIPT = String.raw`
+const { spawn } = require("node:child_process");
+const { existsSync, readFileSync, writeSync } = require("node:fs");
+const releasePath = process.env.CX159_RELEASE_PATH;
+const emergencyMs = Number(process.env.CX159_EMERGENCY_MS || 45000);
+const victim = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+  stdio: "ignore",
+});
+if (!victim.pid) throw new Error("victim pid unavailable");
+writeSync(1, JSON.stringify({ pid: victim.pid }) + "\n");
+const cell = new Int32Array(new SharedArrayBuffer(4));
+const deadline = Date.now() + emergencyMs;
+let mode = null;
+while (mode === null && Date.now() < deadline) {
+  if (existsSync(releasePath)) mode = readFileSync(releasePath, "utf8").trim() || "abort";
+  if (mode === null) Atomics.wait(cell, 0, 0, 25);
+}
+if (mode !== "normal") victim.kill("SIGKILL");
+victim.once("error", (error) => {
+  writeSync(2, String(error && error.message ? error.message : error) + "\n");
+  process.exit(2);
+});
+victim.once("close", () => process.exit(0));
+`;
+
+const DEAD_SOCKET_BINDER_SCRIPT = String.raw`
+const { writeSync } = require("node:fs");
+const { createServer } = require("node:net");
+const server = createServer();
+server.once("error", (error) => {
+  writeSync(2, String(error && error.message ? error.message : error) + "\n");
+  process.exit(2);
+});
+server.listen(process.env.CX159_SOCKET_PATH, () => writeSync(1, "ready\n"));
+setInterval(() => {}, 1000);
+`;
+
+interface ChildClose {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+interface ControlPointer {
+  host: string;
+  port: number;
+  tokenPath: string;
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+
+function childCloseResult(child: ChildProcess): ChildClose | null {
+  if (child.exitCode === null && child.signalCode === null) return null;
+  return { code: child.exitCode, signal: child.signalCode };
+}
+
+function waitForChildClose(child: ChildProcess, timeoutMs: number): Promise<ChildClose> {
+  const closed = childCloseResult(child);
+  if (closed) return Promise.resolve(closed);
+  return new Promise((resolveClose, rejectClose) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      rejectClose(new Error(`child ${child.pid ?? "unknown"} did not close within ${timeoutMs}ms`));
+    }, timeoutMs);
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      child.off("close", onClose);
+      child.off("error", onError);
+    };
+    const onClose = (code: number | null, signal: NodeJS.Signals | null): void => {
+      cleanup();
+      resolveClose({ code, signal });
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      rejectClose(error);
+    };
+    child.once("close", onClose);
+    child.once("error", onError);
+    const raced = childCloseResult(child);
+    if (raced) {
+      cleanup();
+      resolveClose(raced);
+    }
+  });
+}
+
+function waitForLine(child: ChildProcess, timeoutMs: number): Promise<string> {
+  if (!child.stdout) return Promise.reject(new Error("child stdout is not piped"));
+  const stdout = child.stdout;
+  return new Promise((resolveLine, rejectLine) => {
+    let buffered = "";
+    stdout.setEncoding("utf8");
+    const timeout = setTimeout(() => {
+      cleanup();
+      rejectLine(new Error(`child ${child.pid ?? "unknown"} produced no line`));
+    }, timeoutMs);
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      stdout.off("data", onData);
+      child.off("close", onClose);
+      child.off("error", onError);
+    };
+    const onData = (chunk: string): void => {
+      buffered += chunk;
+      const newline = buffered.indexOf("\n");
+      if (newline < 0) return;
+      const line = buffered.slice(0, newline);
+      cleanup();
+      resolveLine(line);
+    };
+    const onClose = (): void => {
+      cleanup();
+      rejectLine(new Error(`child ${child.pid ?? "unknown"} closed before reporting ready`));
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      rejectLine(error);
+    };
+    stdout.on("data", onData);
+    child.once("close", onClose);
+    child.once("error", onError);
+  });
+}
+
+function captureBoundedStderr(child: ChildProcess, maxBytes = 16 * 1024): () => string {
+  let captured = "";
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    captured += chunk;
+    if (Buffer.byteLength(captured) > maxBytes) captured = captured.slice(-maxBytes);
+  });
+  return () => captured;
+}
+
+async function waitForValue<T>(
+  read: () => T | Promise<T>,
+  accept: (value: T) => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let value = await read();
+  while (!accept(value) && Date.now() < deadline) {
+    await delay(25);
+    value = await read();
+  }
+  if (!accept(value)) throw new Error(`${label} did not converge within ${timeoutMs}ms`);
+  return value;
+}
+
+async function stopExactChild(child: ChildProcess): Promise<void> {
+  if (childCloseResult(child)) return;
+  child.kill("SIGTERM");
+  try {
+    await waitForChildClose(child, 3_000);
+  } catch {
+    if (!childCloseResult(child)) child.kill("SIGKILL");
+    await waitForChildClose(child, 3_000);
+  }
+}
+
+function parseControlPointer(path: string): ControlPointer | null {
+  if (!existsSync(path)) return null;
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8")) as Partial<ControlPointer>;
+    if (
+      typeof value.host !== "string" ||
+      !value.host ||
+      !Number.isInteger(value.port) ||
+      Number(value.port) < 1 ||
+      typeof value.tokenPath !== "string" ||
+      !value.tokenPath
+    ) {
+      return null;
+    }
+    return { host: value.host, port: Number(value.port), tokenPath: value.tokenPath };
+  } catch {
+    return null;
+  }
+}
+
+function sameZombieObservation(
+  observation: ProcessObservation,
+  identity: KnownProcessIdentity,
+): boolean {
+  return (
+    observation.linuxState === "Z" &&
+    compareProcessIdentity(identity, observation.identity) === "same"
+  );
+}
+
+it.runIf(process.platform === "linux")(
+  "replaces a real zombie writer and publishes an authenticated Control descriptor",
+  async () => {
+    const repoRoot = resolve(import.meta.dirname, "../../..");
+    const daemonEntry = join(repoRoot, "packages", "cli", "dist", "claudexord.js");
+    if (!existsSync(daemonEntry) || !lstatSync(daemonEntry).isFile()) {
+      throw new Error(`built daemon precondition is missing: ${daemonEntry}`);
+    }
+
+    const root = realpathSync(mkdtempSync(join(realpathSync(tmpdir()), "cx159-")));
+    const home = join(root, "home");
+    const configDir = join(root, "config");
+    const socketPath = join(root, "d.sock");
+    const releasePath = join(root, "release-holder");
+    const daemonDir = join(configDir, "daemon");
+    const pointerPath = join(daemonDir, "control-api.json");
+    const tokenPath = join(daemonDir, "token");
+    const buildSha = "1".repeat(40);
+    mkdirSync(home, { mode: 0o700 });
+    mkdirSync(configDir, { mode: 0o700 });
+
+    let holder: ChildProcess | null = null;
+    let binder: ChildProcess | null = null;
+    let replacement: ChildProcess | null = null;
+    let holderStderr = (): string => "";
+    let binderStderr = (): string => "";
+    let replacementStderr = (): string => "";
+    let victimPid: number | null = null;
+    let victimIdentity: KnownProcessIdentity | null = null;
+    let failure: unknown = null;
+
+    try {
+      holder = spawn(process.execPath, ["-e", HOLDER_SCRIPT], {
+        cwd: root,
+        env: {
+          ...process.env,
+          CX159_RELEASE_PATH: releasePath,
+          CX159_EMERGENCY_MS: "45000",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      holderStderr = captureBoundedStderr(holder);
+      const holderReport = JSON.parse(await waitForLine(holder, 3_000)) as { pid?: unknown };
+      if (!Number.isSafeInteger(holderReport.pid) || Number(holderReport.pid) < 2) {
+        throw new Error("holder reported an invalid victim pid");
+      }
+      victimPid = Number(holderReport.pid);
+      const liveIdentity = defaultProcessIdentityService.read(victimPid);
+      if (liveIdentity.status !== "known") {
+        throw new Error(`victim birth identity is ${liveIdentity.status}`);
+      }
+      victimIdentity = liveIdentity;
+
+      process.kill(victimPid, "SIGKILL");
+      const zombie = await waitForValue(
+        () => defaultProcessObservationReader.observe(victimPid!),
+        (observation) => sameZombieObservation(observation, victimIdentity!),
+        5_000,
+        "real Linux zombie",
+      );
+      expect(zombie.identity).toEqual(victimIdentity);
+      expect(() => process.kill(victimPid!, 0)).not.toThrow();
+
+      const staleOwner: DaemonLeaseOwner = {
+        pid: victimPid,
+        token: "issue-159-zombie-owner",
+        identity: victimIdentity,
+      };
+      const staleOwnerBytes = `${JSON.stringify(staleOwner)}\n`;
+      const leasePath = writerLeasePath(socketPath);
+      mkdirSync(leasePath, { mode: 0o700 });
+      writeFileSync(join(leasePath, "owner.json"), staleOwnerBytes, {
+        mode: 0o600,
+        flag: "wx",
+      });
+      const tombstonePath = writerLeaseTombstonePath(leasePath, staleOwner);
+
+      binder = spawn(process.execPath, ["-e", DEAD_SOCKET_BINDER_SCRIPT], {
+        cwd: root,
+        env: { ...process.env, CX159_SOCKET_PATH: socketPath },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      binderStderr = captureBoundedStderr(binder);
+      expect(await waitForLine(binder, 3_000)).toBe("ready");
+      binder.kill("SIGKILL");
+      const binderExit = await waitForChildClose(binder, 3_000);
+      expect(binderExit.signal).toBe("SIGKILL");
+      expect(lstatSync(socketPath).isSocket()).toBe(true);
+      expect(await socketAlive(socketPath)).toBe(false);
+
+      const daemonEnv: NodeJS.ProcessEnv = {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        PATH: [dirname(process.execPath), process.env.PATH ?? ""].filter(Boolean).join(":"),
+        CLAUDEXOR_CONFIG_DIR: configDir,
+        CLAUDEXOR_DAEMON_SOCK: socketPath,
+        CLAUDEXOR_CONTROL_PORT: "0",
+        CLAUDEXOR_BUILD_SHA: buildSha,
+      };
+      delete daemonEnv.CLAUDEXOR_NO_CONTROL_API;
+      replacement = spawn(process.execPath, [daemonEntry], {
+        cwd: repoRoot,
+        env: daemonEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      replacementStderr = captureBoundedStderr(replacement);
+      const replacementPid = replacement.pid;
+      if (!replacementPid) throw new Error("replacement daemon pid is unavailable");
+
+      const pointer = await waitForValue(
+        () => parseControlPointer(pointerPath),
+        (value): value is ControlPointer => value !== null,
+        25_000,
+        "fresh control-api.json",
+      );
+      if (!pointer) throw new Error("fresh control-api.json vanished after readiness");
+      expect(pointer.tokenPath).toBe(tokenPath);
+      expect(realpathSync(pointer.tokenPath)).toBe(tokenPath);
+      const token = readFileSync(tokenPath, "utf8").trim();
+      if (!token) throw new Error("fresh daemon token is empty");
+      const addr = { baseUrl: `http://${pointer.host}:${pointer.port}`, token };
+
+      const health = await controlApiFetch(addr, "/healthz", {
+        signal: AbortSignal.timeout(2_000),
+      });
+      expect(health.status).toBe(200);
+      expect(await health.json()).toEqual({ ok: true });
+      const engine = await handshakeControlApi(addr, "issue-159-linux-acceptance");
+      expect(engine.engineBuildSha).toBe(buildSha);
+      expect(engine.engineVersion).not.toBeNull();
+      const handshakeResponse = await controlApiFetch(addr, "/v2/handshake", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          protocolMajor: CONTROL_PROTOCOL_MAJOR,
+          client: "issue-159-linux-acceptance-envelope",
+        }),
+      });
+      expect(handshakeResponse.status).toBe(200);
+      const handshake = (await handshakeResponse.json()) as {
+        engine?: { sha?: unknown; entry?: unknown };
+      };
+      expect(handshake.engine?.sha).toBe(buildSha);
+      expect(resolve(String(handshake.engine?.entry ?? ""))).toBe(realpathSync(daemonEntry));
+
+      const replacementLease = inspectDaemonWriterLease(socketPath);
+      if (replacementLease.status !== "owned") {
+        throw new Error(`replacement writer lease is ${replacementLease.status}`);
+      }
+      expect(replacementLease.capability.status).toBe("capable");
+      expect(replacementLease.owner.pid).toBe(replacementPid);
+      expect(replacementLease.owner.token).not.toBe(staleOwner.token);
+      expect(readFileSync(join(tombstonePath, "owner.json"), "utf8")).toBe(staleOwnerBytes);
+      expect(readFileSync(join(replacementLease.path, "owner.json"), "utf8")).not.toBe(
+        staleOwnerBytes,
+      );
+      expect(
+        sameZombieObservation(defaultProcessObservationReader.observe(victimPid), victimIdentity),
+      ).toBe(true);
+
+      replacement.kill("SIGTERM");
+      const replacementExit = await waitForChildClose(replacement, 12_000);
+      expect(replacementExit).toEqual({ code: 0, signal: null });
+      const released = await waitForValue<DaemonWriterLeaseStatus>(
+        () => inspectDaemonWriterLease(socketPath),
+        (status) => status.status === "absent",
+        3_000,
+        "replacement writer-lease release",
+      );
+      expect(released.status).toBe("absent");
+
+      writeFileSync(releasePath, "normal\n", { mode: 0o600 });
+      const holderExit = await waitForChildClose(holder, 5_000);
+      expect(holderExit).toEqual({ code: 0, signal: null });
+      const finalIdentity = await waitForValue(
+        () => defaultProcessIdentityService.read(victimPid!),
+        (identity) => compareProcessIdentity(victimIdentity!, identity) !== "same",
+        3_000,
+        "zombie reap",
+      );
+      expect(compareProcessIdentity(victimIdentity, finalIdentity)).not.toBe("same");
+    } catch (error) {
+      failure = error;
+    } finally {
+      const cleanupErrors: string[] = [];
+      for (const child of [replacement, binder]) {
+        if (!child) continue;
+        try {
+          await stopExactChild(child);
+        } catch (error) {
+          cleanupErrors.push(error instanceof Error ? error.message : String(error));
+        }
+      }
+      if (holder && !childCloseResult(holder)) {
+        try {
+          let releaseMode = "abort";
+          if (victimPid && victimIdentity) {
+            const current = defaultProcessObservationReader.observe(victimPid);
+            if (sameZombieObservation(current, victimIdentity)) releaseMode = "normal";
+          }
+          writeFileSync(releasePath, `${releaseMode}\n`, { mode: 0o600 });
+          await waitForChildClose(holder, 5_000);
+        } catch (error) {
+          cleanupErrors.push(error instanceof Error ? error.message : String(error));
+        }
+      }
+      if (![holder, binder, replacement].some((child) => child && !childCloseResult(child))) {
+        rmSync(root, { recursive: true, force: true });
+      }
+      if (cleanupErrors.length > 0 && failure === null) {
+        failure = new Error(`cleanup failed: ${cleanupErrors.join("; ")}`);
+      }
+    }
+
+    if (failure !== null) {
+      const detail = failure instanceof Error ? failure.message : String(failure);
+      throw new Error(
+        [
+          detail,
+          `holder stderr:\n${holderStderr()}`,
+          `socket binder stderr:\n${binderStderr()}`,
+          `replacement stderr:\n${replacementStderr()}`,
+        ].join("\n"),
+        { cause: failure },
+      );
+    }
+  },
+  60_000,
+);

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -152,13 +152,22 @@ export async function main(): Promise<void> {
     // D5 stage 2: read-only prepare + validate; zero recovery writes.
     const globalPreparation = journalManager.prepare();
     const admission = new DaemonStartupAdmission();
+    // Armed only on NORMAL admission (C1a): polling against unactivated
+    // projections is a swallowed throw, and the recovery plane must stay
+    // byte-for-byte non-mutating. The immediate poll on arming also removes
+    // the one-minute stale window the swallowed stage-2 poll used to leave
+    // (G-QUOTA-01).
     const pollQuota = () => {
       try {
         void quotaStoreSlot.current().pollStale();
       } catch {}
     };
-    quotaPollTimer = setInterval(pollQuota, 60_000).unref();
-    pollQuota();
+    const armQuotaPolling = () => {
+      if (quotaPollTimer) return;
+      quotaPollTimer = setInterval(pollQuota, 60_000);
+      quotaPollTimer.unref();
+      pollQuota();
+    };
     const threads = new ProjectPartitions(
       daemonDir(),
       projectStoreSlot,
@@ -549,6 +558,7 @@ export async function main(): Promise<void> {
         log: (message) => logLine(logPath(), message),
       });
       if (servingMode === "normal" && !shutdownRuntime.requested()) {
+        armQuotaPolling();
         await setupBinding.start();
         quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
         scheduleStartupRetention(services.runRetention, {

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -29,6 +29,12 @@ import {
 } from "@claudexor/daemon";
 import { DaemonControlApiServer, normalizeRunStartRequest } from "@claudexor/control-api";
 import { armDaemonLifecycle, logLine, runStartupCrashGc } from "./daemon-lifecycle.js";
+import { DAEMON_LAUNCH_SOURCE_ENV } from "./daemon-launch.js";
+import {
+  openDaemonStartupDiagnosticsAfterAuthority,
+  safeDaemonLaunchSource,
+  type DaemonStartupDiagnostics,
+} from "./startup-diagnostics.js";
 import {
   bindRecoveryTransport,
   completeStartupAdmission,
@@ -92,6 +98,37 @@ export async function main(): Promise<void> {
   const socketPath = defaultSocketPath();
   // D5 stage 1: permanent barrier (epoch/floor refusals) before ANY recovery.
   const rootAuthority = acquireRootAuthority({ socketPath, version: servingIdentity.version });
+  // C8: the private diagnostics owner opens right after the authority win,
+  // with full launch provenance. Diagnostic failures never control lifecycle.
+  let diagnostics: DaemonStartupDiagnostics | null = null;
+  try {
+    diagnostics = openDaemonStartupDiagnosticsAfterAuthority({
+      runtimeVersion: servingIdentity.version,
+      buildSha: servingIdentity.sha,
+      entryPath: servingIdentity.entry,
+      pid: process.pid,
+      dataRoot: daemonDir(),
+      launchSource: safeDaemonLaunchSource(process.env[DAEMON_LAUNCH_SOURCE_ENV]),
+    });
+    diagnostics.record({
+      stage: "root_authority_won",
+      message: "root authority acquired; startup diagnostics online",
+    });
+  } catch (error) {
+    logLine(
+      logPath(),
+      `startup diagnostics unavailable: ${redactSecrets(
+        error instanceof Error ? error.message : String(error),
+      )}`,
+    );
+  }
+  const recordStage = (stage: string, message: string): void => {
+    try {
+      diagnostics?.record({ stage, message });
+    } catch {
+      /* diagnostics never control lifecycle */
+    }
+  };
   let shutdownRuntime: DaemonRuntimeShutdown | null = null;
   // Release wave round-12 BLOCK: the single-writer lease may only be released
   // after a CLEAN shutdown — a failed/partial shutdown keeps components that
@@ -536,6 +573,7 @@ export async function main(): Promise<void> {
     lifecycle = armDaemonLifecycle({
       daemonDir: daemonDir(),
       logPath: logPath(),
+      ...(diagnostics ? { diagnostics } : {}),
       beginShutdown: (reason) => shutdownRuntime!.beginShutdown(reason),
     });
 
@@ -582,9 +620,17 @@ export async function main(): Promise<void> {
             blockedPartitions: blockedPartitions(),
             global: journalManager,
             partitions: threads,
-            crashGc: () => runStartupCrashGc({ daemonDir: daemonDir(), logPath: logPath() }),
+            crashGc: () =>
+              runStartupCrashGc({
+                daemonDir: daemonDir(),
+                logPath: logPath(),
+                ...(diagnostics ? { diagnostics } : {}),
+              }),
             admission,
-            log: (message) => logLine(logPath(), message),
+            log: (message) => {
+              logLine(logPath(), message);
+              recordStage("startup_admission", message);
+            },
           });
           if (servingMode === "normal") await onNormalAdmission();
           return servingMode;
@@ -657,6 +703,7 @@ export async function main(): Promise<void> {
     await shutdownRuntime.wait();
     lifecycle.finalize();
     logLine(logPath(), "claudexord shut down");
+    recordStage("shutdown_complete", "claudexord shut down");
   } catch (error) {
     // logLine is already best-effort; a failed diagnostic write never masks
     // the lifecycle failure itself.
@@ -666,6 +713,11 @@ export async function main(): Promise<void> {
         error instanceof Error ? `${error.name}: ${error.message}` : String(error),
       )}`,
     );
+    try {
+      diagnostics?.record({ stage: "startup_failure", message: "daemon lifecycle FAILED", error });
+    } catch {
+      /* diagnostics never control lifecycle */
+    }
     if (shutdownRuntime) {
       try {
         await shutdownRuntime.beginShutdown("startup failure");
@@ -687,6 +739,7 @@ export async function main(): Promise<void> {
     throw error;
   } finally {
     if (quotaPollTimer) clearInterval(quotaPollTimer);
+    diagnostics?.close();
     // Drops only the live writer claim; the barrier itself persists (D1).
     if (releaseWriterLease) rootAuthority.release();
   }

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -105,16 +105,6 @@ export async function main(): Promise<void> {
     if (await socketAlive(socketPath)) {
       throw new Error(`a claudexor daemon is already listening on ${socketPath}; stop it first`);
     }
-    // Same-root config evolution hygiene (B9): strip + persist any known-retired
-    // keys an OLDER version wrote into the global config, before any strict
-    // parse can trip on them. Unknown keys NOT on the retired registry still
-    // fail loud at parse (INV-021).
-    for (const sweep of sweepRetiredConfigKeysAtStartup()) {
-      logLine(
-        logPath(),
-        `swept retired config keys from ${sweep.path}: ${sweep.removed.join(", ")}`,
-      );
-    }
 
     const bus = new RunEventBus();
     const { authority: delegationBudgetAuthority, bind: bindDelegationDaemon } =
@@ -183,7 +173,12 @@ export async function main(): Promise<void> {
       forRequest: (params) => threads.interactionsForRequest(params),
       all: () => threads.interactionStores(),
     });
-    const resources = new ResourceStore(join(daemonDir(), "resource-store"));
+    // C5b: construction mkdirs under the daemon dir, and the recovery plane
+    // serves no resources — the store materializes on first product use
+    // (every consumer sits behind normal admission).
+    let resourceStore: ResourceStore | null = null;
+    const resources = (): ResourceStore =>
+      (resourceStore ??= new ResourceStore(join(daemonDir(), "resource-store")));
 
     const server = new DaemonServer({
       socketPath,
@@ -419,7 +414,7 @@ export async function main(): Promise<void> {
                 : undefined,
             attachments: turnId
               ? (threads.getTurn(turnId)?.attachments ?? [])
-              : resources.resolve((p as { attachments?: ResourceAttachmentRef[] }).attachments),
+              : resources().resolve((p as { attachments?: ResourceAttachmentRef[] }).attachments),
             browser: (p as { browser?: boolean }).browser === true,
             mode: p.mode,
             contextMode: noProjectAsk
@@ -562,6 +557,16 @@ export async function main(): Promise<void> {
         // Crash-GC has consumed the previous life's pids.json by now; live
         // snapshots may own the file again (C2).
         lifecycle.beginPidSnapshots();
+        // Same-root config evolution hygiene (B9): persist the retired-key
+        // sweep only on the NORMAL plane (C5a). Pre-admission parses already
+        // tolerate retired keys via loadConfig's in-memory strip; unknown
+        // keys NOT on the retired registry still fail loud (INV-021).
+        for (const sweep of sweepRetiredConfigKeysAtStartup()) {
+          logLine(
+            logPath(),
+            `swept retired config keys from ${sweep.path}: ${sweep.removed.join(", ")}`,
+          );
+        }
         await setupBinding.start();
         quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
         scheduleStartupRetention(services.runRetention, {

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -25,19 +25,17 @@ import {
   ensureDaemonRuntimeRoot,
   logPath,
   socketAlive,
-  type DaemonServingMode,
 } from "@claudexor/daemon";
 import { DaemonControlApiServer, normalizeRunStartRequest } from "@claudexor/control-api";
-import { armDaemonLifecycle, logLine, runStartupCrashGc } from "./daemon-lifecycle.js";
-import { DAEMON_LAUNCH_SOURCE_ENV } from "./daemon-launch.js";
 import {
-  openDaemonStartupDiagnosticsAfterAuthority,
-  safeDaemonLaunchSource,
-  type DaemonStartupDiagnostics,
-} from "./startup-diagnostics.js";
+  createDaemonQuotaPoller,
+  createStartupAdmissionRuntime,
+  openStartupDiagnostics,
+} from "./daemon-admission-runtime.js";
+import { armDaemonLifecycle, logLine } from "./daemon-lifecycle.js";
 import {
   bindRecoveryTransport,
-  completeStartupAdmission,
+  controlApiEnabledForStartup,
   DaemonStartupAdmission,
   proveRecoveryTransport,
   quarantineGhostProjectsAtStartup,
@@ -46,9 +44,9 @@ import {
 import { assertPlanImplementReady } from "./plan-implement-readiness.js";
 import { Orchestrator } from "@claudexor/orchestrator";
 import { delegationBeltForRun } from "./delegation-belt-descriptor.js";
-import { loadConfig, sweepRetiredConfigKeysAtStartup } from "@claudexor/config";
+import { loadConfig } from "@claudexor/config";
 import { engineBuildIdentity, noProjectRepoRoot, redactSecrets } from "@claudexor/util";
-import { type QuotaSubject, type ResourceAttachmentRef } from "@claudexor/schema";
+import { type ResourceAttachmentRef } from "@claudexor/schema";
 import { scheduleStartupRetention } from "./retention-service.js";
 import { controlServices } from "./control-services.js";
 import { AuthReadinessService } from "@claudexor/gateway";
@@ -64,30 +62,16 @@ import {
   threadRunStartRequiresGit,
 } from "./thread-execution-workspace.js";
 import { preflightRunGitRequirement } from "./request-preflight.js";
-import { dispatchClaudexordEntry, runIfDirectEntry } from "./claudexord-entry.js";
+import {
+  dispatchClaudexordEntry,
+  runIfDirectEntry,
+  runProbeIfRequested,
+} from "./claudexord-entry.js";
 import { createDelegationDaemonBinding } from "./delegation-daemon-binding.js";
 import { quotaSubjectUniverseFromConfig } from "./quota-subject-universe.js";
 import { runStopIfRequested } from "./runtime-replacement-stop.js";
 import { threadContinuityContext } from "./thread-continuity-context.js";
 const NO_PROJECT_ROOT = noProjectRepoRoot();
-
-/** Public daemon-composition hook retained for embedders and tests. */
-export function quotaSubjectUniverse(): QuotaSubject[] {
-  return quotaSubjectUniverseFromConfig();
-}
-
-/** Handle `claudexord --probe`: print the engine build identity as ONE JSON line
- * ({version, buildSha}) and exit WITHOUT any durable startup — no writer lease,
- * no socket bind, no journal open, no runtime root. This is the pre-swap
- * handshake the macOS installer's RuntimeInstallCoordinator.probeVersion runs
- * against a freshly-unpacked closure with the app-bundled Node (D-2). Returns
- * true when the probe handled the invocation. */
-export function runProbeIfRequested(argv: readonly string[]): boolean {
-  if (!argv.includes("--probe")) return false;
-  const id = engineBuildIdentity();
-  process.stdout.write(`${JSON.stringify({ version: id.version, buildSha: id.sha })}\n`);
-  return true;
-}
 
 export async function main(): Promise<void> {
   // Probe and identity-proven stop must run before any durable startup.
@@ -98,37 +82,8 @@ export async function main(): Promise<void> {
   const socketPath = defaultSocketPath();
   // D5 stage 1: permanent barrier (epoch/floor refusals) before ANY recovery.
   const rootAuthority = acquireRootAuthority({ socketPath, version: servingIdentity.version });
-  // C8: the private diagnostics owner opens right after the authority win,
-  // with full launch provenance. Diagnostic failures never control lifecycle.
-  let diagnostics: DaemonStartupDiagnostics | null = null;
-  try {
-    diagnostics = openDaemonStartupDiagnosticsAfterAuthority({
-      runtimeVersion: servingIdentity.version,
-      buildSha: servingIdentity.sha,
-      entryPath: servingIdentity.entry,
-      pid: process.pid,
-      dataRoot: daemonDir(),
-      launchSource: safeDaemonLaunchSource(process.env[DAEMON_LAUNCH_SOURCE_ENV]),
-    });
-    diagnostics.record({
-      stage: "root_authority_won",
-      message: "root authority acquired; startup diagnostics online",
-    });
-  } catch (error) {
-    logLine(
-      logPath(),
-      `startup diagnostics unavailable: ${redactSecrets(
-        error instanceof Error ? error.message : String(error),
-      )}`,
-    );
-  }
-  const recordStage = (stage: string, message: string): void => {
-    try {
-      diagnostics?.record({ stage, message });
-    } catch {
-      /* diagnostics never control lifecycle */
-    }
-  };
+  // C8: private diagnostics open right after the authority win (never control lifecycle).
+  const startupDiagnostics = openStartupDiagnostics(servingIdentity);
   let shutdownRuntime: DaemonRuntimeShutdown | null = null;
   // Release wave round-12 BLOCK: the single-writer lease may only be released
   // after a CLEAN shutdown — a failed/partial shutdown keeps components that
@@ -136,7 +91,7 @@ export async function main(): Promise<void> {
   // beside them. On failure the lease dies with the process instead.
   let releaseWriterLease = true;
   let lifecycle: ReturnType<typeof armDaemonLifecycle> | null = null;
-  let quotaPollTimer: NodeJS.Timeout | null = null;
+  let quotaPoller: ReturnType<typeof createDaemonQuotaPoller> | null = null;
   try {
     const token = ensureToken();
 
@@ -156,7 +111,7 @@ export async function main(): Promise<void> {
     const runEventStoreSlot = journalManager.registerProjection(runEventProjection());
     const projectStoreSlot = journalManager.registerProjection(projectProjection());
     const quotaStoreSlot = journalManager.registerProjection(
-      quotaProjection(quotaRefreshers(), quotaSubjectUniverse),
+      quotaProjection(quotaRefreshers(), quotaSubjectUniverseFromConfig),
     );
     // Sidebar invalidation ping (W12): a GLOBAL-partition emitter every
     // ThreadStore (global + per-project) writes through, so any thread
@@ -180,22 +135,11 @@ export async function main(): Promise<void> {
     // D5 stage 2: read-only prepare + validate; zero recovery writes.
     const globalPreparation = journalManager.prepare();
     const admission = new DaemonStartupAdmission();
-    // Armed only on NORMAL admission (C1a): polling against unactivated
-    // projections is a swallowed throw, and the recovery plane must stay
-    // byte-for-byte non-mutating. The immediate poll on arming also removes
-    // the one-minute stale window the swallowed stage-2 poll used to leave
-    // (G-QUOTA-01).
-    const pollQuota = () => {
+    quotaPoller = createDaemonQuotaPoller(() => {
       try {
         void quotaStoreSlot.current().pollStale();
       } catch {}
-    };
-    const armQuotaPolling = () => {
-      if (quotaPollTimer) return;
-      quotaPollTimer = setInterval(pollQuota, 60_000);
-      quotaPollTimer.unref();
-      pollQuota();
-    };
+    });
     const threads = new ProjectPartitions(
       daemonDir(),
       projectStoreSlot,
@@ -215,9 +159,8 @@ export async function main(): Promise<void> {
       forRequest: (params) => threads.interactionsForRequest(params),
       all: () => threads.interactionStores(),
     });
-    // C5b: construction mkdirs under the daemon dir, and the recovery plane
-    // serves no resources — the store materializes on first product use
-    // (every consumer sits behind normal admission).
+    // C5b: construction mkdirs under the daemon dir and the recovery plane
+    // serves no resources — the store materializes on first product use.
     let resourceStore: ResourceStore | null = null;
     const resources = (): ResourceStore =>
       (resourceStore ??= new ResourceStore(join(daemonDir(), "resource-store")));
@@ -528,7 +471,7 @@ export async function main(): Promise<void> {
       control: () => control,
       journal: {
         close: () => {
-          if (quotaPollTimer) clearInterval(quotaPollTimer);
+          quotaPoller?.stop();
           threads.close();
           journalManager.close();
         },
@@ -549,18 +492,11 @@ export async function main(): Promise<void> {
       () => quotaStoreSlot.current(),
       () => selfClient.list(),
     );
-    // C6a: a recovery-required startup verdict binds the control API even
-    // under CLAUDEXOR_NO_CONTROL_API=1 — the recovery surface IS the point
-    // of the recovery plane.
-    const controlDisabledByEnv = process.env.CLAUDEXOR_NO_CONTROL_API === "1";
-    const controlEnabled = !controlDisabledByEnv || startupBlockedPartitions.length > 0;
-    if (controlDisabledByEnv && controlEnabled) {
-      logLine(
-        logPath(),
-        "recovery-required startup verdict overrides CLAUDEXOR_NO_CONTROL_API=1: binding the control API to serve the recovery surface",
-      );
-    }
-    control = !controlEnabled
+    control = !controlApiEnabledForStartup({
+      disabledByEnv: process.env.CLAUDEXOR_NO_CONTROL_API === "1",
+      blockedPartitions: startupBlockedPartitions,
+      log: (message) => logLine(logPath(), message),
+    })
       ? null
       : new DaemonControlApiServer({
           token,
@@ -573,110 +509,33 @@ export async function main(): Promise<void> {
     lifecycle = armDaemonLifecycle({
       daemonDir: daemonDir(),
       logPath: logPath(),
-      ...(diagnostics ? { diagnostics } : {}),
+      ...(startupDiagnostics.diagnostics ? { diagnostics: startupDiagnostics.diagnostics } : {}),
       beginShutdown: (reason) => shutdownRuntime!.beginShutdown(reason),
     });
 
-    // Normal-plane side effects shared by the startup path and the C6b
-    // in-process reopen; guarded to run exactly once.
-    let normalAdmissionCompleted = false;
-    const onNormalAdmission = async (): Promise<void> => {
-      if (normalAdmissionCompleted || shutdownRuntime!.requested()) return;
-      normalAdmissionCompleted = true;
-      armQuotaPolling();
-      // Crash-GC has consumed the previous life's pids.json by now; live
-      // snapshots may own the file again (C2).
-      lifecycle!.beginPidSnapshots();
-      // Same-root config evolution hygiene (B9): persist the retired-key
-      // sweep only on the NORMAL plane (C5a). Pre-admission parses already
-      // tolerate retired keys via loadConfig's in-memory strip; unknown
-      // keys NOT on the retired registry still fail loud (INV-021).
-      for (const sweep of sweepRetiredConfigKeysAtStartup()) {
-        logLine(
-          logPath(),
-          `swept retired config keys from ${sweep.path}: ${sweep.removed.join(", ")}`,
-        );
-      }
-      await setupBinding.start();
-      quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
-      scheduleStartupRetention(services.runRetention, {
-        logPath: logPath(),
-        shuttingDown: () => shutdownRuntime!.requested(),
-      });
-    };
-
-    // D5 stage 4, single-flight: the startup path runs it with the frozen
-    // stage-2 verdict; the C6b recovery-route reopen re-runs it with a live
-    // one. Concurrent callers join the in-flight completion.
-    let admissionCompletion: Promise<DaemonServingMode> | null = null;
-    const runAdmissionCompletion = (
-      blockedPartitions: () => string[],
-    ): Promise<DaemonServingMode> => {
-      if (admission.snapshot() === "normal") return Promise.resolve("normal");
-      admissionCompletion ??= (async () => {
-        try {
-          const servingMode = await completeStartupAdmission({
-            grant: rootAuthority,
-            blockedPartitions: blockedPartitions(),
-            global: journalManager,
-            partitions: threads,
-            crashGc: () =>
-              runStartupCrashGc({
-                daemonDir: daemonDir(),
-                logPath: logPath(),
-                ...(diagnostics ? { diagnostics } : {}),
-              }),
-            admission,
-            log: (message) => {
-              logLine(logPath(), message);
-              recordStage("startup_admission", message);
-            },
-          });
-          if (servingMode === "normal") await onNormalAdmission();
-          return servingMode;
-        } finally {
-          admissionCompletion = null;
-        }
-      })();
-      return admissionCompletion;
-    };
-
-    // C6b: after a successful recovery-route quarantine (openGeneration) the
-    // daemon transitions to normal WITHOUT a restart: re-run the stage-4
-    // completion against a live re-verdict of the current partition state.
-    const reopenAfterRecovery = async (): Promise<void> => {
-      while (admission.snapshot() !== "normal") {
-        const joined = admissionCompletion;
-        if (joined) {
-          await joined.catch(() => {});
-          continue;
-        }
-        const servingMode = await runAdmissionCompletion(() =>
-          recoveryBlockedPartitions({
-            globalPreparation: { inspection: journalManager.inspect() },
-            partitionsPreparation: threads.refreshPreparation(),
+    const { runAdmissionCompletion, wrapQuarantineWithReopen } = createStartupAdmissionRuntime({
+      admission,
+      grant: rootAuthority,
+      global: journalManager,
+      partitions: threads,
+      diagnostics: startupDiagnostics,
+      normalPlane: {
+        requested: () => shutdownRuntime!.requested(),
+        armQuotaPolling: () => quotaPoller!.arm(),
+        beginPidSnapshots: () => lifecycle!.beginPidSnapshots(),
+        startSetup: () => setupBinding.start(),
+        quarantineGhosts: () =>
+          quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message)),
+        scheduleRetention: () =>
+          scheduleStartupRetention(services.runRetention, {
+            logPath: logPath(),
+            shuttingDown: () => shutdownRuntime!.requested(),
           }),
-        );
-        if (servingMode !== "normal") return; // partitions still block: stay protected
-      }
-    };
-    const quarantineService = services.recoveryQuarantinePartition;
-    services.recoveryQuarantinePartition = async (partition: string, input: unknown) => {
-      const receipt = await quarantineService(partition, input);
-      try {
-        await reopenAfterRecovery();
-      } catch (error) {
-        // The quarantine itself SUCCEEDED; a failed reopen stays on the
-        // protected recovery plane and is disclosed.
-        logLine(
-          logPath(),
-          `recovery reopen failed; still serving recovery only: ${redactSecrets(
-            error instanceof Error ? error.message : String(error),
-          )}`,
-        );
-      }
-      return receipt;
-    };
+      },
+    });
+    services.recoveryQuarantinePartition = wrapQuarantineWithReopen(
+      services.recoveryQuarantinePartition,
+    );
 
     // D5 stage 3: bind the REAL transport with product admission CLOSED, then
     // prove self-health/exact identity through it before anything destructive.
@@ -703,7 +562,7 @@ export async function main(): Promise<void> {
     await shutdownRuntime.wait();
     lifecycle.finalize();
     logLine(logPath(), "claudexord shut down");
-    recordStage("shutdown_complete", "claudexord shut down");
+    startupDiagnostics.recordStage("shutdown_complete", "claudexord shut down");
   } catch (error) {
     // logLine is already best-effort; a failed diagnostic write never masks
     // the lifecycle failure itself.
@@ -713,11 +572,7 @@ export async function main(): Promise<void> {
         error instanceof Error ? `${error.name}: ${error.message}` : String(error),
       )}`,
     );
-    try {
-      diagnostics?.record({ stage: "startup_failure", message: "daemon lifecycle FAILED", error });
-    } catch {
-      /* diagnostics never control lifecycle */
-    }
+    startupDiagnostics.recordFailure("daemon lifecycle FAILED", error);
     if (shutdownRuntime) {
       try {
         await shutdownRuntime.beginShutdown("startup failure");
@@ -738,8 +593,8 @@ export async function main(): Promise<void> {
     }
     throw error;
   } finally {
-    if (quotaPollTimer) clearInterval(quotaPollTimer);
-    diagnostics?.close();
+    quotaPoller?.stop();
+    startupDiagnostics.close();
     // Drops only the live writer claim; the barrier itself persists (D1).
     if (releaseWriterLease) rootAuthority.release();
   }

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -559,6 +559,9 @@ export async function main(): Promise<void> {
       });
       if (servingMode === "normal" && !shutdownRuntime.requested()) {
         armQuotaPolling();
+        // Crash-GC has consumed the previous life's pids.json by now; live
+        // snapshots may own the file again (C2).
+        lifecycle.beginPidSnapshots();
         await setupBinding.start();
         quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
         scheduleStartupRetention(services.runRetention, {

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import {
   DaemonClient,
@@ -20,7 +20,7 @@ import {
   type ThreadHeadPingSink,
   daemonDir,
   defaultSocketPath,
-  acquireDaemonWriterLease,
+  acquireRootAuthority,
   ensureToken,
   ensureDaemonRuntimeRoot,
   logPath,
@@ -28,6 +28,14 @@ import {
 } from "@claudexor/daemon";
 import { DaemonControlApiServer, normalizeRunStartRequest } from "@claudexor/control-api";
 import { armDaemonLifecycle, logLine, runStartupCrashGc } from "./daemon-lifecycle.js";
+import {
+  bindRecoveryTransport,
+  completeStartupAdmission,
+  DaemonStartupAdmission,
+  proveRecoveryTransport,
+  quarantineGhostProjectsAtStartup,
+  recoveryBlockedPartitions,
+} from "./daemon-startup.js";
 import { assertPlanImplementReady } from "./plan-implement-readiness.js";
 import { Orchestrator } from "@claudexor/orchestrator";
 import { delegationBeltForRun } from "./delegation-belt-descriptor.js";
@@ -81,7 +89,8 @@ export async function main(): Promise<void> {
   const servingIdentity = engineBuildIdentity();
   ensureDaemonRuntimeRoot();
   const socketPath = defaultSocketPath();
-  const writerLease = acquireDaemonWriterLease(socketPath);
+  // D5 stage 1: permanent barrier (epoch/floor refusals) before ANY recovery.
+  const rootAuthority = acquireRootAuthority({ socketPath, version: servingIdentity.version });
   let shutdownRuntime: DaemonRuntimeShutdown | null = null;
   // Release wave round-12 BLOCK: the single-writer lease may only be released
   // after a CLEAN shutdown — a failed/partial shutdown keeps components that
@@ -96,11 +105,10 @@ export async function main(): Promise<void> {
     if (await socketAlive(socketPath)) {
       throw new Error(`a claudexor daemon is already listening on ${socketPath}; stop it first`);
     }
-    await runStartupCrashGc({ daemonDir: daemonDir(), logPath: logPath() });
     // Same-root config evolution hygiene (B9): strip + persist any known-retired
     // keys an OLDER version wrote into the global config, before any strict
-    // parse can trip on them (mirrors the crash-GC startup sweep). Unknown keys
-    // NOT on the retired registry still fail loud at parse (INV-021).
+    // parse can trip on them. Unknown keys NOT on the retired registry still
+    // fail loud at parse (INV-021).
     for (const sweep of sweepRetiredConfigKeysAtStartup()) {
       logLine(
         logPath(),
@@ -141,7 +149,9 @@ export async function main(): Promise<void> {
       create: (journal) => new SetupJobStore(daemonDir(), { journal }),
       validate: (store) => store.validateProjection(),
     });
-    journalManager.start();
+    // D5 stage 2: read-only prepare + validate; zero recovery writes.
+    const globalPreparation = journalManager.prepare();
+    const admission = new DaemonStartupAdmission();
     const pollQuota = () => {
       try {
         void quotaStoreSlot.current().pollStale();
@@ -159,6 +169,7 @@ export async function main(): Promise<void> {
       threadStoreSlot,
       threadHeadPing,
     );
+    const partitionsPreparation = threads.prepare();
     const interactions = new InteractionRegistry({
       forRequest: (params) => threads.interactionsForRequest(params),
       all: () => threads.interactionStores(),
@@ -169,6 +180,7 @@ export async function main(): Promise<void> {
       socketPath,
       token,
       commands: threads,
+      servingMode: admission.snapshot,
       delegationAuthority: delegationBudgetAuthority,
       onRunTerminal: (runId, threadId) => {
         interactions.dropForRun(runId);
@@ -191,7 +203,7 @@ export async function main(): Promise<void> {
         return shutdownRuntime.beginRuntimeReplacement();
       },
       runtimeIdentity: { version: servingIdentity.version, buildSha: servingIdentity.sha },
-      runtimeLeaseOwner: writerLease.owner,
+      runtimeLeaseOwner: rootAuthority.lease.owner,
       runner: async (params, ctx) => {
         const p = normalizeRunStartRequest(params);
         const mode = p.mode;
@@ -498,6 +510,7 @@ export async function main(): Promise<void> {
             token,
             daemon: new DaemonClient(socketPath, token),
             port: Number(process.env.CLAUDEXOR_CONTROL_PORT ?? 0),
+            servingMode: admission.snapshot,
             bus,
             services,
           });
@@ -507,85 +520,66 @@ export async function main(): Promise<void> {
       beginShutdown: (reason) => shutdownRuntime!.beginShutdown(reason),
     });
 
-    await setupBinding.start();
-    if (!shutdownRuntime.requested()) await server.start();
+    // D5 stage 3: bind the REAL transport with product admission CLOSED, then
+    // prove self-health/exact identity through it before anything destructive.
+    const controlAddr = await bindRecoveryTransport({
+      server,
+      control,
+      requested: () => shutdownRuntime!.requested(),
+      daemonDir: daemonDir(),
+      logPath: logPath(),
+      socketPath,
+    });
     if (!shutdownRuntime.requested()) {
-      appendFileSync(
-        logPath(),
-        `[${new Date().toISOString()}] claudexord listening on ${socketPath}\n`,
-      );
-    }
-    if (control && !shutdownRuntime.requested()) {
-      const controlAddr = await control.start();
-      if (!shutdownRuntime.requested()) {
-        writeFileSync(
-          join(daemonDir(), "control-api.json"),
-          `${JSON.stringify({ ...controlAddr, tokenPath: join(daemonDir(), "token") }, null, 2)}\n`,
-          { mode: 0o600 },
-        );
-        appendFileSync(
-          logPath(),
-          `[${new Date().toISOString()}] claudexor control-api listening on http://${controlAddr.host}:${controlAddr.port}\n`,
-        );
-      }
-    } else if (!control && !shutdownRuntime.requested()) {
-      appendFileSync(
-        logPath(),
-        `[${new Date().toISOString()}] claudexor control-api disabled by CLAUDEXOR_NO_CONTROL_API=1\n`,
-      );
-    }
-    if (!shutdownRuntime.requested()) {
-      // F2 ghost-cleanup: retire projects auto-registered from an
-      // envelope worktree (root inside the Claudexor runtime tree) or whose
-      // root is permanently gone, so a dead root can never poison listings.
-      try {
-        const retired = threads.quarantineGhostProjects();
-        for (const ghost of retired) {
-          logLine(
-            logPath(),
-            `projects: quarantined ghost ${ghost.projectId} (${ghost.reason}): ${ghost.root}`,
-          );
-        }
-      } catch (error) {
-        logLine(
-          logPath(),
-          `projects: ghost sweep failed: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-      scheduleStartupRetention(services.runRetention, {
-        logPath: logPath(),
-        shuttingDown: () => shutdownRuntime!.requested(),
+      await proveRecoveryTransport({
+        socket: selfClient,
+        identity: servingIdentity,
+        token,
+        control: controlAddr,
       });
+      // D5 stage 4: floor advance + destructive recovery + normal admission —
+      // or stay recovery-only with the floor unchanged and cleanup off.
+      const servingMode = await completeStartupAdmission({
+        grant: rootAuthority,
+        blockedPartitions: recoveryBlockedPartitions({ globalPreparation, partitionsPreparation }),
+        global: journalManager,
+        partitions: threads,
+        crashGc: () => runStartupCrashGc({ daemonDir: daemonDir(), logPath: logPath() }),
+        admission,
+        log: (message) => logLine(logPath(), message),
+      });
+      if (servingMode === "normal" && !shutdownRuntime.requested()) {
+        await setupBinding.start();
+        quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
+        scheduleStartupRetention(services.runRetention, {
+          logPath: logPath(),
+          shuttingDown: () => shutdownRuntime!.requested(),
+        });
+      }
     }
     await shutdownRuntime.wait();
     lifecycle.finalize();
-    appendFileSync(logPath(), `[${new Date().toISOString()}] claudexord shut down\n`);
+    logLine(logPath(), "claudexord shut down");
   } catch (error) {
-    try {
-      appendFileSync(
-        logPath(),
-        `[${new Date().toISOString()}] daemon lifecycle FAILED: ${redactSecrets(
-          error instanceof Error ? `${error.name}: ${error.message}` : String(error),
-        )}\n`,
-      );
-    } catch {
-      /* preserve the lifecycle failure */
-    }
+    // logLine is already best-effort; a failed diagnostic write never masks
+    // the lifecycle failure itself.
+    logLine(
+      logPath(),
+      `daemon lifecycle FAILED: ${redactSecrets(
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+      )}`,
+    );
     if (shutdownRuntime) {
       try {
         await shutdownRuntime.beginShutdown("startup failure");
         lifecycle?.finalize();
       } catch (shutdownError) {
-        try {
-          appendFileSync(
-            logPath(),
-            `[${new Date().toISOString()}] shutdown FAILED: ${redactSecrets(
-              shutdownError instanceof Error ? shutdownError.message : String(shutdownError),
-            )}\n`,
-          );
-        } catch {
-          /* preserve the shutdown failure */
-        }
+        logLine(
+          logPath(),
+          `shutdown FAILED: ${redactSecrets(
+            shutdownError instanceof Error ? shutdownError.message : String(shutdownError),
+          )}`,
+        );
         releaseWriterLease = false;
         throw new AggregateError(
           [error, shutdownError],
@@ -596,7 +590,8 @@ export async function main(): Promise<void> {
     throw error;
   } finally {
     if (quotaPollTimer) clearInterval(quotaPollTimer);
-    if (releaseWriterLease) writerLease.release();
+    // Drops only the live writer claim; the barrier itself persists (D1).
+    if (releaseWriterLease) rootAuthority.release();
   }
 }
 

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -25,6 +25,7 @@ import {
   ensureDaemonRuntimeRoot,
   logPath,
   socketAlive,
+  type DaemonServingMode,
 } from "@claudexor/daemon";
 import { DaemonControlApiServer, normalizeRunStartRequest } from "@claudexor/control-api";
 import { armDaemonLifecycle, logLine, runStartupCrashGc } from "./daemon-lifecycle.js";
@@ -169,6 +170,10 @@ export async function main(): Promise<void> {
       threadHeadPing,
     );
     const partitionsPreparation = threads.prepare();
+    const startupBlockedPartitions = recoveryBlockedPartitions({
+      globalPreparation,
+      partitionsPreparation,
+    });
     const interactions = new InteractionRegistry({
       forRequest: (params) => threads.interactionsForRequest(params),
       all: () => threads.interactionStores(),
@@ -507,22 +512,125 @@ export async function main(): Promise<void> {
       () => quotaStoreSlot.current(),
       () => selfClient.list(),
     );
-    control =
-      process.env.CLAUDEXOR_NO_CONTROL_API === "1"
-        ? null
-        : new DaemonControlApiServer({
-            token,
-            daemon: new DaemonClient(socketPath, token),
-            port: Number(process.env.CLAUDEXOR_CONTROL_PORT ?? 0),
-            servingMode: admission.snapshot,
-            bus,
-            services,
-          });
+    // C6a: a recovery-required startup verdict binds the control API even
+    // under CLAUDEXOR_NO_CONTROL_API=1 — the recovery surface IS the point
+    // of the recovery plane.
+    const controlDisabledByEnv = process.env.CLAUDEXOR_NO_CONTROL_API === "1";
+    const controlEnabled = !controlDisabledByEnv || startupBlockedPartitions.length > 0;
+    if (controlDisabledByEnv && controlEnabled) {
+      logLine(
+        logPath(),
+        "recovery-required startup verdict overrides CLAUDEXOR_NO_CONTROL_API=1: binding the control API to serve the recovery surface",
+      );
+    }
+    control = !controlEnabled
+      ? null
+      : new DaemonControlApiServer({
+          token,
+          daemon: new DaemonClient(socketPath, token),
+          port: Number(process.env.CLAUDEXOR_CONTROL_PORT ?? 0),
+          servingMode: admission.snapshot,
+          bus,
+          services,
+        });
     lifecycle = armDaemonLifecycle({
       daemonDir: daemonDir(),
       logPath: logPath(),
       beginShutdown: (reason) => shutdownRuntime!.beginShutdown(reason),
     });
+
+    // Normal-plane side effects shared by the startup path and the C6b
+    // in-process reopen; guarded to run exactly once.
+    let normalAdmissionCompleted = false;
+    const onNormalAdmission = async (): Promise<void> => {
+      if (normalAdmissionCompleted || shutdownRuntime!.requested()) return;
+      normalAdmissionCompleted = true;
+      armQuotaPolling();
+      // Crash-GC has consumed the previous life's pids.json by now; live
+      // snapshots may own the file again (C2).
+      lifecycle!.beginPidSnapshots();
+      // Same-root config evolution hygiene (B9): persist the retired-key
+      // sweep only on the NORMAL plane (C5a). Pre-admission parses already
+      // tolerate retired keys via loadConfig's in-memory strip; unknown
+      // keys NOT on the retired registry still fail loud (INV-021).
+      for (const sweep of sweepRetiredConfigKeysAtStartup()) {
+        logLine(
+          logPath(),
+          `swept retired config keys from ${sweep.path}: ${sweep.removed.join(", ")}`,
+        );
+      }
+      await setupBinding.start();
+      quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
+      scheduleStartupRetention(services.runRetention, {
+        logPath: logPath(),
+        shuttingDown: () => shutdownRuntime!.requested(),
+      });
+    };
+
+    // D5 stage 4, single-flight: the startup path runs it with the frozen
+    // stage-2 verdict; the C6b recovery-route reopen re-runs it with a live
+    // one. Concurrent callers join the in-flight completion.
+    let admissionCompletion: Promise<DaemonServingMode> | null = null;
+    const runAdmissionCompletion = (
+      blockedPartitions: () => string[],
+    ): Promise<DaemonServingMode> => {
+      if (admission.snapshot() === "normal") return Promise.resolve("normal");
+      admissionCompletion ??= (async () => {
+        try {
+          const servingMode = await completeStartupAdmission({
+            grant: rootAuthority,
+            blockedPartitions: blockedPartitions(),
+            global: journalManager,
+            partitions: threads,
+            crashGc: () => runStartupCrashGc({ daemonDir: daemonDir(), logPath: logPath() }),
+            admission,
+            log: (message) => logLine(logPath(), message),
+          });
+          if (servingMode === "normal") await onNormalAdmission();
+          return servingMode;
+        } finally {
+          admissionCompletion = null;
+        }
+      })();
+      return admissionCompletion;
+    };
+
+    // C6b: after a successful recovery-route quarantine (openGeneration) the
+    // daemon transitions to normal WITHOUT a restart: re-run the stage-4
+    // completion against a live re-verdict of the current partition state.
+    const reopenAfterRecovery = async (): Promise<void> => {
+      while (admission.snapshot() !== "normal") {
+        const joined = admissionCompletion;
+        if (joined) {
+          await joined.catch(() => {});
+          continue;
+        }
+        const servingMode = await runAdmissionCompletion(() =>
+          recoveryBlockedPartitions({
+            globalPreparation: { inspection: journalManager.inspect() },
+            partitionsPreparation: threads.refreshPreparation(),
+          }),
+        );
+        if (servingMode !== "normal") return; // partitions still block: stay protected
+      }
+    };
+    const quarantineService = services.recoveryQuarantinePartition;
+    services.recoveryQuarantinePartition = async (partition: string, input: unknown) => {
+      const receipt = await quarantineService(partition, input);
+      try {
+        await reopenAfterRecovery();
+      } catch (error) {
+        // The quarantine itself SUCCEEDED; a failed reopen stays on the
+        // protected recovery plane and is disclosed.
+        logLine(
+          logPath(),
+          `recovery reopen failed; still serving recovery only: ${redactSecrets(
+            error instanceof Error ? error.message : String(error),
+          )}`,
+        );
+      }
+      return receipt;
+    };
 
     // D5 stage 3: bind the REAL transport with product admission CLOSED, then
     // prove self-health/exact identity through it before anything destructive.
@@ -542,38 +650,9 @@ export async function main(): Promise<void> {
         control: controlAddr,
       });
       // D5 stage 4: floor advance + destructive recovery + normal admission —
-      // or stay recovery-only with the floor unchanged and cleanup off.
-      const servingMode = await completeStartupAdmission({
-        grant: rootAuthority,
-        blockedPartitions: recoveryBlockedPartitions({ globalPreparation, partitionsPreparation }),
-        global: journalManager,
-        partitions: threads,
-        crashGc: () => runStartupCrashGc({ daemonDir: daemonDir(), logPath: logPath() }),
-        admission,
-        log: (message) => logLine(logPath(), message),
-      });
-      if (servingMode === "normal" && !shutdownRuntime.requested()) {
-        armQuotaPolling();
-        // Crash-GC has consumed the previous life's pids.json by now; live
-        // snapshots may own the file again (C2).
-        lifecycle.beginPidSnapshots();
-        // Same-root config evolution hygiene (B9): persist the retired-key
-        // sweep only on the NORMAL plane (C5a). Pre-admission parses already
-        // tolerate retired keys via loadConfig's in-memory strip; unknown
-        // keys NOT on the retired registry still fail loud (INV-021).
-        for (const sweep of sweepRetiredConfigKeysAtStartup()) {
-          logLine(
-            logPath(),
-            `swept retired config keys from ${sweep.path}: ${sweep.removed.join(", ")}`,
-          );
-        }
-        await setupBinding.start();
-        quarantineGhostProjectsAtStartup(threads, (message) => logLine(logPath(), message));
-        scheduleStartupRetention(services.runRetention, {
-          logPath: logPath(),
-          shuttingDown: () => shutdownRuntime!.requested(),
-        });
-      }
+      // or stay recovery-only with the floor unchanged and cleanup off. The
+      // normal-plane side effects run inside the single-flight completion.
+      await runAdmissionCompletion(() => startupBlockedPartitions);
     }
     await shutdownRuntime.wait();
     lifecycle.finalize();

--- a/packages/cli/src/control-services.ts
+++ b/packages/cli/src/control-services.ts
@@ -99,7 +99,9 @@ export function controlServices(
   setupBinding: SetupBinding,
   journalManager: JournalManager,
   authReadiness: AuthReadinessService,
-  resources: ResourceStore,
+  /** Lazy accessor (C5b): the store mkdirs on construction and only product
+   * routes touch it, so the recovery plane must never materialize it. */
+  resources: () => ResourceStore,
   quotaRegistry: () => QuotaRegistry,
   daemonJobs: () => Promise<
     Array<{ runId?: string; state: string; finishedAt?: string; params?: unknown }>
@@ -145,7 +147,10 @@ export function controlServices(
     }
   };
   mkdirSync(NO_PROJECT_ROOT, { recursive: true, mode: 0o700 });
-  const preflightRunRequirements = createRunRequirementsPreflight(resources, NO_PROJECT_ROOT, {
+  const lazyResources: Pick<ResourceStore, "resolve"> = {
+    resolve: (refs) => resources().resolve(refs),
+  };
+  const preflightRunRequirements = createRunRequirementsPreflight(lazyResources, NO_PROJECT_ROOT, {
     requiresGit: (request: ControlRunStartRequest) => {
       const root = request.scope.kind === "project" ? request.scope.root : NO_PROJECT_ROOT;
       const thread = request.threadId ? threads.getThread(request.threadId) : undefined;
@@ -157,7 +162,7 @@ export function controlServices(
     },
   });
   const preflightThreadRunRequirements = createRunRequirementsPreflight(
-    resources,
+    lazyResources,
     NO_PROJECT_ROOT,
     {
       requiresGit: (request: ControlRunStartRequest) => {
@@ -176,18 +181,18 @@ export function controlServices(
     preflightRunRequirements,
     preflightThreadRunRequirements,
     createUpload: async (input: unknown, idempotencyKey: string) =>
-      resources.create(input, idempotencyKey),
+      resources().create(input, idempotencyKey),
     writeUpload: async (uploadId: string, chunks: AsyncIterable<Uint8Array>) =>
-      resources.write(uploadId, chunks),
-    uploadStatus: async (uploadId: string) => resources.status(uploadId),
-    cancelUpload: async (uploadId: string) => resources.cancel(uploadId),
+      resources().write(uploadId, chunks),
+    uploadStatus: async (uploadId: string) => resources().status(uploadId),
+    cancelUpload: async (uploadId: string) => resources().cancel(uploadId),
     finalizeUpload: async (
       uploadId: string,
       expectedSha256: string | undefined,
       idempotencyKey: string,
-    ) => resources.finalize(uploadId, expectedSha256, idempotencyKey),
+    ) => resources().finalize(uploadId, expectedSha256, idempotencyKey),
     validateResources: async (refs: ResourceAttachmentRef[]) => {
-      resources.resolve(refs);
+      resources().resolve(refs);
     },
     runRetention: createRetentionRunner({ projects, threads, daemonJobs }),
     // F3 nested-project disclosure: each project carries its recomputed
@@ -242,7 +247,7 @@ export function controlServices(
       const { threads: rows, problems } = threads.listThreadsResilient();
       return { threads: rows as unknown[], problems: problems as unknown[] };
     },
-    ...threadTurnServices(threads, resources),
+    ...threadTurnServices(threads, lazyResources),
     updateThread: async (
       id: string,
       patch: {

--- a/packages/cli/src/control-services.ts
+++ b/packages/cli/src/control-services.ts
@@ -150,31 +150,22 @@ export function controlServices(
   const lazyResources: Pick<ResourceStore, "resolve"> = {
     resolve: (refs) => resources().resolve(refs),
   };
+  const runStartRequiresGit = (request: ControlRunStartRequest): boolean => {
+    const root = request.scope.kind === "project" ? request.scope.root : NO_PROJECT_ROOT;
+    const thread = request.threadId ? threads.getThread(request.threadId) : undefined;
+    return threadRunStartRequiresGit(
+      request,
+      thread,
+      loadConfig(root).project.constraints.protected_paths,
+    );
+  };
   const preflightRunRequirements = createRunRequirementsPreflight(lazyResources, NO_PROJECT_ROOT, {
-    requiresGit: (request: ControlRunStartRequest) => {
-      const root = request.scope.kind === "project" ? request.scope.root : NO_PROJECT_ROOT;
-      const thread = request.threadId ? threads.getThread(request.threadId) : undefined;
-      return threadRunStartRequiresGit(
-        request,
-        thread,
-        loadConfig(root).project.constraints.protected_paths,
-      );
-    },
+    requiresGit: runStartRequiresGit,
   });
   const preflightThreadRunRequirements = createRunRequirementsPreflight(
     lazyResources,
     NO_PROJECT_ROOT,
-    {
-      requiresGit: (request: ControlRunStartRequest) => {
-        const root = request.scope.kind === "project" ? request.scope.root : NO_PROJECT_ROOT;
-        const thread = request.threadId ? threads.getThread(request.threadId) : undefined;
-        return threadRunStartRequiresGit(
-          request,
-          thread,
-          loadConfig(root).project.constraints.protected_paths,
-        );
-      },
-    },
+    { requiresGit: runStartRequiresGit },
     { git: "durable_job" },
   );
   return {

--- a/packages/cli/src/daemon-admission-runtime.ts
+++ b/packages/cli/src/daemon-admission-runtime.ts
@@ -1,0 +1,243 @@
+/**
+ * Claudexord's startup-admission runtime, kept out of main() so the
+ * entrypoint stays a thin composition root:
+ *
+ * - C8: the best-effort post-authority diagnostics opener with launch
+ *   provenance (a diagnostics failure never controls daemon lifecycle);
+ * - the quota poller armed only on normal admission (C1a);
+ * - D5 stage 4 as ONE single-flight completion shared by the startup path
+ *   and the C6b recovery-route reopen, which re-runs it with a LIVE
+ *   re-verdict so the daemon transitions to normal without a restart.
+ */
+import {
+  daemonDir,
+  logPath,
+  type DaemonServingMode,
+  type JournalManager,
+  type ProjectPartitions,
+  type RootAuthorityGrant,
+} from "@claudexor/daemon";
+import { sweepRetiredConfigKeysAtStartup } from "@claudexor/config";
+import { redactSecrets } from "@claudexor/util";
+import { DAEMON_LAUNCH_SOURCE_ENV } from "./daemon-launch.js";
+import { logLine, runStartupCrashGc } from "./daemon-lifecycle.js";
+import {
+  completeStartupAdmission,
+  recoveryBlockedPartitions,
+  type DaemonStartupAdmission,
+} from "./daemon-startup.js";
+import {
+  openDaemonStartupDiagnosticsAfterAuthority,
+  safeDaemonLaunchSource,
+  type DaemonStartupDiagnostics,
+} from "./startup-diagnostics.js";
+
+export interface StartupDiagnosticsHandle {
+  diagnostics: DaemonStartupDiagnostics | null;
+  recordStage(stage: string, message: string): void;
+  recordFailure(message: string, error: unknown): void;
+  close(): void;
+}
+
+/** C8: open the private post-authority diagnostics with full launch
+ * provenance (runtime identity, entry path, pid, data root, and the
+ * CLAUDEXOR_DAEMON_LAUNCH_SOURCE value coerced to a safe label). */
+export function openStartupDiagnostics(identity: {
+  version: string;
+  sha: string;
+  entry: string;
+}): StartupDiagnosticsHandle {
+  let diagnostics: DaemonStartupDiagnostics | null = null;
+  try {
+    diagnostics = openDaemonStartupDiagnosticsAfterAuthority({
+      runtimeVersion: identity.version,
+      buildSha: identity.sha,
+      entryPath: identity.entry,
+      pid: process.pid,
+      dataRoot: daemonDir(),
+      launchSource: safeDaemonLaunchSource(process.env[DAEMON_LAUNCH_SOURCE_ENV]),
+    });
+    diagnostics.record({
+      stage: "root_authority_won",
+      message: "root authority acquired; startup diagnostics online",
+    });
+  } catch (error) {
+    logLine(
+      logPath(),
+      `startup diagnostics unavailable: ${redactSecrets(
+        error instanceof Error ? error.message : String(error),
+      )}`,
+    );
+  }
+  const record = (value: Parameters<DaemonStartupDiagnostics["record"]>[0]): void => {
+    try {
+      diagnostics?.record(value);
+    } catch {
+      /* diagnostics never control lifecycle */
+    }
+  };
+  return {
+    diagnostics,
+    recordStage: (stage, message) => record({ stage, message }),
+    recordFailure: (message, error) => record({ stage: "startup_failure", message, error }),
+    close: () => diagnostics?.close(),
+  };
+}
+
+/** C1a/G-QUOTA-01: quota polling belongs to the NORMAL plane — polling
+ * against unactivated projections is a swallowed throw, and the recovery
+ * plane must stay non-mutating. Arming polls immediately, removing the
+ * one-minute stale window the swallowed stage-2 poll used to leave. */
+export function createDaemonQuotaPoller(poll: () => void): { arm(): void; stop(): void } {
+  let timer: NodeJS.Timeout | null = null;
+  return {
+    arm: () => {
+      if (timer) return;
+      timer = setInterval(poll, 60_000);
+      timer.unref();
+      poll();
+    },
+    stop: () => {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+  };
+}
+
+/** The composition root's normal-plane duties, run exactly once from either
+ * the startup path or the C6b reopen (C1a quota arming, C2 pid snapshots,
+ * C5a retired-key sweep persistence, setup binding, ghost quarantine,
+ * startup retention). */
+export interface NormalPlaneDuties {
+  requested(): boolean;
+  armQuotaPolling(): void;
+  beginPidSnapshots(): void;
+  startSetup(): Promise<void>;
+  quarantineGhosts(): void;
+  scheduleRetention(): void;
+}
+
+/** D5 stage 4, single-flight: the startup path runs it with the frozen
+ * stage-2 verdict; the C6b recovery-route reopen re-runs it with a live one.
+ * Concurrent callers join the in-flight completion. */
+export function createStartupAdmissionRuntime(input: {
+  admission: DaemonStartupAdmission;
+  grant: Pick<RootAuthorityGrant, "advanceFloor">;
+  global: JournalManager;
+  partitions: ProjectPartitions;
+  diagnostics: StartupDiagnosticsHandle;
+  normalPlane: NormalPlaneDuties;
+}): {
+  runAdmissionCompletion(blockedPartitions: () => string[]): Promise<DaemonServingMode>;
+  wrapQuarantineWithReopen<T>(
+    service: (partition: string, request: unknown) => Promise<T>,
+  ): (partition: string, request: unknown) => Promise<T>;
+} {
+  // Normal-plane side effects run exactly once, from whichever path opened
+  // normal admission first.
+  let normalAdmissionCompleted = false;
+  const onNormalAdmission = async (): Promise<void> => {
+    if (normalAdmissionCompleted || input.normalPlane.requested()) return;
+    normalAdmissionCompleted = true;
+    input.normalPlane.armQuotaPolling();
+    // Crash-GC has consumed the previous life's pids.json by now; live
+    // snapshots may own the file again (C2).
+    input.normalPlane.beginPidSnapshots();
+    // Same-root config evolution hygiene (B9): persist the retired-key sweep
+    // only on the NORMAL plane (C5a). Pre-admission parses already tolerate
+    // retired keys via loadConfig's in-memory strip; unknown keys NOT on the
+    // retired registry still fail loud (INV-021).
+    for (const sweep of sweepRetiredConfigKeysAtStartup()) {
+      logLine(
+        logPath(),
+        `swept retired config keys from ${sweep.path}: ${sweep.removed.join(", ")}`,
+      );
+    }
+    await input.normalPlane.startSetup();
+    input.normalPlane.quarantineGhosts();
+    input.normalPlane.scheduleRetention();
+  };
+
+  let admissionCompletion: Promise<DaemonServingMode> | null = null;
+  const runAdmissionCompletion = (
+    blockedPartitions: () => string[],
+  ): Promise<DaemonServingMode> => {
+    if (input.admission.snapshot() === "normal") return Promise.resolve("normal");
+    admissionCompletion ??= (async () => {
+      try {
+        const servingMode = await completeStartupAdmission({
+          grant: input.grant,
+          blockedPartitions: blockedPartitions(),
+          global: {
+            // A manager already reopened by a recovery-route quarantine
+            // (openGeneration) is live authority; only still-prepared state
+            // revalidates (the reopen runs over a mix of both).
+            revalidatePreparation: () => {
+              if (!input.global.ready()) input.global.revalidatePreparation();
+            },
+            activatePrepared: () => input.global.activatePrepared(),
+            recoverAfterStartup: () => input.global.recoverAfterStartup(),
+          },
+          partitions: input.partitions,
+          crashGc: () =>
+            runStartupCrashGc({
+              daemonDir: daemonDir(),
+              logPath: logPath(),
+              ...(input.diagnostics.diagnostics
+                ? { diagnostics: input.diagnostics.diagnostics }
+                : {}),
+            }),
+          admission: input.admission,
+          log: (message) => {
+            logLine(logPath(), message);
+            input.diagnostics.recordStage("startup_admission", message);
+          },
+        });
+        if (servingMode === "normal") await onNormalAdmission();
+        return servingMode;
+      } finally {
+        admissionCompletion = null;
+      }
+    })();
+    return admissionCompletion;
+  };
+
+  // C6b: after a successful recovery-route quarantine the daemon transitions
+  // to normal WITHOUT a restart, re-verdicting the CURRENT partition state.
+  const reopenAfterRecovery = async (): Promise<void> => {
+    while (input.admission.snapshot() !== "normal") {
+      const joined = admissionCompletion;
+      if (joined) {
+        await joined.catch(() => {});
+        continue;
+      }
+      const servingMode = await runAdmissionCompletion(() =>
+        recoveryBlockedPartitions({
+          globalPreparation: { inspection: input.global.inspect() },
+          partitionsPreparation: input.partitions.refreshPreparation(),
+        }),
+      );
+      if (servingMode !== "normal") return; // partitions still block: stay protected
+    }
+  };
+
+  return {
+    runAdmissionCompletion,
+    wrapQuarantineWithReopen: (service) => async (partition, request) => {
+      const receipt = await service(partition, request);
+      try {
+        await reopenAfterRecovery();
+      } catch (error) {
+        // The quarantine itself SUCCEEDED; a failed reopen stays on the
+        // protected recovery plane and is disclosed.
+        logLine(
+          logPath(),
+          `recovery reopen failed; still serving recovery only: ${redactSecrets(
+            error instanceof Error ? error.message : String(error),
+          )}`,
+        );
+      }
+      return receipt;
+    },
+  };
+}

--- a/packages/cli/src/daemon-launch.test.ts
+++ b/packages/cli/src/daemon-launch.test.ts
@@ -1,6 +1,7 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   CLI_DAEMON_LAUNCH_SOURCES,
@@ -21,6 +22,23 @@ function root(): string {
   return value;
 }
 
+async function waitForFile(path: string, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!existsSync(path)) {
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${path}`);
+    await delay(20);
+  }
+}
+
+function killIfRunning(pid: number | null): void {
+  if (pid === null) return;
+  try {
+    process.kill(pid);
+  } catch {
+    // The exact test child already exited.
+  }
+}
+
 describe("bounded caller-side daemon launch adapter", () => {
   it("adds exact launch provenance without mutating or dropping the caller environment", () => {
     const base = { HOME: "/tmp/home", KEEP_ME: "yes" };
@@ -33,16 +51,16 @@ describe("bounded caller-side daemon launch adapter", () => {
     expect(base).toEqual({ HOME: "/tmp/home", KEEP_ME: "yes" });
   });
 
-  it("makes an import/pre-claim exit caller-visible without forging the daemon-owned log", async () => {
+  it("makes a real missing-module import failure visible without forging the daemon-owned log", async () => {
     const dataRoot = root();
-    const entry = join(dataRoot, "exit-before-claim.cjs");
+    const entry = join(dataRoot, "exit-before-claim.mjs");
     const sourceReceipt = join(dataRoot, "launch-source.txt");
     writeFileSync(
       entry,
       [
-        'const fs = require("node:fs");',
-        `fs.writeFileSync(${JSON.stringify(sourceReceipt)}, process.env.CLAUDEXOR_DAEMON_LAUNCH_SOURCE || "missing");`,
-        "process.exitCode = 7;",
+        'import { writeFileSync } from "node:fs";',
+        `writeFileSync(${JSON.stringify(sourceReceipt)}, process.env.CLAUDEXOR_DAEMON_LAUNCH_SOURCE || "missing");`,
+        'await import("./missing-preclaim-module.mjs");',
       ].join("\n"),
     );
 
@@ -53,7 +71,15 @@ describe("bounded caller-side daemon launch adapter", () => {
     });
     const failure = await launch.waitForFailure();
 
-    expect(failure).toMatchObject({ kind: "preclaim_exit", exitCode: 7 });
+    expect(failure).toMatchObject({
+      kind: "preclaim_exit",
+      exitCode: 1,
+      stderr: {
+        kind: "retained",
+        message: expect.stringMatching(/ERR_MODULE_NOT_FOUND|Cannot find module/),
+      },
+    });
+    expect(JSON.stringify(failure)).toContain("missing-preclaim-module.mjs");
     expect(readFileSync(sourceReceipt, "utf8")).toBe("cli_explicit_start");
     expect(() => readFileSync(join(dataRoot, "daemon", "claudexord.log"), "utf8")).toThrow();
     const error = launch.callerError("startup_wait", 15_000);
@@ -61,6 +87,127 @@ describe("bounded caller-side daemon launch adapter", () => {
     expect(error.requiredActions?.join(" ")).toContain("daemon logs");
     expect(error.requiredActions?.join(" ")).toMatch(/fixed runtime|eligible/i);
     expect(JSON.stringify(error.context)).toContain("preclaim_exit");
+    expect(error.message).toMatch(/ERR_MODULE_NOT_FOUND|Cannot find module/);
+  });
+
+  it("redacts a secret crossing the 2k projection boundary before bounding stderr", async () => {
+    const dataRoot = root();
+    const entry = join(dataRoot, "secret-stderr.cjs");
+    const token = `sk-${"a".repeat(40)}`;
+    const raw = `${"p".repeat(1_984)} ${token} TAIL`;
+    writeFileSync(entry, `process.stderr.write(${JSON.stringify(raw)}); process.exitCode = 9;\n`);
+
+    const launch = launchDetachedDaemon({
+      entryPath: entry,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
+      env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+    });
+    const failure = await launch.waitForFailure();
+    expect(failure).toMatchObject({
+      kind: "preclaim_exit",
+      stderr: { kind: "retained", message: expect.stringContaining("[redacted]") },
+    });
+    const projected = JSON.stringify(failure);
+    expect(projected).not.toContain(token);
+    expect(projected).not.toContain(token.slice(0, 15));
+    const error = launch.callerError("socket_wait", 30_000);
+    expect(error.message).not.toContain(token);
+    expect(JSON.stringify(error.context)).not.toContain(token);
+  });
+
+  it("discards every raw stderr byte on overflow and exposes only the typed marker", async () => {
+    const dataRoot = root();
+    const entry = join(dataRoot, "oversize-stderr.cjs");
+    const rawBytes = 64 * 1_024 + 1;
+    writeFileSync(
+      entry,
+      `process.stderr.write("RAW-BEGIN|" + "x".repeat(${rawBytes}) + "|RAW-END"); process.exitCode = 11;\n`,
+    );
+
+    const launch = launchDetachedDaemon({
+      entryPath: entry,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
+      env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+    });
+    const failure = await launch.waitForFailure();
+    expect(failure).toMatchObject({
+      kind: "preclaim_exit",
+      stderr: { kind: "oversize_discarded" },
+    });
+    const error = launch.callerError("socket_wait", 30_000);
+    const projected = JSON.stringify({ failure, message: error.message, context: error.context });
+    expect(projected).toContain("oversize_discarded");
+    expect(projected).not.toContain("RAW-BEGIN");
+    expect(projected).not.toContain("RAW-END");
+  });
+
+  it("markReady closes the transient stderr pipe and ignores the later child close", async () => {
+    const dataRoot = root();
+    const entry = join(dataRoot, "ready-stderr.cjs");
+    const started = join(dataRoot, "started.txt");
+    const pipeClosed = join(dataRoot, "pipe-closed.txt");
+    writeFileSync(
+      entry,
+      [
+        'const fs = require("node:fs");',
+        `fs.writeFileSync(${JSON.stringify(started)}, "started");`,
+        `process.stderr.on("error", (error) => { fs.writeFileSync(${JSON.stringify(pipeClosed)}, error.code || "error"); process.exit(0); });`,
+        'setInterval(() => process.stderr.write("pre-authority stderr\\n"), 10);',
+        "setTimeout(() => process.exit(2), 5000);",
+      ].join("\n"),
+    );
+    const launch = launchDetachedDaemon({
+      entryPath: entry,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.explicitStart,
+      env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+    });
+    try {
+      await waitForFile(started);
+      await delay(30);
+      launch.markReady();
+      await waitForFile(pipeClosed);
+      expect(readFileSync(pipeClosed, "utf8")).toBe("EPIPE");
+      await delay(30);
+      expect(launch.failure()).toBeNull();
+    } finally {
+      killIfRunning(launch.pid);
+    }
+  });
+
+  it("a terminal caller timeout types its stderr evidence and closes the pipe", async () => {
+    const dataRoot = root();
+    const entry = join(dataRoot, "timeout-stderr.cjs");
+    const started = join(dataRoot, "started.txt");
+    const pipeClosed = join(dataRoot, "pipe-closed.txt");
+    writeFileSync(
+      entry,
+      [
+        'const fs = require("node:fs");',
+        `fs.writeFileSync(${JSON.stringify(started)}, "started");`,
+        `process.stderr.on("error", (error) => { fs.writeFileSync(${JSON.stringify(pipeClosed)}, error.code || "error"); process.exit(0); });`,
+        'setInterval(() => process.stderr.write("waiting for readiness\\n"), 10);',
+        "setTimeout(() => process.exit(2), 5000);",
+      ].join("\n"),
+    );
+    const launch = launchDetachedDaemon({
+      entryPath: entry,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
+      env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+    });
+    try {
+      await waitForFile(started);
+      await delay(30);
+      const error = launch.callerError("socket_wait", 1);
+      expect(launch.failure()).toMatchObject({
+        kind: "startup_timeout",
+        stderr: { kind: "retained", message: expect.stringContaining("waiting for readiness") },
+      });
+      expect(JSON.stringify(error.context)).toContain("startup_timeout");
+      await waitForFile(pipeClosed);
+      expect(readFileSync(pipeClosed, "utf8")).toBe("EPIPE");
+    } finally {
+      killIfRunning(launch.pid);
+    }
   });
 
   it("bounds and types a spawn refusal before any daemon authority exists", async () => {

--- a/packages/cli/src/daemon-launch.test.ts
+++ b/packages/cli/src/daemon-launch.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CLI_DAEMON_LAUNCH_SOURCES,
+  DAEMON_LAUNCH_SOURCE_ENV,
+  daemonLaunchEnvironment,
+  launchDetachedDaemon,
+} from "./daemon-launch.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "claudexor-daemon-launch-"));
+  roots.push(value);
+  return value;
+}
+
+describe("bounded caller-side daemon launch adapter", () => {
+  it("adds exact launch provenance without mutating or dropping the caller environment", () => {
+    const base = { HOME: "/tmp/home", KEEP_ME: "yes" };
+    const env = daemonLaunchEnvironment(base, CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon);
+    expect(env).toMatchObject({
+      HOME: "/tmp/home",
+      KEEP_ME: "yes",
+      [DAEMON_LAUNCH_SOURCE_ENV]: "cli_ensure_daemon",
+    });
+    expect(base).toEqual({ HOME: "/tmp/home", KEEP_ME: "yes" });
+  });
+
+  it("makes an import/pre-claim exit caller-visible without forging the daemon-owned log", async () => {
+    const dataRoot = root();
+    const entry = join(dataRoot, "exit-before-claim.cjs");
+    const sourceReceipt = join(dataRoot, "launch-source.txt");
+    writeFileSync(
+      entry,
+      [
+        'const fs = require("node:fs");',
+        `fs.writeFileSync(${JSON.stringify(sourceReceipt)}, process.env.CLAUDEXOR_DAEMON_LAUNCH_SOURCE || "missing");`,
+        "process.exitCode = 7;",
+      ].join("\n"),
+    );
+
+    const launch = launchDetachedDaemon({
+      entryPath: entry,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.explicitStart,
+      env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+    });
+    const failure = await launch.waitForFailure();
+
+    expect(failure).toMatchObject({ kind: "preclaim_exit", exitCode: 7 });
+    expect(readFileSync(sourceReceipt, "utf8")).toBe("cli_explicit_start");
+    expect(() => readFileSync(join(dataRoot, "daemon", "claudexord.log"), "utf8")).toThrow();
+    const error = launch.callerError("startup_wait", 15_000);
+    expect(error.code).toBe("daemon_start_failed");
+    expect(error.requiredActions?.join(" ")).toContain("daemon logs");
+    expect(error.requiredActions?.join(" ")).toMatch(/fixed runtime|eligible/i);
+    expect(JSON.stringify(error.context)).toContain("preclaim_exit");
+  });
+
+  it("bounds and types a spawn refusal before any daemon authority exists", async () => {
+    const dataRoot = root();
+    const entry = join(dataRoot, "entry.cjs");
+    writeFileSync(entry, "setInterval(() => {}, 1000);\n");
+    const launch = launchDetachedDaemon({
+      entryPath: entry,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
+      env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+      nodePath: join(dataRoot, `missing-node-${"x".repeat(5000)}`),
+    });
+    const failure = await launch.waitForFailure();
+    expect(failure?.kind).toBe("spawn_error");
+    const error = launch.callerError("spawn", 30_000);
+    expect(error.code).toBe("daemon_start_failed");
+    expect(error.message.length).toBeLessThanOrEqual(2_000);
+    expect(JSON.stringify(error.context).length).toBeLessThan(8_192);
+  });
+
+  it("refuses a missing entry as an actionable typed pre-spawn error", () => {
+    const dataRoot = root();
+    expect(() =>
+      launchDetachedDaemon({
+        entryPath: join(dataRoot, "missing-claudexord.js"),
+        launchSource: CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
+        env: { ...process.env, CLAUDEXOR_CONFIG_DIR: dataRoot },
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        code: "daemon_entry_missing",
+        retryable: false,
+      }),
+    );
+  });
+});

--- a/packages/cli/src/daemon-launch.ts
+++ b/packages/cli/src/daemon-launch.ts
@@ -1,6 +1,7 @@
 /** Caller-visible daemon launch evidence before root authority exists. */
 import { spawn, type ChildProcess } from "node:child_process";
 import { lstatSync } from "node:fs";
+import type { Readable } from "node:stream";
 import { logPath } from "@claudexor/daemon";
 import {
   safeProblemContext,
@@ -19,6 +20,23 @@ export const CLI_DAEMON_LAUNCH_SOURCES = {
 export type CliDaemonLaunchSource =
   (typeof CLI_DAEMON_LAUNCH_SOURCES)[keyof typeof CLI_DAEMON_LAUNCH_SOURCES];
 
+const DAEMON_LAUNCH_STDERR_RAW_LIMIT_BYTES = 64 * 1_024;
+
+export type DaemonLaunchStderrEvidence =
+  | {
+      kind: "empty";
+    }
+  | {
+      kind: "retained";
+      byteLength: number;
+      message: string;
+    }
+  | {
+      kind: "oversize_discarded";
+      observedBytes: number;
+      limitBytes: number;
+    };
+
 export type DaemonLaunchFailure =
   | {
       kind: "spawn_error";
@@ -29,6 +47,12 @@ export type DaemonLaunchFailure =
       kind: "preclaim_exit";
       exitCode: number | null;
       signal: NodeJS.Signals | null;
+      stderr: DaemonLaunchStderrEvidence;
+    }
+  | {
+      kind: "startup_timeout";
+      timeoutMs: number;
+      stderr: DaemonLaunchStderrEvidence;
     };
 
 export interface DetachedDaemonLaunch {
@@ -89,6 +113,84 @@ function canonicalLogRemedy(): string {
   }
 }
 
+interface PreAuthorityStderrCapture {
+  evidence(): DaemonLaunchStderrEvidence;
+  destroyAndDiscard(): void;
+}
+
+function capturePreAuthorityStderr(stream: Readable | null): PreAuthorityStderrCapture {
+  let chunks: Buffer[] = [];
+  let retainedBytes = 0;
+  let observedBytes = 0;
+  let oversize = false;
+  let discarded = false;
+
+  const onData = (chunk: Buffer | string): void => {
+    if (discarded) return;
+    const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    observedBytes += bytes.length;
+    if (oversize) return;
+    if (observedBytes > DAEMON_LAUNCH_STDERR_RAW_LIMIT_BYTES) {
+      oversize = true;
+      chunks = [];
+      retainedBytes = 0;
+      return;
+    }
+    chunks.push(Buffer.from(bytes));
+    retainedBytes += bytes.length;
+  };
+  stream?.on("data", onData);
+
+  return {
+    evidence: () => {
+      if (oversize) {
+        return {
+          kind: "oversize_discarded",
+          observedBytes,
+          limitBytes: DAEMON_LAUNCH_STDERR_RAW_LIMIT_BYTES,
+        };
+      }
+      if (retainedBytes === 0) return { kind: "empty" };
+      const raw = Buffer.concat(chunks, retainedBytes).toString("utf8");
+      return {
+        kind: "retained",
+        byteLength: retainedBytes,
+        message: safeProblemMessage(raw),
+      };
+    },
+    destroyAndDiscard: () => {
+      if (discarded) return;
+      discarded = true;
+      chunks = [];
+      retainedBytes = 0;
+      stream?.off("data", onData);
+      stream?.destroy();
+    },
+  };
+}
+
+function stderrMessage(evidence: DaemonLaunchStderrEvidence): string {
+  switch (evidence.kind) {
+    case "empty":
+      return "; pre-authority stderr: empty";
+    case "retained":
+      return `; pre-authority stderr (retained): ${evidence.message}`;
+    case "oversize_discarded":
+      return `; pre-authority stderr: oversize_discarded after ${evidence.observedBytes} bytes (limit ${evidence.limitBytes})`;
+  }
+}
+
+function failureMessage(failure: DaemonLaunchFailure): string {
+  switch (failure.kind) {
+    case "spawn_error":
+      return `daemon launch failed before root authority: ${failure.message}`;
+    case "preclaim_exit":
+      return `daemon exited before it became ready (exit ${failure.exitCode ?? "null"}${failure.signal ? `, signal ${failure.signal}` : ""})${stderrMessage(failure.stderr)}`;
+    case "startup_timeout":
+      return `daemon did not become ready within ${Math.round(failure.timeoutMs / 1_000)}s${stderrMessage(failure.stderr)}`;
+  }
+}
+
 /**
  * Spawn without an inherited canonical-log descriptor. Import, spawn and
  * pre-claim exits remain bounded caller evidence; the daemon may start its own
@@ -98,6 +200,7 @@ export function launchDetachedDaemon(options: LaunchDetachedDaemonOptions): Deta
   proveEntry(options.entryPath);
   let failure: DaemonLaunchFailure | null = null;
   let ready = false;
+  let stderrCapture: PreAuthorityStderrCapture | undefined;
   let resolveFailure: ((value: DaemonLaunchFailure) => void) | undefined;
   const failurePromise = new Promise<DaemonLaunchFailure>((resolve) => {
     resolveFailure = resolve;
@@ -107,22 +210,30 @@ export function launchDetachedDaemon(options: LaunchDetachedDaemonOptions): Deta
     failure = value;
     resolveFailure?.(value);
   };
+  const discardStderr = (): void => {
+    stderrCapture?.destroyAndDiscard();
+    stderrCapture = undefined;
+  };
   let child: ChildProcess | undefined;
   try {
     child = spawn(options.nodePath ?? process.execPath, [options.entryPath], {
       detached: true,
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
       env: daemonLaunchEnvironment(options.env ?? process.env, options.launchSource),
     });
+    stderrCapture = capturePreAuthorityStderr(child.stderr);
     child.once("error", (error) => {
       const code =
         typeof (error as NodeJS.ErrnoException).code === "string"
           ? (error as NodeJS.ErrnoException).code
           : undefined;
       settleFailure({ kind: "spawn_error", message: safeProblemMessage(error), code });
+      discardStderr();
     });
-    child.once("exit", (exitCode, signal) => {
-      settleFailure({ kind: "preclaim_exit", exitCode, signal });
+    child.once("close", (exitCode, signal) => {
+      const stderr = stderrCapture?.evidence() ?? { kind: "empty" };
+      discardStderr();
+      settleFailure({ kind: "preclaim_exit", exitCode, signal, stderr });
     });
     child.unref();
   } catch (error) {
@@ -134,13 +245,18 @@ export function launchDetachedDaemon(options: LaunchDetachedDaemonOptions): Deta
   }
 
   const callerError = (stage: string, timeoutMs: number): CliError => {
-    const observed = failure;
-    const message = observed
-      ? observed.kind === "spawn_error"
-        ? `daemon launch failed before root authority: ${observed.message}`
-        : `daemon exited before it became ready (exit ${observed.exitCode ?? "null"}${observed.signal ? `, signal ${observed.signal}` : ""})`
-      : `daemon did not become ready within ${Math.round(timeoutMs / 1000)}s`;
-    return new CliError("operational", message, {
+    let observed = failure;
+    if (!observed) {
+      const timeoutFailure: DaemonLaunchFailure = {
+        kind: "startup_timeout",
+        timeoutMs,
+        stderr: stderrCapture?.evidence() ?? { kind: "empty" },
+      };
+      settleFailure(timeoutFailure);
+      discardStderr();
+      observed = failure ?? timeoutFailure;
+    }
+    return new CliError("operational", safeProblemMessage(failureMessage(observed)), {
       code: "daemon_start_failed",
       retryable: true,
       requiredActions: safeProblemRequiredActions([
@@ -152,7 +268,7 @@ export function launchDetachedDaemon(options: LaunchDetachedDaemonOptions): Deta
         timeoutMs,
         entryPath: options.entryPath,
         launchSource: options.launchSource,
-        failure: observed ?? { kind: "startup_timeout" },
+        failure: observed,
       }),
     });
   };
@@ -163,6 +279,7 @@ export function launchDetachedDaemon(options: LaunchDetachedDaemonOptions): Deta
     waitForFailure: () => (failure ? Promise.resolve(failure) : failurePromise),
     markReady: () => {
       ready = true;
+      discardStderr();
     },
     callerError,
   };

--- a/packages/cli/src/daemon-launch.ts
+++ b/packages/cli/src/daemon-launch.ts
@@ -1,0 +1,169 @@
+/** Caller-visible daemon launch evidence before root authority exists. */
+import { spawn, type ChildProcess } from "node:child_process";
+import { lstatSync } from "node:fs";
+import { logPath } from "@claudexor/daemon";
+import {
+  safeProblemContext,
+  safeProblemMessage,
+  safeProblemRequiredActions,
+} from "@claudexor/util";
+import { CliError } from "./cli-error.js";
+
+export const DAEMON_LAUNCH_SOURCE_ENV = "CLAUDEXOR_DAEMON_LAUNCH_SOURCE";
+
+export const CLI_DAEMON_LAUNCH_SOURCES = {
+  ensureDaemon: "cli_ensure_daemon",
+  explicitStart: "cli_explicit_start",
+} as const;
+
+export type CliDaemonLaunchSource =
+  (typeof CLI_DAEMON_LAUNCH_SOURCES)[keyof typeof CLI_DAEMON_LAUNCH_SOURCES];
+
+export type DaemonLaunchFailure =
+  | {
+      kind: "spawn_error";
+      message: string;
+      code?: string;
+    }
+  | {
+      kind: "preclaim_exit";
+      exitCode: number | null;
+      signal: NodeJS.Signals | null;
+    };
+
+export interface DetachedDaemonLaunch {
+  readonly pid: number | null;
+  failure(): DaemonLaunchFailure | null;
+  waitForFailure(): Promise<DaemonLaunchFailure>;
+  markReady(): void;
+  callerError(stage: string, timeoutMs: number): CliError;
+}
+
+export interface LaunchDetachedDaemonOptions {
+  entryPath: string;
+  launchSource: CliDaemonLaunchSource;
+  env?: NodeJS.ProcessEnv;
+  nodePath?: string;
+}
+
+export function daemonLaunchEnvironment(
+  source: NodeJS.ProcessEnv,
+  launchSource: CliDaemonLaunchSource,
+): NodeJS.ProcessEnv {
+  return { ...source, [DAEMON_LAUNCH_SOURCE_ENV]: launchSource };
+}
+
+function missingEntryError(entryPath: string, reason: unknown): CliError {
+  return new CliError(
+    "operational",
+    `cannot start the daemon: the selected entry is unavailable (${safeProblemMessage(reason)})`,
+    {
+      code: "daemon_entry_missing",
+      retryable: false,
+      requiredActions: [
+        "Reinstall Claudexor or rebuild the matching runtime before retrying.",
+        "Use an eligible fixed runtime; do not fall back to an older daemon for this data root.",
+      ],
+      context: safeProblemContext({ entryPath }),
+    },
+  );
+}
+
+function proveEntry(entryPath: string): void {
+  try {
+    const stat = lstatSync(entryPath);
+    if (!stat.isFile() && !stat.isSymbolicLink()) {
+      throw missingEntryError(entryPath, "entry is not a file");
+    }
+  } catch (error) {
+    if (error instanceof CliError) throw error;
+    throw missingEntryError(entryPath, error);
+  }
+}
+
+function canonicalLogRemedy(): string {
+  try {
+    return `Run \`claudexor daemon logs\` for the canonical post-authority log at ${logPath()}; a pre-authority failure may have no log record.`;
+  } catch {
+    return "Run `claudexor daemon logs` for the canonical post-authority log; a pre-authority failure may have no log record.";
+  }
+}
+
+/**
+ * Spawn without an inherited canonical-log descriptor. Import, spawn and
+ * pre-claim exits remain bounded caller evidence; the daemon may start its own
+ * permanent diagnostic writer only after a separate root-authority decision.
+ */
+export function launchDetachedDaemon(options: LaunchDetachedDaemonOptions): DetachedDaemonLaunch {
+  proveEntry(options.entryPath);
+  let failure: DaemonLaunchFailure | null = null;
+  let ready = false;
+  let resolveFailure: ((value: DaemonLaunchFailure) => void) | undefined;
+  const failurePromise = new Promise<DaemonLaunchFailure>((resolve) => {
+    resolveFailure = resolve;
+  });
+  const settleFailure = (value: DaemonLaunchFailure): void => {
+    if (failure || ready) return;
+    failure = value;
+    resolveFailure?.(value);
+  };
+  let child: ChildProcess | undefined;
+  try {
+    child = spawn(options.nodePath ?? process.execPath, [options.entryPath], {
+      detached: true,
+      stdio: "ignore",
+      env: daemonLaunchEnvironment(options.env ?? process.env, options.launchSource),
+    });
+    child.once("error", (error) => {
+      const code =
+        typeof (error as NodeJS.ErrnoException).code === "string"
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+      settleFailure({ kind: "spawn_error", message: safeProblemMessage(error), code });
+    });
+    child.once("exit", (exitCode, signal) => {
+      settleFailure({ kind: "preclaim_exit", exitCode, signal });
+    });
+    child.unref();
+  } catch (error) {
+    const code =
+      typeof (error as NodeJS.ErrnoException).code === "string"
+        ? (error as NodeJS.ErrnoException).code
+        : undefined;
+    settleFailure({ kind: "spawn_error", message: safeProblemMessage(error), code });
+  }
+
+  const callerError = (stage: string, timeoutMs: number): CliError => {
+    const observed = failure;
+    const message = observed
+      ? observed.kind === "spawn_error"
+        ? `daemon launch failed before root authority: ${observed.message}`
+        : `daemon exited before it became ready (exit ${observed.exitCode ?? "null"}${observed.signal ? `, signal ${observed.signal}` : ""})`
+      : `daemon did not become ready within ${Math.round(timeoutMs / 1000)}s`;
+    return new CliError("operational", message, {
+      code: "daemon_start_failed",
+      retryable: true,
+      requiredActions: safeProblemRequiredActions([
+        canonicalLogRemedy(),
+        "Verify that this CLI uses an eligible fixed runtime, then retry; stop an older root claimant explicitly if it still owns the root.",
+      ]),
+      context: safeProblemContext({
+        stage,
+        timeoutMs,
+        entryPath: options.entryPath,
+        launchSource: options.launchSource,
+        failure: observed ?? { kind: "startup_timeout" },
+      }),
+    });
+  };
+
+  return {
+    pid: child?.pid ?? null,
+    failure: () => failure,
+    waitForFailure: () => (failure ? Promise.resolve(failure) : failurePromise),
+    markReady: () => {
+      ready = true;
+    },
+    callerError,
+  };
+}

--- a/packages/cli/src/daemon-lifecycle.test.ts
+++ b/packages/cli/src/daemon-lifecycle.test.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from "node:events";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import { armDaemonLifecycle } from "./daemon-lifecycle.js";
+import { describe, expect, it, vi } from "vitest";
+import { armDaemonLifecycle, runStartupCrashGc } from "./daemon-lifecycle.js";
 import { rmSync as __rmSyncReap } from "node:fs";
 import { afterAll as __afterAllReap } from "vitest";
 
@@ -19,6 +19,55 @@ __afterAllReap(() => {
 });
 
 describe("armDaemonLifecycle", () => {
+  it("leaves a previous life's pids.json byte-untouched until snapshots are armed; crash-GC consumes it on the normal start (C2)", async () => {
+    vi.useFakeTimers();
+    try {
+      const root = reapMk(join(tmpdir(), "claudexor-lifecycle-"));
+      const pidsPath = join(root, "pids.json");
+      // A crashed previous life's reap list: one dead process group recorded
+      // with full birth identity (the only record of surviving children).
+      const previousLife = `${JSON.stringify({
+        pids: [
+          {
+            pid: 999_999_990,
+            cmd: "crashed-previous-life-harness",
+            processGroup: {
+              schemaVersion: 1,
+              pgid: 999_999_990,
+              leader: {
+                status: "known",
+                pid: 999_999_990,
+                platform: "darwin",
+                source: "proc_pidinfo",
+                startToken: "darwin:1:000001",
+                processGroupId: 999_999_990,
+              },
+            },
+          },
+        ],
+      })}\n`;
+      writeFileSync(pidsPath, previousLife, { mode: 0o600 });
+      const signals = new EventEmitter() as EventEmitter & Pick<NodeJS.Process, "on" | "off">;
+      const lifecycle = armDaemonLifecycle({
+        daemonDir: root,
+        logPath: join(root, "daemon.log"),
+        signals,
+        beginShutdown: async () => {},
+      });
+      // Recovery-only serving: crash-GC never ran, so the previous file must
+      // survive every snapshot interval AND the shutdown finalizer.
+      vi.advanceTimersByTime(10_000);
+      expect(readFileSync(pidsPath, "utf8")).toBe(previousLife);
+      lifecycle.finalize();
+      expect(readFileSync(pidsPath, "utf8")).toBe(previousLife);
+      // The later NORMAL start's crash-GC consumes the reap list.
+      await runStartupCrashGc({ daemonDir: root, logPath: join(root, "daemon.log") });
+      expect(existsSync(pidsPath)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("routes lifecycle messages through the post-authority diagnostic sink with exact stages", async () => {
     const root = reapMk(join(tmpdir(), "claudexor-lifecycle-"));
     const signals = new EventEmitter() as EventEmitter & Pick<NodeJS.Process, "on" | "off">;

--- a/packages/cli/src/daemon-lifecycle.test.ts
+++ b/packages/cli/src/daemon-lifecycle.test.ts
@@ -89,6 +89,7 @@ describe("armDaemonLifecycle", () => {
 
     signals.emit("SIGTERM");
     await new Promise<void>((resolve) => setImmediate(resolve));
+    lifecycle.beginPidSnapshots();
     lifecycle.finalize();
 
     expect(records).toEqual(
@@ -131,6 +132,7 @@ describe("armDaemonLifecycle", () => {
     expect(signals.listenerCount("SIGTERM")).toBe(1);
     const log = readFileSync(join(root, "daemon.log"), "utf8");
     expect(log).toContain("SIGTERM received; stopping daemon");
+    lifecycle.beginPidSnapshots();
     lifecycle.finalize();
     lifecycle.finalize();
     expect(signals.listenerCount("SIGTERM")).toBe(0);

--- a/packages/cli/src/daemon-lifecycle.test.ts
+++ b/packages/cli/src/daemon-lifecycle.test.ts
@@ -19,6 +19,44 @@ __afterAllReap(() => {
 });
 
 describe("armDaemonLifecycle", () => {
+  it("routes lifecycle messages through the post-authority diagnostic sink with exact stages", async () => {
+    const root = reapMk(join(tmpdir(), "claudexor-lifecycle-"));
+    const signals = new EventEmitter() as EventEmitter & Pick<NodeJS.Process, "on" | "off">;
+    const records: Array<{ stage: string; message: string }> = [];
+    const lifecycle = armDaemonLifecycle({
+      daemonDir: root,
+      diagnostics: {
+        record: (record) => {
+          records.push({ stage: record.stage, message: record.message });
+          return true;
+        },
+      },
+      signals,
+      snapshot: () => {
+        throw new Error("snapshot failed");
+      },
+      beginShutdown: async () => {},
+    });
+
+    signals.emit("SIGTERM");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    lifecycle.finalize();
+
+    expect(records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stage: "shutdown_signal",
+          message: expect.stringContaining("SIGTERM"),
+        }),
+        expect.objectContaining({
+          stage: "pid_snapshot",
+          message: expect.stringContaining("snapshot failed"),
+        }),
+      ]),
+    );
+    expect(() => readFileSync(join(root, "daemon.log"), "utf8")).toThrow();
+  });
+
   it("coalesces SIGTERM and SIGINT into ONE state-machine entry and finalizes idempotently", async () => {
     const root = reapMk(join(tmpdir(), "claudexor-lifecycle-"));
     const signals = new EventEmitter() as EventEmitter & Pick<NodeJS.Process, "on" | "off">;

--- a/packages/cli/src/daemon-lifecycle.ts
+++ b/packages/cli/src/daemon-lifecycle.ts
@@ -80,8 +80,18 @@ export async function runStartupCrashGc(
  * Post-start: periodic live-children snapshots (the reap list a crash leaves
  * behind) and SIGTERM/SIGINT -> the shutdown state machine (abort children,
  * persist, close, bounded escalation). Returns the finalizer for main()'s tail.
+ *
+ * The snapshot timer is NOT armed here: with zero live children a snapshot
+ * DELETES pids.json, and until stage-4 crash-GC has consumed the previous
+ * life's file that file is the only record of surviving children (C2). The
+ * composition root calls `beginPidSnapshots()` once admission is normal;
+ * recovery-only serving leaves the previous pids.json byte-untouched, and the
+ * finalizer writes a final snapshot only when snapshots were armed.
  */
-export function armDaemonLifecycle(deps: LifecycleDeps): { finalize: () => void } {
+export function armDaemonLifecycle(deps: LifecycleDeps): {
+  beginPidSnapshots: () => void;
+  finalize: () => void;
+} {
   const pidsPath = join(deps.daemonDir, "pids.json");
   const signals = deps.signals ?? process;
   const snapshot = deps.snapshot ?? writePidsSnapshot;
@@ -96,8 +106,7 @@ export function armDaemonLifecycle(deps: LifecycleDeps): { finalize: () => void 
       });
     }
   };
-  const pidsTimer = setInterval(writeSnapshot, 2_000);
-  pidsTimer.unref?.();
+  let pidsTimer: NodeJS.Timeout | null = null;
 
   let stopping = false;
   let finalized = false;
@@ -120,15 +129,24 @@ export function armDaemonLifecycle(deps: LifecycleDeps): { finalize: () => void 
   signals.on("SIGINT", onSigint);
 
   return {
+    beginPidSnapshots: () => {
+      if (pidsTimer || finalized) return;
+      pidsTimer = setInterval(writeSnapshot, 2_000);
+      pidsTimer.unref?.();
+    },
     finalize: () => {
       if (finalized) return;
       finalized = true;
-      clearInterval(pidsTimer);
+      const snapshotsWereArmed = pidsTimer !== null;
+      if (pidsTimer) clearInterval(pidsTimer);
+      pidsTimer = null;
       signals.off("SIGTERM", onSigterm);
       signals.off("SIGINT", onSigint);
       // Graceful stop aborted all children; one final snapshot records any
       // that survived the grace window (SIGKILL escalation may be in flight).
-      writeSnapshot();
+      // Without armed snapshots there were no children to record, and the
+      // previous life's pids.json must stay byte-untouched (C2).
+      if (snapshotsWereArmed) writeSnapshot();
     },
   };
 }

--- a/packages/cli/src/daemon-lifecycle.ts
+++ b/packages/cli/src/daemon-lifecycle.ts
@@ -8,12 +8,20 @@
  */
 import { appendFileSync } from "node:fs";
 import { join } from "node:path";
+import { safeProblemMessage } from "@claudexor/util";
 import { reapRecordedOrphans, writePidsSnapshot } from "./orphan-reaper.js";
 import { sweepOrphanWorkspaces } from "./orphan-sweeper.js";
+import type {
+  DaemonStartupDiagnosticRecord,
+  DaemonStartupDiagnostics,
+} from "./startup-diagnostics.js";
 
 interface LifecycleDeps {
   daemonDir: string;
-  logPath: string;
+  /** Compatibility fallback until the shared composition root wires the sink. */
+  logPath?: string;
+  /** Narrow post-authority diagnostic port; it never controls lifecycle. */
+  diagnostics?: Pick<DaemonStartupDiagnostics, "record">;
   /** Enter the shutdown state machine (DaemonRuntimeShutdown.beginShutdown). */
   beginShutdown: (reason: string) => Promise<void>;
   signals?: Pick<NodeJS.Process, "on" | "off">;
@@ -22,30 +30,49 @@ interface LifecycleDeps {
 
 export const logLine = (path: string, message: string): void => {
   try {
-    appendFileSync(path, `[${new Date().toISOString()}] ${message}\n`);
+    appendFileSync(path, `[${new Date().toISOString()}] ${safeProblemMessage(message)}\n`);
   } catch {
     /* lifecycle safety must not depend on diagnostic I/O */
   }
 };
 
+function lifecycleDiagnostic(
+  deps: Pick<LifecycleDeps, "diagnostics" | "logPath">,
+  record: DaemonStartupDiagnosticRecord,
+): void {
+  if (deps.diagnostics) {
+    try {
+      void deps.diagnostics.record(record);
+    } catch {
+      /* lifecycle safety must not depend on diagnostic I/O */
+    }
+    return;
+  }
+  if (deps.logPath) logLine(deps.logPath, record.message);
+}
+
 /** Pre-start: kill surviving children of a previous daemon life, then GC
  * envelopes/branches/tmp-homes nothing owns anymore. */
 export async function runStartupCrashGc(
-  deps: Pick<LifecycleDeps, "daemonDir" | "logPath">,
+  deps: Pick<LifecycleDeps, "daemonDir" | "diagnostics" | "logPath">,
 ): Promise<void> {
   const pidsPath = join(deps.daemonDir, "pids.json");
   for (const action of reapRecordedOrphans(pidsPath)) {
-    logLine(deps.logPath, `reaper: ${action}`);
+    lifecycleDiagnostic(deps, { stage: "crash_gc_reaper", message: `reaper: ${action}` });
   }
   try {
     const sweepActions = await sweepOrphanWorkspaces({
       journalRoot: join(deps.daemonDir, "journal"),
     });
     for (const action of sweepActions) {
-      logLine(deps.logPath, `sweep: ${action}`);
+      lifecycleDiagnostic(deps, { stage: "crash_gc_sweep", message: `sweep: ${action}` });
     }
   } catch (err) {
-    logLine(deps.logPath, `sweep FAILED: ${err instanceof Error ? err.message : String(err)}`);
+    lifecycleDiagnostic(deps, {
+      stage: "crash_gc_sweep",
+      message: `sweep FAILED: ${err instanceof Error ? err.message : String(err)}`,
+      error: err,
+    });
   }
 }
 
@@ -62,10 +89,11 @@ export function armDaemonLifecycle(deps: LifecycleDeps): { finalize: () => void 
     try {
       snapshot(pidsPath);
     } catch (error) {
-      logLine(
-        deps.logPath,
-        `pid snapshot FAILED: ${error instanceof Error ? error.message : String(error)}`,
-      );
+      lifecycleDiagnostic(deps, {
+        stage: "pid_snapshot",
+        message: `pid snapshot FAILED: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+      });
     }
   };
   const pidsTimer = setInterval(writeSnapshot, 2_000);
@@ -78,7 +106,10 @@ export function armDaemonLifecycle(deps: LifecycleDeps): { finalize: () => void 
     // machine's deadline timer guarantees termination.
     if (stopping) return;
     stopping = true;
-    logLine(deps.logPath, `${sig} received; stopping daemon`);
+    lifecycleDiagnostic(deps, {
+      stage: "shutdown_signal",
+      message: `${sig} received; stopping daemon`,
+    });
     void deps.beginShutdown(sig).catch(() => {
       // The machine logged the failure and keeps its deadline armed.
     });

--- a/packages/cli/src/daemon-run.test.ts
+++ b/packages/cli/src/daemon-run.test.ts
@@ -386,6 +386,18 @@ const TYPED_STOPPING_503 = () => ({
   }),
 });
 
+/** A recovery-only daemon's SUCCESSFUL handshake (issue #165 D5 / C7). */
+const RECOVERY_ONLY_200 = () => ({
+  status: 200,
+  body: JSON.stringify({
+    protocolMajor: 3,
+    compatible: true,
+    operationsPath: "/v2/operations",
+    engine: { version: CLAUDEXOR_VERSION, sha: "unknown", entry: "/opt/claudexor/daemon.js" },
+    servingMode: "recovery_only",
+  }),
+});
+
 describe("absence vs refusal discrimination (#93)", () => {
   let dir: string;
   let prevConfigDir: string | undefined;
@@ -528,6 +540,32 @@ describe("absence vs refusal discrimination (#93)", () => {
     }
     expect(observedEngineSkew()).toBeNull();
     expect(stderrChunks.join("")).toBe("");
+  });
+
+  it("connectDaemonIfRunning: surfaces the handshake servingMode to read-only consumers (C7a)", async () => {
+    socketServer = await fakeDaemonSocket(process.env.CLAUDEXOR_DAEMON_SOCK as string);
+    const api = await fakeControlApi(RECOVERY_ONLY_200);
+    httpServer = api.server;
+    writeDaemonFixture(api.port);
+    const conn = await connectDaemonIfRunning();
+    expect(conn).not.toBeNull();
+    expect(conn!.engine.servingMode).toBe("recovery_only");
+  });
+
+  it("ensureDaemon: a recovery-only daemon fails typed + retryable, never proceeding into route refusals (C7d)", async () => {
+    socketServer = await fakeDaemonSocket(process.env.CLAUDEXOR_DAEMON_SOCK as string);
+    const api = await fakeControlApi(RECOVERY_ONLY_200);
+    httpServer = api.server;
+    writeDaemonFixture(api.port);
+    const err: unknown = await ensureDaemon().then(
+      () => null,
+      (thrown: unknown) => thrown,
+    );
+    expect(err).toBeInstanceOf(CliError);
+    const problem = err as CliError;
+    expect(problem.code).toBe("daemon_recovery_only");
+    expect(problem.retryable).toBe(true);
+    expect(problem.message).toContain("serving recovery only");
   });
 
   it("ensureDaemon: a typed refusal short-circuits (no 10s control-API wait, no NO_CONTROL_API flatten)", async () => {

--- a/packages/cli/src/daemon-run.test.ts
+++ b/packages/cli/src/daemon-run.test.ts
@@ -554,6 +554,7 @@ describe("absence vs refusal discrimination (#93)", () => {
     httpServer = api.server;
     writeDaemonFixture(api.port);
     const pidFile = join(dir, "fake-daemon.pid");
+    const sourceFile = join(dir, "fake-daemon.launch-source");
     const entry = join(dir, "fake-daemon-entry.cjs");
     writeFileSync(
       entry,
@@ -577,12 +578,14 @@ describe("absence vs refusal discrimination (#93)", () => {
         "});",
         "server.listen(process.env.CLAUDEXOR_DAEMON_SOCK, () => {",
         "  fs.writeFileSync(process.env.CLAUDEXOR_FAKE_DAEMON_PID_FILE, String(process.pid));",
+        '  fs.writeFileSync(process.env.CLAUDEXOR_FAKE_DAEMON_SOURCE_FILE, process.env.CLAUDEXOR_DAEMON_LAUNCH_SOURCE || "missing");',
         "});",
         "setTimeout(() => process.exit(0), 15000);",
       ].join("\n"),
     );
     process.env.CLAUDEXOR_DAEMON_ENTRY = entry;
     process.env.CLAUDEXOR_FAKE_DAEMON_PID_FILE = pidFile;
+    process.env.CLAUDEXOR_FAKE_DAEMON_SOURCE_FILE = sourceFile;
     try {
       const err: unknown = await ensureDaemon().then(
         () => null,
@@ -591,8 +594,10 @@ describe("absence vs refusal discrimination (#93)", () => {
       expect(err).toBeInstanceOf(CliError);
       expect((err as CliError).code).toBe("incompatible_protocol_major");
       expect((err as CliError).requiredActions).toContain(ENGINE_STOP_REMEDY);
+      expect(readFileSync(sourceFile, "utf8")).toBe("cli_ensure_daemon");
     } finally {
       delete process.env.CLAUDEXOR_FAKE_DAEMON_PID_FILE;
+      delete process.env.CLAUDEXOR_FAKE_DAEMON_SOURCE_FILE;
       // Exact-PID cleanup of OUR fake daemon (it also self-exits after 15s).
       try {
         const pid = Number(readFileSync(pidFile, "utf8"));

--- a/packages/cli/src/daemon-run.test.ts
+++ b/packages/cli/src/daemon-run.test.ts
@@ -9,6 +9,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CliError } from "./cli-error.js";
 import { ENGINE_STOP_REMEDY, observedEngineSkew, recordEngineSkew } from "./engine-skew.js";
 import {
+  DAEMON_CONTROL_API_FRESH_START_TAIL_MS,
   DAEMON_START_READY_TIMEOUT_MS,
   connectDaemonIfRunning,
   daemonOutcomeSummary,
@@ -445,6 +446,13 @@ describe("absence vs refusal discrimination (#93)", () => {
 
   it("connectDaemonIfRunning: absence (no daemon at all) is null, never a spawn", async () => {
     expect(await connectDaemonIfRunning()).toBeNull();
+  });
+
+  it("pins the control-API fresh-start tail as a NAMED slice of the start budget (C10)", () => {
+    // ensureDaemon waits this bounded tail for the control-api pointer AFTER
+    // the socket answers; it must never grow past the whole start budget.
+    expect(DAEMON_CONTROL_API_FRESH_START_TAIL_MS).toBe(10_000);
+    expect(DAEMON_CONTROL_API_FRESH_START_TAIL_MS).toBeLessThan(DAEMON_START_READY_TIMEOUT_MS);
   });
 
   it("waitForDaemonReady: the default budget covers a journal-heavy cold start", async () => {

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -1,6 +1,4 @@
 import process from "node:process";
-import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import {
   DaemonClient,
@@ -13,6 +11,11 @@ import {
 import { harnessRuntimeEnv } from "@claudexor/core";
 import { hashJson } from "@claudexor/util";
 import { CliError, controlProblemError } from "./cli-error.js";
+import {
+  CLI_DAEMON_LAUNCH_SOURCES,
+  launchDetachedDaemon,
+  type DetachedDaemonLaunch,
+} from "./daemon-launch.js";
 import { recordEngineSkew, type EngineIdentity } from "./engine-skew.js";
 import {
   controlApiAddress,
@@ -85,6 +88,7 @@ export async function ensureDaemon(
   const token = ensureToken();
   const socketPath = defaultSocketPath();
   let client = new DaemonClient(socketPath, token);
+  let launch: DetachedDaemonLaunch | null = null;
 
   const ok = await daemonReachable(client);
   if (!ok) {
@@ -92,17 +96,11 @@ export async function ensureDaemon(
     const daemonScript =
       process.env["CLAUDEXOR_DAEMON_ENTRY"] ??
       fileURLToPath(new URL("./claudexord.js", import.meta.url));
-    if (!existsSync(daemonScript)) {
-      throw new Error(
-        `cannot auto-start the daemon: entry not found at ${daemonScript} (run \`pnpm build\`)`,
-      );
-    }
-    const child = spawn(process.execPath, [daemonScript], {
-      detached: true,
-      stdio: "ignore",
+    launch = launchDetachedDaemon({
+      entryPath: daemonScript,
+      launchSource: CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
       env: harnessRuntimeEnv(),
     });
-    child.unref();
     // Wait for the socket to accept connections (health round-trip).
     const deadline = Date.now() + timeoutMs;
     let started = false;
@@ -115,12 +113,9 @@ export async function ensureDaemon(
         started = true;
         break;
       }
+      if (launch.failure()) throw launch.callerError("socket_wait", timeoutMs);
     }
-    if (!started) {
-      throw new Error(
-        `daemon did not come up within ${Math.round(timeoutMs / 1000)}s after auto-start (socket ${socketPath}); check \`claudexor daemon logs\``,
-      );
-    }
+    if (!started) throw launch.callerError("socket_wait", timeoutMs);
   }
 
   // The control API (HTTP/SSE viewport over the daemon) is what streams events
@@ -131,13 +126,16 @@ export async function ensureDaemon(
     while (Date.now() < deadline && !reached) {
       await sleep(150);
       reached = await controlApiReachable();
+      if (!reached && launch?.failure()) throw launch.callerError("control_api_wait", 10_000);
     }
   }
   if (!reached) {
+    if (launch) throw launch.callerError("control_api_wait", 10_000);
     throw new Error(
       `daemon is up but its control API is not reachable (no ${daemonDir()}/control-api.json); it may be disabled by CLAUDEXOR_NO_CONTROL_API=1`,
     );
   }
+  launch?.markReady();
   return { client, addr: reached.addr, engine: reached.engine };
 }
 
@@ -171,11 +169,14 @@ export async function connectDaemonIfRunning(): Promise<{
  */
 export async function waitForDaemonReady(
   timeoutMs = DAEMON_START_READY_TIMEOUT_MS,
+  abort?: () => Error | null,
 ): Promise<{ client: DaemonClientType; addr: ControlApiAddress } | null> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const conn = await connectDaemonIfRunning();
     if (conn) return conn;
+    const failure = abort?.();
+    if (failure) throw failure;
     if (Date.now() >= deadline) return null;
     await sleep(150);
   }

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -35,6 +35,13 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
 // neither reports a false failure while the detached daemon is still starting.
 export const DAEMON_START_READY_TIMEOUT_MS = 90_000;
 
+// The bounded TAIL of that fresh-start budget spent waiting for the control
+// API after the daemon socket already answers (C10): the pointer file lands
+// as soon as the control transport binds — on the recovery plane too — so
+// this tail covers only bind/pointer-write latency, never journal replay
+// (that part is behind the socket wait above).
+export const DAEMON_CONTROL_API_FRESH_START_TAIL_MS = 10_000;
+
 /** Is something accepting on the daemon socket right now? (cheap reachability probe). */
 async function daemonReachable(client: DaemonClientType): Promise<boolean> {
   return client.health().then(
@@ -122,15 +129,17 @@ export async function ensureDaemon(
   // and resolves the run for apply/decision. Wait for its pointer to be written.
   let reached = await controlApiReachable();
   if (!reached) {
-    const deadline = Date.now() + 10_000;
+    const deadline = Date.now() + DAEMON_CONTROL_API_FRESH_START_TAIL_MS;
     while (Date.now() < deadline && !reached) {
       await sleep(150);
       reached = await controlApiReachable();
-      if (!reached && launch?.failure()) throw launch.callerError("control_api_wait", 10_000);
+      if (!reached && launch?.failure()) {
+        throw launch.callerError("control_api_wait", DAEMON_CONTROL_API_FRESH_START_TAIL_MS);
+      }
     }
   }
   if (!reached) {
-    if (launch) throw launch.callerError("control_api_wait", 10_000);
+    if (launch) throw launch.callerError("control_api_wait", DAEMON_CONTROL_API_FRESH_START_TAIL_MS);
     throw new Error(
       `daemon is up but its control API is not reachable (no ${daemonDir()}/control-api.json); it may be disabled by CLAUDEXOR_NO_CONTROL_API=1`,
     );

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -139,7 +139,8 @@ export async function ensureDaemon(
     }
   }
   if (!reached) {
-    if (launch) throw launch.callerError("control_api_wait", DAEMON_CONTROL_API_FRESH_START_TAIL_MS);
+    if (launch)
+      throw launch.callerError("control_api_wait", DAEMON_CONTROL_API_FRESH_START_TAIL_MS);
     throw new Error(
       `daemon is up but its control API is not reachable (no ${daemonDir()}/control-api.json); it may be disabled by CLAUDEXOR_NO_CONTROL_API=1`,
     );

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -136,6 +136,22 @@ export async function ensureDaemon(
     );
   }
   launch?.markReady();
+  // C7d: acting paths must not proceed into a wall of daemon_recovery_only
+  // route refusals — name the recovery state once, typed and retryable.
+  if (reached.engine.servingMode !== "normal") {
+    throw new CliError(
+      "operational",
+      "daemon is serving recovery only; product routes are closed until journal recovery completes",
+      {
+        code: "daemon_recovery_only",
+        retryable: true,
+        requiredActions: [
+          "inspect `claudexor daemon logs` and the /recovery control surface",
+          "retry after journal recovery completes",
+        ],
+      },
+    );
+  }
   return { client, addr: reached.addr, engine: reached.engine };
 }
 
@@ -151,6 +167,9 @@ export async function ensureDaemon(
 export async function connectDaemonIfRunning(): Promise<{
   client: DaemonClientType;
   addr: ControlApiAddress;
+  /** Handshake identity incl. servingMode (C7): read-only paths stay
+   * connectable to a recovery-only daemon and report the mode honestly. */
+  engine: EngineIdentity;
 } | null> {
   const token = readToken();
   if (!token) return null;
@@ -158,7 +177,7 @@ export async function connectDaemonIfRunning(): Promise<{
   if (!(await daemonReachable(client))) return null;
   const reached = await controlApiReachable();
   if (!reached) return null;
-  return { client, addr: reached.addr };
+  return { client, addr: reached.addr, engine: reached.engine };
 }
 
 /**
@@ -170,7 +189,7 @@ export async function connectDaemonIfRunning(): Promise<{
 export async function waitForDaemonReady(
   timeoutMs = DAEMON_START_READY_TIMEOUT_MS,
   abort?: () => Error | null,
-): Promise<{ client: DaemonClientType; addr: ControlApiAddress } | null> {
+): Promise<{ client: DaemonClientType; addr: ControlApiAddress; engine: EngineIdentity } | null> {
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const conn = await connectDaemonIfRunning();

--- a/packages/cli/src/daemon-start-report.ts
+++ b/packages/cli/src/daemon-start-report.ts
@@ -1,0 +1,34 @@
+/** C7c: `claudexor daemon start` reports the admission mode honestly — a
+ * recovery-only daemon came up (exit 0) but product routes stay closed until
+ * journal recovery completes, and the JSON envelope carries servingMode. */
+import { print, printJson } from "./cli-io.js";
+
+const RECOVERY_ONLY_NOTE =
+  " and is serving recovery only — product routes are closed until journal recovery completes";
+
+export function reportDaemonStartReady(input: {
+  json: boolean;
+  socket: string;
+  servingMode: "normal" | "recovery_only";
+  pid: number | null;
+  alreadyRunning: boolean;
+}): void {
+  if (input.json) {
+    printJson({
+      pid: input.pid,
+      socket: input.socket,
+      ready: true,
+      ...(input.alreadyRunning ? { alreadyRunning: true } : {}),
+      servingMode: input.servingMode,
+    });
+    return;
+  }
+  const note = input.servingMode === "recovery_only" ? RECOVERY_ONLY_NOTE : "";
+  print(
+    input.alreadyRunning
+      ? `claudexord already running${note}; socket ${input.socket}`
+      : note
+        ? `claudexord started (pid ${input.pid})${note}; socket ${input.socket}`
+        : `claudexord ready (pid ${input.pid}); socket ${input.socket}`,
+  );
+}

--- a/packages/cli/src/daemon-startup-recovery.integration.test.ts
+++ b/packages/cli/src/daemon-startup-recovery.integration.test.ts
@@ -1,9 +1,12 @@
 import { createHash } from "node:crypto";
 import {
+  chmodSync,
   cpSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   statSync,
@@ -46,6 +49,10 @@ interface PartitionPreparation {
   recoveryRequiredPartitions: string[];
 }
 
+interface ManagerPreparation {
+  inspection: { status: "ready" | "recovery_required"; recovery: unknown };
+}
+
 const cleanup: string[] = [];
 
 afterEach(() => {
@@ -81,8 +88,8 @@ function partitions(root: string, slots: GlobalSlots): ProjectPartitions {
   );
 }
 
-function prepareManager(manager: JournalManager): void {
-  (manager as unknown as { prepare(): void }).prepare();
+function prepareManager(manager: JournalManager): ManagerPreparation {
+  return (manager as unknown as { prepare(): ManagerPreparation }).prepare();
 }
 
 function preparePartitions(value: ProjectPartitions): PartitionPreparation {
@@ -118,8 +125,21 @@ function seedCopiedRoot(): {
   global.close();
 
   const copy = tempRoot("startup-copy");
-  cpSync(source, copy, { recursive: true, force: true });
+  copyRootPreservingModes(source, copy);
   return { root: copy, projectIds };
+}
+
+function copyRootPreservingModes(source: string, destination: string): void {
+  cpSync(source, destination, { recursive: true, force: true });
+  const restore = (sourcePath: string, destinationPath: string): void => {
+    const stat = lstatSync(sourcePath);
+    chmodSync(destinationPath, stat.mode & 0o777);
+    if (!stat.isDirectory()) return;
+    for (const name of readdirSync(sourcePath)) {
+      restore(join(sourcePath, name), join(destinationPath, name));
+    }
+  };
+  restore(source, destination);
 }
 
 function corruptFirstByte(path: string): void {
@@ -157,7 +177,10 @@ describe("daemon startup recovery preparation", () => {
 
     const global = new JournalManager(root);
     const slots = registerGlobal(global);
-    prepareManager(global);
+    const globalPreparation = prepareManager(global);
+    expect(globalPreparation.inspection.status, JSON.stringify(globalPreparation.inspection)).toBe(
+      "ready",
+    );
     const projectPartitions = partitions(root, slots);
     const result = preparePartitions(projectPartitions);
 
@@ -183,7 +206,7 @@ describe("daemon startup recovery preparation", () => {
 
     const global = new JournalManager(root);
     const slots = registerGlobal(global);
-    prepareManager(global);
+    expect(prepareManager(global).inspection).toMatchObject({ status: "recovery_required" });
     const projectPartitions = partitions(root, slots);
     const result = preparePartitions(projectPartitions);
 

--- a/packages/cli/src/daemon-startup-recovery.integration.test.ts
+++ b/packages/cli/src/daemon-startup-recovery.integration.test.ts
@@ -1,0 +1,199 @@
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  commandProjection,
+  interactionProjection,
+  JournalManager,
+  operatorDecisionProjection,
+  ProjectPartitions,
+  projectProjection,
+  runEventProjection,
+  threadProjection,
+  type CommandStore,
+  type InteractionStore,
+  type JournalProjectionSlot,
+  type OperatorDecisionStore,
+  type ProjectStore,
+  type RunEventStore,
+  type ThreadStore,
+} from "@claudexor/daemon";
+import { DurableJournal, journalPartitionDirectory } from "@claudexor/journal";
+import { afterEach, describe, expect, it } from "vitest";
+
+interface GlobalSlots {
+  commands: JournalProjectionSlot<CommandStore>;
+  interactions: JournalProjectionSlot<InteractionStore>;
+  decisions: JournalProjectionSlot<OperatorDecisionStore>;
+  runEvents: JournalProjectionSlot<RunEventStore>;
+  projects: JournalProjectionSlot<ProjectStore>;
+  threads: JournalProjectionSlot<ThreadStore>;
+}
+
+interface PartitionPreparation {
+  coverage: "complete" | "global_registry_unavailable";
+  readyPartitions: string[];
+  recoveryRequiredPartitions: string[];
+}
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const path of cleanup.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function tempRoot(name: string): string {
+  const path = realpathSync(mkdtempSync(join(tmpdir(), `claudexor-${name}-`)));
+  cleanup.push(path);
+  return path;
+}
+
+function registerGlobal(manager: JournalManager): GlobalSlots {
+  return {
+    commands: manager.registerProjection(commandProjection()),
+    interactions: manager.registerProjection(interactionProjection()),
+    decisions: manager.registerProjection(operatorDecisionProjection()),
+    runEvents: manager.registerProjection(runEventProjection()),
+    projects: manager.registerProjection(projectProjection()),
+    threads: manager.registerProjection(threadProjection()),
+  };
+}
+
+function partitions(root: string, slots: GlobalSlots): ProjectPartitions {
+  return new ProjectPartitions(
+    root,
+    slots.projects,
+    slots.commands,
+    slots.interactions,
+    slots.decisions,
+    slots.runEvents,
+    slots.threads,
+  );
+}
+
+function prepareManager(manager: JournalManager): void {
+  (manager as unknown as { prepare(): void }).prepare();
+}
+
+function preparePartitions(value: ProjectPartitions): PartitionPreparation {
+  return (value as unknown as { prepare(): PartitionPreparation }).prepare();
+}
+
+function seedCopiedRoot(): {
+  root: string;
+  projectIds: string[];
+} {
+  const source = tempRoot("startup-source");
+  const projectRoots = [join(source, "repo-a"), join(source, "repo-b")];
+  for (const projectRoot of projectRoots) mkdirSync(projectRoot);
+  const global = new JournalManager(source);
+  const slots = registerGlobal(global);
+  global.start();
+  const projectIds = projectRoots.map(
+    (projectRoot, index) =>
+      slots.projects.current().register({
+        root: projectRoot,
+        idempotencyKey: `register-${index}`,
+        clientId: "startup-test",
+      }).id,
+  );
+  for (const projectId of projectIds) {
+    const projectJournal = new DurableJournal({
+      rootDir: join(source, "journal"),
+      partition: `project:${projectId}`,
+    });
+    projectJournal.append("integration.seed", { projectId });
+    projectJournal.close();
+  }
+  global.close();
+
+  const copy = tempRoot("startup-copy");
+  cpSync(source, copy, { recursive: true, force: true });
+  return { root: copy, projectIds };
+}
+
+function corruptFirstByte(path: string): void {
+  const bytes = readFileSync(path);
+  bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+  writeFileSync(path, bytes, { mode: 0o600 });
+}
+
+function receipt(paths: string[]): string {
+  const hash = createHash("sha256");
+  for (const path of paths) {
+    const stat = statSync(path);
+    hash.update(`${path}\0${stat.mode & 0o777}\0${stat.size}\0`);
+    hash.update(readFileSync(path));
+  }
+  return hash.digest("hex");
+}
+
+describe("daemon startup recovery preparation", () => {
+  it("leaves crash-GC and maintenance inputs untouched when one registered project is corrupt", () => {
+    const { root, projectIds } = seedCopiedRoot();
+    const corruptPath = join(
+      journalPartitionDirectory(join(root, "journal"), `project:${projectIds[0]}`),
+      "journal.bin",
+    );
+    corruptFirstByte(corruptPath);
+    const pids = join(root, "pids.json");
+    const config = join(root, "config.json");
+    const workspace = join(root, "workspace-owner.json");
+    writeFileSync(pids, '{"children":[{"pid":4242}]}\n', { mode: 0o600 });
+    writeFileSync(config, '{"retired_key":"must-survive"}\n', { mode: 0o600 });
+    writeFileSync(workspace, '{"owner":"must-survive"}\n', { mode: 0o600 });
+    const guarded = [pids, config, workspace, corruptPath];
+    const before = receipt(guarded);
+
+    const global = new JournalManager(root);
+    const slots = registerGlobal(global);
+    prepareManager(global);
+    const projectPartitions = partitions(root, slots);
+    const result = preparePartitions(projectPartitions);
+
+    expect(result.coverage).toBe("complete");
+    expect(result.recoveryRequiredPartitions).toEqual([`project:${projectIds[0]}`]);
+    expect(result.readyPartitions).toEqual([`project:${projectIds[1]}`]);
+    expect(receipt(guarded)).toBe(before);
+    projectPartitions.close();
+    global.close();
+  });
+
+  it("does not discover or touch project partitions when the copied global registry is corrupt", () => {
+    const { root, projectIds } = seedCopiedRoot();
+    const globalPath = join(
+      journalPartitionDirectory(join(root, "journal"), "global"),
+      "journal.bin",
+    );
+    corruptFirstByte(globalPath);
+    const projectPaths = projectIds.map((id) =>
+      join(journalPartitionDirectory(join(root, "journal"), `project:${id}`), "journal.bin"),
+    );
+    const before = receipt([globalPath, ...projectPaths]);
+
+    const global = new JournalManager(root);
+    const slots = registerGlobal(global);
+    prepareManager(global);
+    const projectPartitions = partitions(root, slots);
+    const result = preparePartitions(projectPartitions);
+
+    expect(result).toMatchObject({
+      coverage: "global_registry_unavailable",
+      readyPartitions: [],
+      recoveryRequiredPartitions: [],
+    });
+    expect(receipt([globalPath, ...projectPaths])).toBe(before);
+    projectPartitions.close();
+    global.close();
+  });
+});

--- a/packages/cli/src/daemon-startup.test.ts
+++ b/packages/cli/src/daemon-startup.test.ts
@@ -1,0 +1,429 @@
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  cpSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  commandProjection,
+  interactionProjection,
+  JournalManager,
+  operatorDecisionProjection,
+  ProjectPartitions,
+  projectProjection,
+  runEventProjection,
+  threadProjection,
+  type JournalManagerPreparation,
+  type ProjectPartitionsPreparation,
+} from "@claudexor/daemon";
+import {
+  DurableJournal,
+  JournalRecoveryRequiredError,
+  journalPartitionDirectory,
+} from "@claudexor/journal";
+import { CONTROL_PROTOCOL_MAJOR } from "@claudexor/schema";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  completeStartupAdmission,
+  DaemonStartupAdmission,
+  proveRecoveryTransport,
+  recoveryBlockedPartitions,
+} from "./daemon-startup.js";
+
+const cleanup: Array<() => void> = [];
+
+afterEach(() => {
+  for (const dispose of cleanup.splice(0)) dispose();
+});
+
+function tempRoot(name: string): string {
+  const path = realpathSync(mkdtempSync(join(tmpdir(), `claudexor-${name}-`)));
+  cleanup.push(() => rmSync(path, { recursive: true, force: true }));
+  return path;
+}
+
+function preparation(status: "ready" | "recovery_required"): JournalManagerPreparation {
+  return { inspection: { status } } as unknown as JournalManagerPreparation;
+}
+
+function partitionsPreparation(
+  input: Partial<Pick<ProjectPartitionsPreparation, "coverage" | "recoveryRequiredPartitions">>,
+): ProjectPartitionsPreparation {
+  return {
+    coverage: input.coverage ?? "complete",
+    recoveryRequiredPartitions: input.recoveryRequiredPartitions ?? [],
+  } as unknown as ProjectPartitionsPreparation;
+}
+
+function orderedFixture(options: { failActivation?: boolean } = {}) {
+  const order: string[] = [];
+  const admission = new DaemonStartupAdmission();
+  return {
+    order,
+    admission,
+    input: {
+      grant: {
+        advanceFloor: () => {
+          order.push("advanceFloor");
+          return { schemaVersion: 2 as const, epoch: 2, state: "served" as const };
+        },
+      },
+      global: {
+        activatePrepared: () => {
+          order.push("global.activatePrepared");
+          if (options.failActivation) {
+            throw new JournalRecoveryRequiredError({
+              status: "recovery_required",
+              discardedTailBytes: 0,
+              reason: "journal changed during validation",
+              offset: 0,
+            } as never);
+          }
+        },
+        recoverAfterStartup: () => order.push("global.recoverAfterStartup"),
+      },
+      partitions: {
+        activatePrepared: () => order.push("partitions.activatePrepared"),
+        recoverAfterStartup: () => order.push("partitions.recoverAfterStartup"),
+      },
+      crashGc: async () => {
+        order.push("crashGc");
+      },
+      admission,
+      log: () => {},
+    },
+  };
+}
+
+describe("two-stage startup admission ordering (issue #165 D5)", () => {
+  it("starts recovery-only and opens normal admission through the coordinator only", () => {
+    const admission = new DaemonStartupAdmission();
+    expect(admission.snapshot()).toBe("recovery_only");
+    admission.openNormal();
+    expect(admission.snapshot()).toBe("normal");
+  });
+
+  it("runs floor advance and destructive recovery strictly AFTER the read-only verdict, in order", async () => {
+    const { order, admission, input } = orderedFixture();
+    const mode = await completeStartupAdmission({ ...input, blockedPartitions: [] });
+    expect(mode).toBe("normal");
+    expect(admission.snapshot()).toBe("normal");
+    expect(order).toEqual([
+      "advanceFloor",
+      "crashGc",
+      "global.activatePrepared",
+      "partitions.activatePrepared",
+      "global.recoverAfterStartup",
+      "partitions.recoverAfterStartup",
+    ]);
+  });
+
+  it("keeps the floor unchanged and destructive work OFF for a recovery-needed partition", async () => {
+    const { order, admission, input } = orderedFixture();
+    const mode = await completeStartupAdmission({
+      ...input,
+      blockedPartitions: ["project:abc"],
+    });
+    expect(mode).toBe("recovery_only");
+    expect(admission.snapshot()).toBe("recovery_only");
+    expect(order).toEqual([]);
+  });
+
+  it("stays on the recovery plane when prepared activation itself enters recovery", async () => {
+    const { order, admission, input } = orderedFixture({ failActivation: true });
+    const mode = await completeStartupAdmission({ ...input, blockedPartitions: [] });
+    expect(mode).toBe("recovery_only");
+    expect(admission.snapshot()).toBe("recovery_only");
+    expect(order).toEqual(["advanceFloor", "crashGc", "global.activatePrepared"]);
+    expect(order).not.toContain("global.recoverAfterStartup");
+  });
+
+  it("collects every blocking partition from the stage-2 receipts", () => {
+    expect(
+      recoveryBlockedPartitions({
+        globalPreparation: preparation("ready"),
+        partitionsPreparation: partitionsPreparation({}),
+      }),
+    ).toEqual([]);
+    expect(
+      recoveryBlockedPartitions({
+        globalPreparation: preparation("recovery_required"),
+        partitionsPreparation: partitionsPreparation({ coverage: "global_registry_unavailable" }),
+      }),
+    ).toEqual(["global", "project-registry"]);
+    expect(
+      recoveryBlockedPartitions({
+        globalPreparation: preparation("ready"),
+        partitionsPreparation: partitionsPreparation({
+          recoveryRequiredPartitions: ["project:p1"],
+        }),
+      }),
+    ).toEqual(["project:p1"]);
+  });
+});
+
+describe("recovery transport proof (issue #165 D5 stage 3)", () => {
+  it("accepts a recovery-only socket health report without a control plane", async () => {
+    await expect(
+      proveRecoveryTransport({
+        socket: { health: async () => ({ ok: true, servingMode: "recovery_only" }) },
+        identity: { version: "3.4.0", sha: "a".repeat(40) },
+        token: "token",
+        control: null,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses a socket that does not prove the recovery-only serving daemon", async () => {
+    await expect(
+      proveRecoveryTransport({
+        socket: { health: async () => ({ ok: true, servingMode: "normal" }) },
+        identity: { version: "3.4.0", sha: "a".repeat(40) },
+        token: "token",
+        control: null,
+      }),
+    ).rejects.toThrow(/transport proof failed/);
+  });
+
+  it("proves exact identity through the REAL control handshake and refuses a mismatch", async () => {
+    const identity = { version: "3.4.0", sha: "b".repeat(40) };
+    const serve = (engine: { version: string; sha: string }): Promise<Server> =>
+      new Promise((resolve) => {
+        const server = createServer((req, res) => {
+          if (req.method === "POST" && req.url === "/v2/handshake") {
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(
+              JSON.stringify({
+                protocolMajor: CONTROL_PROTOCOL_MAJOR,
+                compatible: true,
+                operationsPath: "/v2/operations",
+                engine: { ...engine, entry: "/opt/claudexor/daemon.js" },
+                servingMode: "recovery_only",
+              }),
+            );
+            return;
+          }
+          res.writeHead(404).end();
+        });
+        server.listen(0, "127.0.0.1", () => resolve(server));
+        cleanup.push(() => server.close());
+      });
+
+    const matching = await serve(identity);
+    const matchingPort = (matching.address() as { port: number }).port;
+    await expect(
+      proveRecoveryTransport({
+        socket: { health: async () => ({ ok: true, servingMode: "recovery_only" }) },
+        identity,
+        token: "token",
+        control: { host: "127.0.0.1", port: matchingPort },
+      }),
+    ).resolves.toBeUndefined();
+
+    const foreign = await serve({ version: "3.3.7", sha: "c".repeat(40) });
+    const foreignPort = (foreign.address() as { port: number }).port;
+    await expect(
+      proveRecoveryTransport({
+        socket: { health: async () => ({ ok: true, servingMode: "recovery_only" }) },
+        identity,
+        token: "token",
+        control: { host: "127.0.0.1", port: foreignPort },
+      }),
+    ).rejects.toThrow(/exact recovery-only runtime/);
+  });
+});
+
+// Copied-journal integration (reuses I-B's daemon-startup-recovery patterns):
+// one registered project partition is corrupt in a copied root. Stage 2 must
+// flag it read-only, and the stage-4 coordinator must leave the floor, crash
+// GC and every byte of the root untouched while the recovery plane stays on.
+describe("copied-journal startup admission integration", () => {
+  function seedCopiedRoot(): { root: string; projectIds: string[] } {
+    const source = tempRoot("id-startup-source");
+    const projectRoots = [join(source, "repo-a"), join(source, "repo-b")];
+    for (const projectRoot of projectRoots) mkdirSync(projectRoot);
+    const global = new JournalManager(source);
+    const slots = registerGlobal(global);
+    global.start();
+    const projectIds = projectRoots.map(
+      (projectRoot, index) =>
+        slots.projects.current().register({
+          root: projectRoot,
+          idempotencyKey: `register-${index}`,
+          clientId: "id-startup-test",
+        }).id,
+    );
+    for (const projectId of projectIds) {
+      const projectJournal = new DurableJournal({
+        rootDir: join(source, "journal"),
+        partition: `project:${projectId}`,
+      });
+      projectJournal.append("integration.seed", { projectId });
+      projectJournal.close();
+    }
+    global.close();
+    const copy = tempRoot("id-startup-copy");
+    cpSync(source, copy, { recursive: true, force: true });
+    const restore = (sourcePath: string, destinationPath: string): void => {
+      const stat = lstatSync(sourcePath);
+      chmodSync(destinationPath, stat.mode & 0o777);
+      if (!stat.isDirectory()) return;
+      for (const name of readdirSync(sourcePath)) {
+        restore(join(sourcePath, name), join(destinationPath, name));
+      }
+    };
+    restore(source, copy);
+    return { root: copy, projectIds };
+  }
+
+  function registerGlobal(manager: JournalManager) {
+    return {
+      commands: manager.registerProjection(commandProjection()),
+      interactions: manager.registerProjection(interactionProjection()),
+      decisions: manager.registerProjection(operatorDecisionProjection()),
+      runEvents: manager.registerProjection(runEventProjection()),
+      projects: manager.registerProjection(projectProjection()),
+      threads: manager.registerProjection(threadProjection()),
+    };
+  }
+
+  function receipt(paths: string[]): string {
+    const hash = createHash("sha256");
+    for (const path of paths) {
+      const stat = statSync(path);
+      hash.update(`${path}\0${stat.mode & 0o777}\0${stat.size}\0`);
+      hash.update(readFileSync(path));
+    }
+    return hash.digest("hex");
+  }
+
+  it("keeps the recovery plane on with floor unchanged and zero writes for a corrupt copied partition", async () => {
+    const { root, projectIds } = seedCopiedRoot();
+    const corruptPath = join(
+      journalPartitionDirectory(join(root, "journal"), `project:${projectIds[0]}`),
+      "journal.bin",
+    );
+    const bytes = readFileSync(corruptPath);
+    bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+    writeFileSync(corruptPath, bytes, { mode: 0o600 });
+    const guarded = [corruptPath];
+    const before = receipt(guarded);
+
+    const global = new JournalManager(root);
+    const slots = registerGlobal(global);
+    const globalPreparation = global.prepare();
+    const partitions = new ProjectPartitions(
+      root,
+      slots.projects,
+      slots.commands,
+      slots.interactions,
+      slots.decisions,
+      slots.runEvents,
+      slots.threads,
+    );
+    const receiptBefore = partitions.prepare();
+    cleanup.push(() => {
+      partitions.close();
+      global.close();
+    });
+
+    const blocked = recoveryBlockedPartitions({
+      globalPreparation,
+      partitionsPreparation: receiptBefore,
+    });
+    expect(blocked).toEqual([`project:${projectIds[0]}`]);
+
+    const admission = new DaemonStartupAdmission();
+    let floorAdvanced = 0;
+    let crashGcRan = 0;
+    const mode = await completeStartupAdmission({
+      grant: {
+        advanceFloor: () => {
+          floorAdvanced += 1;
+          return { schemaVersion: 2 as const, epoch: 2, state: "served" as const };
+        },
+      },
+      blockedPartitions: blocked,
+      global,
+      partitions,
+      crashGc: async () => {
+        crashGcRan += 1;
+      },
+      admission,
+      log: () => {},
+    });
+
+    expect(mode).toBe("recovery_only");
+    expect(admission.snapshot()).toBe("recovery_only");
+    expect(floorAdvanced).toBe(0);
+    expect(crashGcRan).toBe(0);
+    expect(receipt(guarded)).toBe(before);
+  });
+
+  it("activates, terminalizes and opens normal admission for a healthy copied root", async () => {
+    const { root, projectIds } = seedCopiedRoot();
+    const global = new JournalManager(root);
+    const slots = registerGlobal(global);
+    const globalPreparation = global.prepare();
+    const partitions = new ProjectPartitions(
+      root,
+      slots.projects,
+      slots.commands,
+      slots.interactions,
+      slots.decisions,
+      slots.runEvents,
+      slots.threads,
+    );
+    const receiptBefore = partitions.prepare();
+    cleanup.push(() => {
+      partitions.close();
+      global.close();
+    });
+
+    const blocked = recoveryBlockedPartitions({
+      globalPreparation,
+      partitionsPreparation: receiptBefore,
+    });
+    expect(blocked).toEqual([]);
+
+    const admission = new DaemonStartupAdmission();
+    let floorAdvanced = 0;
+    const mode = await completeStartupAdmission({
+      grant: {
+        advanceFloor: () => {
+          floorAdvanced += 1;
+          return { schemaVersion: 2 as const, epoch: 2, state: "served" as const };
+        },
+      },
+      blockedPartitions: blocked,
+      global,
+      partitions,
+      crashGc: async () => {},
+      admission,
+      log: () => {},
+    });
+
+    expect(mode).toBe("normal");
+    expect(admission.snapshot()).toBe("normal");
+    expect(floorAdvanced).toBe(1);
+    expect(global.ready()).toBe(true);
+    // The registered project stores are live product authorities again.
+    expect(
+      slots.projects
+        .current()
+        .list()
+        .map((project) => project.id),
+    ).toEqual(expect.arrayContaining(projectIds));
+  });
+});

--- a/packages/cli/src/daemon-startup.test.ts
+++ b/packages/cli/src/daemon-startup.test.ts
@@ -66,9 +66,16 @@ function partitionsPreparation(
   } as unknown as ProjectPartitionsPreparation;
 }
 
-function orderedFixture(options: { failActivation?: boolean } = {}) {
+function orderedFixture(options: { failActivation?: boolean; failRevalidation?: boolean } = {}) {
   const order: string[] = [];
   const admission = new DaemonStartupAdmission();
+  const recoveryRequired = () =>
+    new JournalRecoveryRequiredError({
+      status: "recovery_required",
+      discardedTailBytes: 0,
+      reason: "journal changed during validation",
+      offset: 0,
+    } as never);
   return {
     order,
     admission,
@@ -80,20 +87,18 @@ function orderedFixture(options: { failActivation?: boolean } = {}) {
         },
       },
       global: {
+        revalidatePreparation: () => {
+          order.push("global.revalidatePreparation");
+          if (options.failRevalidation) throw recoveryRequired();
+        },
         activatePrepared: () => {
           order.push("global.activatePrepared");
-          if (options.failActivation) {
-            throw new JournalRecoveryRequiredError({
-              status: "recovery_required",
-              discardedTailBytes: 0,
-              reason: "journal changed during validation",
-              offset: 0,
-            } as never);
-          }
+          if (options.failActivation) throw recoveryRequired();
         },
         recoverAfterStartup: () => order.push("global.recoverAfterStartup"),
       },
       partitions: {
+        revalidatePreparation: () => order.push("partitions.revalidatePreparation"),
         activatePrepared: () => order.push("partitions.activatePrepared"),
         recoverAfterStartup: () => order.push("partitions.recoverAfterStartup"),
       },
@@ -114,12 +119,14 @@ describe("two-stage startup admission ordering (issue #165 D5)", () => {
     expect(admission.snapshot()).toBe("normal");
   });
 
-  it("runs floor advance and destructive recovery strictly AFTER the read-only verdict, in order", async () => {
+  it("revalidates every preparation FIRST; floor advance and destructive recovery follow only on all-green (C3)", async () => {
     const { order, admission, input } = orderedFixture();
     const mode = await completeStartupAdmission({ ...input, blockedPartitions: [] });
     expect(mode).toBe("normal");
     expect(admission.snapshot()).toBe("normal");
     expect(order).toEqual([
+      "global.revalidatePreparation",
+      "partitions.revalidatePreparation",
       "advanceFloor",
       "crashGc",
       "global.activatePrepared",
@@ -127,6 +134,14 @@ describe("two-stage startup admission ordering (issue #165 D5)", () => {
       "global.recoverAfterStartup",
       "partitions.recoverAfterStartup",
     ]);
+  });
+
+  it("a revalidation failure keeps the floor UNCHANGED with zero destructive work (C3)", async () => {
+    const { order, admission, input } = orderedFixture({ failRevalidation: true });
+    const mode = await completeStartupAdmission({ ...input, blockedPartitions: [] });
+    expect(mode).toBe("recovery_only");
+    expect(admission.snapshot()).toBe("recovery_only");
+    expect(order).toEqual(["global.revalidatePreparation"]);
   });
 
   it("keeps the floor unchanged and destructive work OFF for a recovery-needed partition", async () => {
@@ -145,7 +160,13 @@ describe("two-stage startup admission ordering (issue #165 D5)", () => {
     const mode = await completeStartupAdmission({ ...input, blockedPartitions: [] });
     expect(mode).toBe("recovery_only");
     expect(admission.snapshot()).toBe("recovery_only");
-    expect(order).toEqual(["advanceFloor", "crashGc", "global.activatePrepared"]);
+    expect(order).toEqual([
+      "global.revalidatePreparation",
+      "partitions.revalidatePreparation",
+      "advanceFloor",
+      "crashGc",
+      "global.activatePrepared",
+    ]);
     expect(order).not.toContain("global.recoverAfterStartup");
   });
 

--- a/packages/cli/src/daemon-startup.ts
+++ b/packages/cli/src/daemon-startup.ts
@@ -31,10 +31,15 @@ export class DaemonStartupAdmission {
   }
 }
 
-/** Stage-2 verdict: every partition that blocks destructive recovery. */
+/** Stage-2 verdict: every partition that blocks destructive recovery. The
+ * loose Picks let the C6 in-process reopen feed LIVE inspections through the
+ * same verdict the frozen stage-2 receipts use. */
 export function recoveryBlockedPartitions(input: {
-  globalPreparation: JournalManagerPreparation;
-  partitionsPreparation: ProjectPartitionsPreparation;
+  globalPreparation: { inspection: Pick<JournalManagerPreparation["inspection"], "status"> };
+  partitionsPreparation: Pick<
+    ProjectPartitionsPreparation,
+    "coverage" | "recoveryRequiredPartitions"
+  >;
 }): string[] {
   const blocked: string[] = [];
   if (input.globalPreparation.inspection.status !== "ready") blocked.push("global");

--- a/packages/cli/src/daemon-startup.ts
+++ b/packages/cli/src/daemon-startup.ts
@@ -132,13 +132,22 @@ export async function proveRecoveryTransport(input: {
   }
 }
 
-/** Stage 4: floor advance + destructive recovery + normal admission — or the
- * protected recovery-only outcome (floor unchanged, cleanup off). */
+/** Stage 4: revalidate every read-only preparation FIRST; only on all-green
+ * advance the floor, run destructive recovery and open normal admission — or
+ * the protected recovery-only outcome (floor unchanged, cleanup off). */
 export async function completeStartupAdmission(input: {
   grant: Pick<RootAuthorityGrant, "advanceFloor">;
   blockedPartitions: string[];
-  global: { activatePrepared(): void; recoverAfterStartup(): void };
-  partitions: { activatePrepared(): void; recoverAfterStartup(): void };
+  global: {
+    revalidatePreparation(): void;
+    activatePrepared(): void;
+    recoverAfterStartup(): void;
+  };
+  partitions: {
+    revalidatePreparation(): void;
+    activatePrepared(): void;
+    recoverAfterStartup(): void;
+  };
   crashGc: () => Promise<void>;
   admission: DaemonStartupAdmission;
   log: (message: string) => void;
@@ -149,6 +158,21 @@ export async function completeStartupAdmission(input: {
     );
     return "recovery_only";
   }
+  // C3: prove the filesystem still matches every stage-2 preparation BEFORE
+  // the first irreversible act. Any revalidation failure leaves the floor
+  // UNCHANGED and zero destructive work done.
+  try {
+    input.global.revalidatePreparation();
+    input.partitions.revalidatePreparation();
+  } catch (error) {
+    if (error instanceof JournalRecoveryRequiredError) {
+      input.log(
+        `startup admission: preparation revalidation failed; serving recovery only with floor unchanged (${error.message})`,
+      );
+      return "recovery_only";
+    }
+    throw error;
+  }
   input.grant.advanceFloor();
   await input.crashGc();
   try {
@@ -158,7 +182,7 @@ export async function completeStartupAdmission(input: {
     input.partitions.recoverAfterStartup();
   } catch (error) {
     if (error instanceof JournalRecoveryRequiredError) {
-      // Revalidation/activation raced a journal mutation: stay on the
+      // Activation re-revalidates and raced a journal mutation: stay on the
       // recovery plane instead of serving a partition we could not activate.
       input.log(
         `startup admission: prepared activation entered recovery; serving recovery only (${error.message})`,

--- a/packages/cli/src/daemon-startup.ts
+++ b/packages/cli/src/daemon-startup.ts
@@ -50,6 +50,22 @@ export function recoveryBlockedPartitions(input: {
   return blocked;
 }
 
+/** C6a: whether the control API binds this startup. CLAUDEXOR_NO_CONTROL_API=1
+ * is honored only on a clean verdict — the recovery surface IS the point of
+ * the recovery plane, so a recovery-required verdict overrides it (logged). */
+export function controlApiEnabledForStartup(input: {
+  disabledByEnv: boolean;
+  blockedPartitions: string[];
+  log: (message: string) => void;
+}): boolean {
+  if (!input.disabledByEnv) return true;
+  if (input.blockedPartitions.length === 0) return false;
+  input.log(
+    "recovery-required startup verdict overrides CLAUDEXOR_NO_CONTROL_API=1: binding the control API to serve the recovery surface",
+  );
+  return true;
+}
+
 /** Stage 3 bind: start the REAL socket + control transports (product
  * admission still closed) and publish their addresses. Returns the control
  * address, or null when the control API is disabled or shutdown began. */

--- a/packages/cli/src/daemon-startup.ts
+++ b/packages/cli/src/daemon-startup.ts
@@ -1,0 +1,189 @@
+/**
+ * Two-stage daemon startup admission (issue #165 D5).
+ *
+ * Stage order enforced by main(): (1) acquire the root authority barrier with
+ * its epoch/floor refusals; (2) read-only prepare + validate the global AND
+ * every registered project partition — zero recovery writes; (3) bind the
+ * REAL transport (socket + control API) with product admission CLOSED and
+ * prove self-health/exact identity through it; (4) only then advance the
+ * semantic floor, run destructive recovery (crash-GC, prepared activation,
+ * recoverAfterStartup terminalization) and open normal admission. A
+ * recovery-needed partition leaves the recovery plane online with the floor
+ * UNCHANGED and cleanup OFF.
+ */
+import { appendFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type DaemonServingMode,
+  type JournalManagerPreparation,
+  type ProjectPartitionsPreparation,
+  type RootAuthorityGrant,
+} from "@claudexor/daemon";
+import { JournalRecoveryRequiredError } from "@claudexor/journal";
+import { CONTROL_PROTOCOL_MAJOR } from "@claudexor/schema";
+
+/** Single canonical admission snapshot; both transports read the SAME fact. */
+export class DaemonStartupAdmission {
+  private mode: DaemonServingMode = "recovery_only";
+  readonly snapshot = (): DaemonServingMode => this.mode;
+  openNormal(): void {
+    this.mode = "normal";
+  }
+}
+
+/** Stage-2 verdict: every partition that blocks destructive recovery. */
+export function recoveryBlockedPartitions(input: {
+  globalPreparation: JournalManagerPreparation;
+  partitionsPreparation: ProjectPartitionsPreparation;
+}): string[] {
+  const blocked: string[] = [];
+  if (input.globalPreparation.inspection.status !== "ready") blocked.push("global");
+  if (input.partitionsPreparation.coverage !== "complete") {
+    blocked.push("project-registry");
+  }
+  blocked.push(...input.partitionsPreparation.recoveryRequiredPartitions);
+  return blocked;
+}
+
+/** Stage 3 bind: start the REAL socket + control transports (product
+ * admission still closed) and publish their addresses. Returns the control
+ * address, or null when the control API is disabled or shutdown began. */
+export async function bindRecoveryTransport(input: {
+  server: { start(): Promise<void> };
+  control: { start(): Promise<{ host: string; port: number }> } | null;
+  requested: () => boolean;
+  daemonDir: string;
+  logPath: string;
+  socketPath: string;
+}): Promise<{ host: string; port: number } | null> {
+  const stamp = () => `[${new Date().toISOString()}]`;
+  if (!input.requested()) await input.server.start();
+  if (!input.requested()) {
+    appendFileSync(
+      input.logPath,
+      `${stamp()} claudexord listening on ${input.socketPath} (recovery-only admission)\n`,
+    );
+  }
+  if (!input.control) {
+    if (!input.requested()) {
+      appendFileSync(
+        input.logPath,
+        `${stamp()} claudexor control-api disabled by CLAUDEXOR_NO_CONTROL_API=1\n`,
+      );
+    }
+    return null;
+  }
+  if (input.requested()) return null;
+  const controlAddr = await input.control.start();
+  if (input.requested()) return null;
+  writeFileSync(
+    join(input.daemonDir, "control-api.json"),
+    `${JSON.stringify({ ...controlAddr, tokenPath: join(input.daemonDir, "token") }, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  appendFileSync(
+    input.logPath,
+    `${stamp()} claudexor control-api listening on http://${controlAddr.host}:${controlAddr.port}\n`,
+  );
+  return controlAddr;
+}
+
+/** Stage 3 proof: prove self-health and exact identity through the REAL
+ * transport while product admission is still closed. */
+export async function proveRecoveryTransport(input: {
+  socket: { health(): Promise<unknown> };
+  identity: { version: string; sha: string };
+  token: string;
+  control: { host: string; port: number } | null;
+}): Promise<void> {
+  const health = (await input.socket.health()) as {
+    ok?: unknown;
+    servingMode?: unknown;
+  } | null;
+  if (health?.ok !== true || health.servingMode !== "recovery_only") {
+    throw new Error(
+      "daemon transport proof failed: socket health did not report a recovery-only serving daemon",
+    );
+  }
+  if (!input.control) return;
+  const response = await fetch(`http://${input.control.host}:${input.control.port}/v2/handshake`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${input.token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ protocolMajor: CONTROL_PROTOCOL_MAJOR, client: "claudexord-startup" }),
+  });
+  if (!response.ok) {
+    throw new Error(`daemon transport proof failed: control handshake HTTP ${response.status}`);
+  }
+  const body = (await response.json()) as {
+    engine?: { version?: unknown; sha?: unknown };
+    servingMode?: unknown;
+  } | null;
+  if (
+    body?.engine?.version !== input.identity.version ||
+    body.engine.sha !== input.identity.sha ||
+    body.servingMode !== "recovery_only"
+  ) {
+    throw new Error(
+      "daemon transport proof failed: control handshake did not prove this exact recovery-only runtime",
+    );
+  }
+}
+
+/** Stage 4: floor advance + destructive recovery + normal admission — or the
+ * protected recovery-only outcome (floor unchanged, cleanup off). */
+export async function completeStartupAdmission(input: {
+  grant: Pick<RootAuthorityGrant, "advanceFloor">;
+  blockedPartitions: string[];
+  global: { activatePrepared(): void; recoverAfterStartup(): void };
+  partitions: { activatePrepared(): void; recoverAfterStartup(): void };
+  crashGc: () => Promise<void>;
+  admission: DaemonStartupAdmission;
+  log: (message: string) => void;
+}): Promise<DaemonServingMode> {
+  if (input.blockedPartitions.length > 0) {
+    input.log(
+      `startup admission: serving recovery only — floor unchanged, destructive recovery and cleanup OFF (recovery required: ${input.blockedPartitions.join(", ")})`,
+    );
+    return "recovery_only";
+  }
+  input.grant.advanceFloor();
+  await input.crashGc();
+  try {
+    input.global.activatePrepared();
+    input.partitions.activatePrepared();
+    input.global.recoverAfterStartup();
+    input.partitions.recoverAfterStartup();
+  } catch (error) {
+    if (error instanceof JournalRecoveryRequiredError) {
+      // Revalidation/activation raced a journal mutation: stay on the
+      // recovery plane instead of serving a partition we could not activate.
+      input.log(
+        `startup admission: prepared activation entered recovery; serving recovery only (${error.message})`,
+      );
+      return "recovery_only";
+    }
+    throw error;
+  }
+  input.admission.openNormal();
+  input.log("startup admission: normal product admission open");
+  return "normal";
+}
+
+/** Post-admission ghost-project quarantine (F2), normal admission only. */
+export function quarantineGhostProjectsAtStartup(
+  threads: {
+    quarantineGhostProjects(): Iterable<{ projectId: string; reason: string; root: string }>;
+  },
+  log: (message: string) => void,
+): void {
+  try {
+    for (const ghost of threads.quarantineGhostProjects()) {
+      log(`projects: quarantined ghost ${ghost.projectId} (${ghost.reason}): ${ghost.root}`);
+    }
+  } catch (error) {
+    log(`projects: ghost sweep failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/packages/cli/src/engine-skew.test.ts
+++ b/packages/cli/src/engine-skew.test.ts
@@ -38,7 +38,11 @@ describe("consumeHandshakeIdentity", () => {
   it("records a validated same-major skew with the daemon sha and returns the advisory", () => {
     const sha = "f".repeat(40);
     const identity = consumeHandshakeIdentity(canonical("9.9.9", sha));
-    expect(identity.engine).toEqual({ engineVersion: "9.9.9", engineBuildSha: sha });
+    expect(identity.engine).toEqual({
+      engineVersion: "9.9.9",
+      engineBuildSha: sha,
+      servingMode: "normal",
+    });
     expect(identity.skewAdvisory).toContain("daemon is engine 9.9.9");
     expect(identity.skewAdvisory).toContain(ENGINE_STOP_REMEDY);
     expect(observedEngineSkew()).toEqual({
@@ -54,6 +58,7 @@ describe("consumeHandshakeIdentity", () => {
     expect(identity.engine).toEqual({
       engineVersion: CLAUDEXOR_VERSION,
       engineBuildSha: "unknown",
+      servingMode: "normal",
     });
     expect(identity.skewAdvisory).toBeNull();
     expect(observedEngineSkew()).toBeNull();
@@ -66,7 +71,7 @@ describe("consumeHandshakeIdentity", () => {
       engine: { version: "9.9.9", sha: "x", entry: "/e" },
     });
     expect(identity).toEqual({
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
       skewAdvisory: null,
     });
     expect(observedEngineSkew()).toBeNull();
@@ -81,7 +86,11 @@ describe("consumeHandshakeIdentity", () => {
 
   it("omits a malformed sha from the identity and the skew record", () => {
     const identity = consumeHandshakeIdentity(canonical("9.9.9", "not-a-sha"));
-    expect(identity.engine).toEqual({ engineVersion: "9.9.9", engineBuildSha: null });
+    expect(identity.engine).toEqual({
+      engineVersion: "9.9.9",
+      engineBuildSha: null,
+      servingMode: "normal",
+    });
     expect(observedEngineSkew()).toEqual({
       daemonVersion: "9.9.9",
       cliVersion: CLAUDEXOR_VERSION,

--- a/packages/cli/src/engine-skew.ts
+++ b/packages/cli/src/engine-skew.ts
@@ -39,6 +39,10 @@ export interface EngineSkew {
 export interface EngineIdentity {
   engineVersion: string | null;
   engineBuildSha: string | null;
+  /** Product admission at handshake time (issue #165 D5). A pre-#165 daemon
+   * reports nothing and is always serving normally, so absent maps to
+   * `normal`; `recovery_only` means product routes are typed-closed. */
+  servingMode: "normal" | "recovery_only";
 }
 
 /** The ONE remedy wording — stderr advisory and typed requiredActions speak
@@ -90,9 +94,13 @@ export function consumeHandshakeIdentity(body: unknown): HandshakeIdentity {
   if (!parsed.success) {
     // Identity is advisory; a malformed body never fails the handshake.
     recordEngineSkew(null);
-    return { engine: { engineVersion: null, engineBuildSha: null }, skewAdvisory: null };
+    return {
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
+      skewAdvisory: null,
+    };
   }
   const { version, sha } = parsed.data.engine;
+  const servingMode = parsed.data.servingMode ?? "normal";
   const daemonVersion = ENGINE_VERSION_RE.test(version) ? version : null;
   const engineBuildSha = sha === "unknown" || BUILD_SHA_RE.test(sha) ? sha : null;
   if (daemonVersion && daemonVersion !== CLAUDEXOR_VERSION) {
@@ -102,14 +110,17 @@ export function consumeHandshakeIdentity(body: unknown): HandshakeIdentity {
       cliVersion: CLAUDEXOR_VERSION,
     });
     return {
-      engine: { engineVersion: daemonVersion, engineBuildSha },
+      engine: { engineVersion: daemonVersion, engineBuildSha, servingMode },
       skewAdvisory:
         `claudexor: daemon is engine ${daemonVersion} but this CLI is ${CLAUDEXOR_VERSION}; ` +
         `${ENGINE_STOP_REMEDY}\n`,
     };
   }
   recordEngineSkew(null);
-  return { engine: { engineVersion: daemonVersion, engineBuildSha }, skewAdvisory: null };
+  return {
+    engine: { engineVersion: daemonVersion, engineBuildSha, servingMode },
+    skewAdvisory: null,
+  };
 }
 
 /** The typed-problem fields `stampEngineSkew` shapes — a structural mirror of

--- a/packages/cli/src/fixtures/legacy-v3.3.7/provenance.json
+++ b/packages/cli/src/fixtures/legacy-v3.3.7/provenance.json
@@ -1,0 +1,16 @@
+{
+  "tag": "v3.3.7",
+  "commit": "a4b004d79d54bfe03735a247c40b297552c2a624",
+  "sourcePath": "packages/daemon/src/writer-lease.ts",
+  "sourceBlob": "f2cde81164ee0843b22fb8266e43193d2f05f1eb",
+  "sourceSha256": "f8bf76956c24bdadec40ff2917f59bc6c2dfff02e15b9f4a4cc14ec9151b8344",
+  "fixtureSha256": "5abf7e48822d52e3c954d99c09777f3eb974995f89aaa9b0156f1079b9ce42c8",
+  "parityMarkers": [
+    "for (let attempt = 0; attempt < 2; attempt += 1)",
+    "mkdirSync(path, { mode: 0o700 });",
+    "writeFileSync(ownerPath, `${JSON.stringify(owner)}\\n`, {",
+    "if (!existing || processIsAlive(existing.pid)) throw writerBusy(path);",
+    "renameSync(path, stale);",
+    "rmSync(stale, { recursive: true, force: true });"
+  ]
+}

--- a/packages/cli/src/fixtures/legacy-v3.3.7/writer-claimant.cjs
+++ b/packages/cli/src/fixtures/legacy-v3.3.7/writer-claimant.cjs
@@ -1,0 +1,86 @@
+// Executable compatibility fixture derived from v3.3.7's
+// packages/daemon/src/writer-lease.ts. Keep acquisition markers byte-parallel;
+// provenance.json binds this compact claimant to the exact upstream source.
+const { randomUUID } = require("node:crypto");
+const { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } = require("node:fs");
+
+function writerBusy(path) {
+  return Object.assign(new Error(`another claudexor daemon owns ${path}`), {
+    code: "daemon_writer_busy",
+    status: 409,
+  });
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === "EPERM";
+  }
+}
+
+function readLeaseOwner(path) {
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"));
+    if (
+      !Number.isSafeInteger(value.pid) ||
+      Number(value.pid) <= 0 ||
+      typeof value.token !== "string"
+    ) {
+      return null;
+    }
+    return { pid: Number(value.pid), token: value.token };
+  } catch {
+    return null;
+  }
+}
+
+function acquireDaemonWriterLease(socketPath) {
+  const path = `${socketPath}.writer`;
+  const token = randomUUID();
+  const ownerPath = `${path}/owner.json`;
+  const owner = { pid: process.pid, token };
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      mkdirSync(path, { mode: 0o700 });
+      writeFileSync(ownerPath, `${JSON.stringify(owner)}\n`, {
+        mode: 0o600,
+        flag: "wx",
+      });
+      break;
+    } catch (error) {
+      if (error.code !== "EEXIST") throw error;
+      const existing = readLeaseOwner(ownerPath);
+      if (!existing || processIsAlive(existing.pid)) throw writerBusy(path);
+      const stale = `${path}.stale-${process.pid}-${randomUUID()}`;
+      try {
+        renameSync(path, stale);
+        rmSync(stale, { recursive: true, force: true });
+      } catch (cleanupError) {
+        if (cleanupError.code !== "ENOENT") throw cleanupError;
+      }
+      if (attempt === 1) throw new Error(`could not replace stale daemon writer lease ${path}`);
+    }
+  }
+  return { path, owner };
+}
+
+try {
+  const socketPath = process.env.CLAUDEXOR_DAEMON_SOCK;
+  if (!socketPath) throw new Error("CLAUDEXOR_DAEMON_SOCK is required");
+  const lease = acquireDaemonWriterLease(socketPath);
+  process.stdout.write(
+    `${JSON.stringify({ ok: true, stage: "writer_claim", path: lease.path })}\n`,
+  );
+} catch (error) {
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: false,
+      code: typeof error.code === "string" ? error.code : "legacy_claim_failed",
+      stage: "writer_claim",
+      message: error instanceof Error ? error.message : String(error),
+    })}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/packages/cli/src/legacy-writer-claimant.test.ts
+++ b/packages/cli/src/legacy-writer-claimant.test.ts
@@ -1,0 +1,90 @@
+import { createHash } from "node:crypto";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const fixtureRoot = resolve(import.meta.dirname, "fixtures", "legacy-v3.3.7");
+const claimantPath = join(fixtureRoot, "writer-claimant.cjs");
+const provenancePath = join(fixtureRoot, "provenance.json");
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+describe("exact-v3.3.7 legacy writer claimant fixture", () => {
+  it("binds the executable fixture to the exact tag/commit/blob/source bytes and parity markers", () => {
+    const provenance = JSON.parse(readFileSync(provenancePath, "utf8")) as {
+      tag: string;
+      commit: string;
+      sourcePath: string;
+      sourceBlob: string;
+      sourceSha256: string;
+      fixtureSha256: string;
+      parityMarkers: string[];
+    };
+    expect(provenance).toMatchObject({
+      tag: "v3.3.7",
+      commit: "a4b004d79d54bfe03735a247c40b297552c2a624",
+      sourcePath: "packages/daemon/src/writer-lease.ts",
+      sourceBlob: "f2cde81164ee0843b22fb8266e43193d2f05f1eb",
+      sourceSha256: "f8bf76956c24bdadec40ff2917f59bc6c2dfff02e15b9f4a4cc14ec9151b8344",
+    });
+    const source = execFileSync("git", ["show", `${provenance.tag}:${provenance.sourcePath}`], {
+      cwd: resolve(import.meta.dirname, "../../.."),
+      encoding: "utf8",
+    });
+    const fixture = readFileSync(claimantPath, "utf8");
+    expect(
+      execFileSync("git", ["rev-parse", `${provenance.tag}^{commit}`], { encoding: "utf8" }).trim(),
+    ).toBe(provenance.commit);
+    expect(
+      execFileSync("git", ["rev-parse", `${provenance.tag}:${provenance.sourcePath}`], {
+        encoding: "utf8",
+      }).trim(),
+    ).toBe(provenance.sourceBlob);
+    expect(sha256(source)).toBe(provenance.sourceSha256);
+    expect(sha256(fixture)).toBe(provenance.fixtureSha256);
+    for (const marker of provenance.parityMarkers) {
+      expect(source, `tag source missing parity marker: ${marker}`).toContain(marker);
+      expect(fixture, `fixture missing parity marker: ${marker}`).toContain(marker);
+    }
+  });
+
+  it("fails before journal/GC when a later opaque barrier occupies the canonical legacy path", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "claudexor-legacy-claimant-"));
+    roots.push(dataRoot);
+    const daemonRoot = join(dataRoot, "daemon");
+    const socketPath = join(daemonRoot, "claudexord.sock");
+    const barrier = `${socketPath}.writer`;
+    mkdirSync(barrier, { recursive: true, mode: 0o700 });
+    const marker = join(barrier, "root-authority-v2.json");
+    writeFileSync(marker, '{"schemaVersion":2,"state":"vacant"}\n', { mode: 0o600 });
+    const before = readFileSync(marker);
+
+    const result = spawnSync(process.execPath, [claimantPath], {
+      cwd: dataRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CLAUDEXOR_CONFIG_DIR: dataRoot,
+        CLAUDEXOR_DAEMON_SOCK: socketPath,
+      },
+    });
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      ok: false,
+      code: "daemon_writer_busy",
+      stage: "writer_claim",
+    });
+    expect(readFileSync(marker)).toEqual(before);
+    expect(() => readFileSync(join(daemonRoot, "journal", "events.log"))).toThrow();
+  });
+});

--- a/packages/cli/src/legacy-writer-claimant.test.ts
+++ b/packages/cli/src/legacy-writer-claimant.test.ts
@@ -1,8 +1,18 @@
 import { createHash } from "node:crypto";
 import { execFileSync, spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, join, resolve } from "node:path";
+import { acquireRootAuthority, readRootAuthority } from "@claudexor/daemon";
 import { afterEach, describe, expect, it } from "vitest";
 
 const fixtureRoot = resolve(import.meta.dirname, "fixtures", "legacy-v3.3.7");
@@ -55,6 +65,76 @@ describe("exact-v3.3.7 legacy writer claimant fixture", () => {
       expect(source, `tag source missing parity marker: ${marker}`).toContain(marker);
       expect(fixture, `fixture missing parity marker: ${marker}`).toContain(marker);
     }
+  });
+
+  it("fails closed at every step of the stale-flat first migration; the address is never absent (C4)", () => {
+    const dataRoot = mkdtempSync(join(tmpdir(), "claudexor-legacy-claimant-"));
+    roots.push(dataRoot);
+    const daemonRoot = join(dataRoot, "daemon");
+    mkdirSync(daemonRoot, { recursive: true, mode: 0o700 });
+    const socketPath = join(daemonRoot, "claudexord.sock");
+    const anchor = `${socketPath}.writer`;
+    // A DEAD pre-fix owner holds the flat legacy address: the exact state the
+    // first migration converts. Before our first mutation a legacy claimant
+    // may still win (D3's bounded limitation); after it, never.
+    mkdirSync(anchor, { mode: 0o700 });
+    writeFileSync(join(anchor, "owner.json"), '{"pid":2147483646,"token":"legacy"}\n', {
+      mode: 0o600,
+    });
+
+    const probeLegacyClaimant = (step: string): void => {
+      expect(lstatSync(anchor).isDirectory(), `address absent at ${step}`).toBe(true);
+      const result = spawnSync(process.execPath, [claimantPath], {
+        cwd: dataRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          CLAUDEXOR_CONFIG_DIR: dataRoot,
+          CLAUDEXOR_DAEMON_SOCK: socketPath,
+        },
+      });
+      expect(result.status, `legacy claimant won at ${step}: ${result.stdout}`).toBe(1);
+      expect(lstatSync(anchor).isDirectory(), `claimant destroyed the address at ${step}`).toBe(
+        true,
+      );
+    };
+
+    // Every rename/remove of the migration flows through the lease seam. The
+    // canonical address itself must never be renamed away or removed — that
+    // is the absence window a newly arriving legacy claimant wins.
+    let mutations = 0;
+    const grant = acquireRootAuthority({
+      socketPath,
+      version: "3.4.0",
+      canonicalSocketPath: socketPath,
+      deps: {
+        filesystem: {
+          rename: (from, to) => {
+            expect(from, "the migration renamed the canonical address away").not.toBe(anchor);
+            renameSync(from, to);
+            mutations += 1;
+            probeLegacyClaimant(`after rename #${mutations} (${basename(from)} -> ${basename(to)})`);
+          },
+          remove: (path) => {
+            expect(path, "the migration removed the canonical address").not.toBe(anchor);
+            rmSync(path, { recursive: true, force: true });
+          },
+        },
+      },
+    });
+    expect(mutations).toBeGreaterThanOrEqual(2);
+    // Final state: permanent barrier + nested claim; the stale owner record is
+    // preserved as evidence inside the same directory; no parseable owner.
+    expect(readRootAuthority(anchor)).toMatchObject({ status: "valid" });
+    probeLegacyClaimant("after barrier installation");
+    expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+    expect(
+      readdirSync(anchor).some(
+        (name) => name.startsWith("owner.stale-") && name.endsWith(".json"),
+      ),
+    ).toBe(true);
+    expect(grant.lease.path).toBe(join(anchor, "active.writer"));
+    grant.release();
   });
 
   it("fails before journal/GC when a later opaque barrier occupies the canonical legacy path", () => {

--- a/packages/cli/src/legacy-writer-claimant.test.ts
+++ b/packages/cli/src/legacy-writer-claimant.test.ts
@@ -113,7 +113,9 @@ describe("exact-v3.3.7 legacy writer claimant fixture", () => {
             expect(from, "the migration renamed the canonical address away").not.toBe(anchor);
             renameSync(from, to);
             mutations += 1;
-            probeLegacyClaimant(`after rename #${mutations} (${basename(from)} -> ${basename(to)})`);
+            probeLegacyClaimant(
+              `after rename #${mutations} (${basename(from)} -> ${basename(to)})`,
+            );
           },
           remove: (path) => {
             expect(path, "the migration removed the canonical address").not.toBe(anchor);
@@ -129,9 +131,7 @@ describe("exact-v3.3.7 legacy writer claimant fixture", () => {
     probeLegacyClaimant("after barrier installation");
     expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
     expect(
-      readdirSync(anchor).some(
-        (name) => name.startsWith("owner.stale-") && name.endsWith(".json"),
-      ),
+      readdirSync(anchor).some((name) => name.startsWith("owner.stale-") && name.endsWith(".json")),
     ).toBe(true);
     expect(grant.lease.path).toBe(join(anchor, "active.writer"));
     grant.release();

--- a/packages/cli/src/live.test.ts
+++ b/packages/cli/src/live.test.ts
@@ -773,7 +773,11 @@ describe("handshake engine identity (v3.0.3 S4c)", () => {
         baseUrl: `http://127.0.0.1:${port}`,
         token: "t",
       });
-      expect(identity).toEqual({ engineVersion: CLAUDEXOR_VERSION, engineBuildSha: "unknown" });
+      expect(identity).toEqual({
+        engineVersion: CLAUDEXOR_VERSION,
+        engineBuildSha: "unknown",
+        servingMode: "normal",
+      });
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/packages/cli/src/mcp-runner.test.ts
+++ b/packages/cli/src/mcp-runner.test.ts
@@ -245,7 +245,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     vi.stubGlobal(
       "fetch",
@@ -316,6 +316,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     vi.stubGlobal(
       "fetch",
@@ -349,7 +350,7 @@ describe("mcp daemon body mapping", () => {
       const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
         client: {} as never,
         addr: { baseUrl: "http://x", token: "t" } as never,
-        engine: { engineVersion: null, engineBuildSha: null },
+        engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
       });
       const runDir = mkdtempSync(join(tmpdir(), "claudexor-mcp-detail-problem-"));
       mkdirSync(join(runDir, "final"));
@@ -398,7 +399,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-soft-absence",
@@ -443,7 +444,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-done",
@@ -480,7 +481,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi
       .spyOn(daemonRun, "enqueueAndAwait")
@@ -508,7 +509,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-best-of",
@@ -541,7 +542,7 @@ describe("mcp daemon body mapping", () => {
     const connection = {
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" as const },
     };
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue(connection);
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue(connection);
@@ -597,6 +598,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     vi.stubGlobal(
       "fetch",
@@ -635,7 +637,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-durable",
@@ -683,7 +685,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-fast-failed",
@@ -727,7 +729,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-child",
@@ -798,7 +800,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-invalid",
@@ -910,7 +912,7 @@ describe("mcp daemon body mapping", () => {
     const ensureSpy = vi.spyOn(daemonRun, "ensureDaemon").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
-      engine: { engineVersion: null, engineBuildSha: null },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const enqueueSpy = vi.spyOn(daemonRun, "enqueueAndAwait").mockResolvedValue({
       runId: "run-right",
@@ -953,6 +955,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     // Page 1 caps at 2 with hasMore; page 2 (cursor present) returns the tail.
     const urls: string[] = [];
@@ -999,6 +1002,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     vi.stubGlobal(
       "fetch",
@@ -1080,6 +1084,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const retryable = problemCode === "invalid_service_response";
     const fetchSpy = vi.fn(async () => ({
@@ -1134,6 +1139,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const responses = [
       {
@@ -1198,6 +1204,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     vi.stubGlobal(
       "fetch",
@@ -1243,6 +1250,7 @@ describe("mcp daemon body mapping", () => {
       const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
         client: {} as never,
         addr: { baseUrl: "http://x", token: "t" } as never,
+        engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
       });
       const fetchSpy = vi.fn(async () => ({
         ok: false,
@@ -1275,6 +1283,7 @@ describe("mcp daemon body mapping", () => {
     const connectSpy = vi.spyOn(daemonRun, "connectDaemonIfRunning").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://x", token: "t" } as never,
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
     const failure = {
       phase: "execute",

--- a/packages/cli/src/ops-commands-daemon-stop.test.ts
+++ b/packages/cli/src/ops-commands-daemon-stop.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { type DaemonWriterLeaseStatus } from "@claudexor/daemon";
+import { stopDaemonForOperator } from "./ops-commands.js";
+
+const IDENTITY = {
+  status: "known",
+  pid: 7331,
+  platform: "linux",
+  source: "procfs_stat",
+  startToken: "linux:7331",
+  processGroupId: 7331,
+} as const;
+const OWNER = { pid: IDENTITY.pid, token: "operator-stop-owner", identity: IDENTITY };
+const OBSERVATION = {
+  identity: IDENTITY,
+  linuxState: "S",
+} as const;
+const CAPABLE_LEASE = {
+  status: "owned",
+  path: "/tmp/claudexord.sock.writer",
+  owner: OWNER,
+  capability: {
+    status: "capable",
+    reason: "identity_match",
+    observation: OBSERVATION,
+  },
+} satisfies DaemonWriterLeaseStatus;
+
+describe("ordinary daemon stop writer-owner pin", () => {
+  it("captures one strict capable owner before shutdown and passes that exact owner to the waiter", async () => {
+    const events: string[] = [];
+    await expect(
+      stopDaemonForOperator("/tmp/claudexord.sock", {
+        inspectLease: (path) => {
+          expect(path).toBe("/tmp/claudexord.sock");
+          events.push("inspect");
+          return CAPABLE_LEASE;
+        },
+        shutdown: async () => {
+          events.push("shutdown");
+        },
+        awaitTermination: async (path, options) => {
+          events.push("wait");
+          expect(path).toBe("/tmp/claudexord.sock");
+          if (!options) throw new Error("expected termination options");
+          expect(options).toEqual({
+            allowSigkill: true,
+            expectedOwner: OWNER,
+            requireNoSuccessor: false,
+          });
+          expect(options.expectedOwner).toBe(OWNER);
+          return { outcome: "exited", detail: "pinned owner exited" };
+        },
+      }),
+    ).resolves.toEqual({ outcome: "exited", detail: "pinned owner exited" });
+    expect(events).toEqual(["inspect", "shutdown", "wait"]);
+  });
+
+  it.each([
+    ["physical absence", { status: "absent", path: "/tmp/claudexord.sock.writer" }],
+    [
+      "malformed authority",
+      {
+        status: "unknown",
+        path: "/tmp/claudexord.sock.writer",
+        reason: "owner_malformed",
+      },
+    ],
+    [
+      "unknown owner capability",
+      {
+        ...CAPABLE_LEASE,
+        capability: {
+          status: "unknown",
+          reason: "identity_unavailable",
+          observation: {
+            identity: {
+              status: "unknown",
+              pid: OWNER.pid,
+              platform: "linux",
+              reason: "permission_denied",
+            },
+            linuxState: null,
+          },
+        },
+      },
+    ],
+    [
+      "proven-stale owner",
+      {
+        ...CAPABLE_LEASE,
+        capability: {
+          status: "proven_stale",
+          reason: "process_missing",
+          observation: {
+            identity: { status: "missing", pid: OWNER.pid, platform: "linux" },
+            linuxState: null,
+          },
+        },
+      },
+    ],
+  ] satisfies readonly (readonly [string, DaemonWriterLeaseStatus])[])(
+    "keeps %s passive and never grants SIGKILL authority",
+    async (_label, lease) => {
+      let shutdowns = 0;
+      await stopDaemonForOperator("/tmp/claudexord.sock", {
+        inspectLease: () => lease,
+        shutdown: async () => {
+          shutdowns += 1;
+        },
+        awaitTermination: async (_path, options) => {
+          if (!options) throw new Error("expected termination options");
+          expect(options).toEqual({ allowSigkill: false, requireNoSuccessor: false });
+          expect(options.expectedOwner).toBeUndefined();
+          return { outcome: "still_alive", detail: "passive confirmation only" };
+        },
+      });
+      expect(shutdowns).toBe(1);
+    },
+  );
+});

--- a/packages/cli/src/ops-commands.projector.test.ts
+++ b/packages/cli/src/ops-commands.projector.test.ts
@@ -113,6 +113,7 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
     vi.spyOn(daemonRun, "waitForDaemonReady").mockResolvedValue({
       client: {} as never,
       addr: { baseUrl: "http://127.0.0.1:1", token: "token" },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "normal" },
     });
 
     const { code, env } = await captureJson(() =>
@@ -127,6 +128,34 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
       }),
     );
     expect(markReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("`daemon start` reports a recovery-only daemon honestly (exit 0, servingMode field) (C7c)", async () => {
+    const markReady = vi.fn();
+    vi.spyOn(daemonLaunch, "launchDetachedDaemon").mockReturnValue({
+      pid: 12346,
+      failure: () => null,
+      markReady,
+      waitForFailure: async () => ({
+        kind: "preclaim_exit",
+        exitCode: 0,
+        signal: null,
+        stderr: { kind: "empty" },
+      }),
+      callerError: () => new CliError("operational", "unused"),
+    });
+    vi.spyOn(daemonRun, "waitForDaemonReady").mockResolvedValue({
+      client: {} as never,
+      addr: { baseUrl: "http://127.0.0.1:1", token: "token" },
+      engine: { engineVersion: null, engineBuildSha: null, servingMode: "recovery_only" },
+    });
+
+    const { code, env } = await captureJson(() =>
+      daemonCommand(parseArgs(["daemon", "start"]), true),
+    );
+
+    expect(code).toBe(0);
+    expect(env).toMatchObject({ pid: 12346, ready: true, servingMode: "recovery_only" });
   });
 
   it.each([

--- a/packages/cli/src/ops-commands.projector.test.ts
+++ b/packages/cli/src/ops-commands.projector.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureToken } from "@claudexor/daemon";
 import { parseArgs } from "./args.js";
+import * as daemonLaunch from "./daemon-launch.js";
+import * as daemonRun from "./daemon-run.js";
 import { daemonCommand } from "./ops-commands.js";
 
 /** Capture the single JSON object printed on stdout across an async command. */
@@ -70,5 +72,33 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
     expect(env["exitCode"]).toBe(2);
     expect(String(env["message"])).toContain("usage: claudexor daemon");
     expect(env["error"]).toBe(env["message"]);
+  });
+
+  it("`daemon start` uses the shared detached adapter with explicit-start provenance", async () => {
+    const markReady = vi.fn();
+    const launchSpy = vi.spyOn(daemonLaunch, "launchDetachedDaemon").mockReturnValue({
+      pid: 12345,
+      failure: () => null,
+      markReady,
+      waitForFailure: async () => null,
+      callerError: () => new Error("unused"),
+    });
+    vi.spyOn(daemonRun, "waitForDaemonReady").mockResolvedValue({
+      client: {} as never,
+      addr: { baseUrl: "http://127.0.0.1:1", token: "token" },
+    });
+
+    const { code, env } = await captureJson(() =>
+      daemonCommand(parseArgs(["daemon", "start"]), true),
+    );
+
+    expect(code).toBe(0);
+    expect(env).toMatchObject({ pid: 12345, ready: true });
+    expect(launchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        launchSource: daemonLaunch.CLI_DAEMON_LAUNCH_SOURCES.explicitStart,
+      }),
+    );
+    expect(markReady).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/ops-commands.projector.test.ts
+++ b/packages/cli/src/ops-commands.projector.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureToken } from "@claudexor/daemon";
@@ -8,6 +8,7 @@ import { CliError } from "./cli-error.js";
 import * as daemonLaunch from "./daemon-launch.js";
 import * as daemonRun from "./daemon-run.js";
 import { daemonCommand } from "./ops-commands.js";
+import { projectCommand } from "./project-command.js";
 
 /** Capture the single JSON object printed on stdout across an async command. */
 async function captureJson(fn: () => Promise<number>): Promise<{
@@ -32,17 +33,21 @@ async function captureJson(fn: () => Promise<number>): Promise<{
 describe("ops-commands: ad-hoc failure envelopes route through the ONE projector (Ф2)", () => {
   let configDir: string;
   let prevConfigDir: string | undefined;
+  let prevDaemonEntry: string | undefined;
 
   beforeEach(() => {
     // Hermetic: an empty config dir means no daemon token on disk.
     configDir = realpathSync(mkdtempSync(join(tmpdir(), "clawdexor-ops-")));
     prevConfigDir = process.env["CLAUDEXOR_CONFIG_DIR"];
+    prevDaemonEntry = process.env["CLAUDEXOR_DAEMON_ENTRY"];
     process.env["CLAUDEXOR_CONFIG_DIR"] = configDir;
   });
 
   afterEach(() => {
     if (prevConfigDir === undefined) delete process.env["CLAUDEXOR_CONFIG_DIR"];
     else process.env["CLAUDEXOR_CONFIG_DIR"] = prevConfigDir;
+    if (prevDaemonEntry === undefined) delete process.env["CLAUDEXOR_DAEMON_ENTRY"];
+    else process.env["CLAUDEXOR_DAEMON_ENTRY"] = prevDaemonEntry;
     rmSync(configDir, { recursive: true, force: true });
     vi.restoreAllMocks();
   });
@@ -85,6 +90,7 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
         kind: "preclaim_exit",
         exitCode: 0,
         signal: null,
+        stderr: { kind: "empty" },
       }),
       callerError: () => new CliError("operational", "unused"),
     });
@@ -106,4 +112,42 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
     );
     expect(markReady).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    {
+      label: "explicit daemon start",
+      run: () => daemonCommand(parseArgs(["daemon", "start"]), true),
+      source: daemonLaunch.CLI_DAEMON_LAUNCH_SOURCES.explicitStart,
+    },
+    {
+      label: "ensureDaemon project command",
+      run: () => projectCommand(parseArgs(["project", "list"]), true),
+      source: daemonLaunch.CLI_DAEMON_LAUNCH_SOURCES.ensureDaemon,
+    },
+  ])(
+    "projects real pre-claim stderr through the $label failure envelope",
+    async ({ run, source }) => {
+      const entry = join(configDir, `missing-import-${source}.mjs`);
+      writeFileSync(entry, 'await import("./projector-missing-module.mjs");\n');
+      process.env["CLAUDEXOR_DAEMON_ENTRY"] = entry;
+
+      const { code, env } = await captureJson(run);
+
+      expect(code).toBe(1);
+      expect(env).toMatchObject({
+        ok: false,
+        code: "daemon_start_failed",
+        context: {
+          launchSource: source,
+          failure: {
+            kind: "preclaim_exit",
+            stderr: { kind: "retained" },
+          },
+        },
+      });
+      expect(String(env["message"])).toMatch(/ERR_MODULE_NOT_FOUND|Cannot find module/);
+      expect(JSON.stringify(env)).toContain("projector-missing-module.mjs");
+      expect(existsSync(join(configDir, "daemon", "claudexord.log"))).toBe(false);
+    },
+  );
 });

--- a/packages/cli/src/ops-commands.projector.test.ts
+++ b/packages/cli/src/ops-commands.projector.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { ensureToken } from "@claudexor/daemon";
+import { ensureToken, logPath } from "@claudexor/daemon";
 import { parseArgs } from "./args.js";
 import { CliError } from "./cli-error.js";
 import * as daemonLaunch from "./daemon-launch.js";
@@ -78,6 +78,22 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
     expect(env["exitCode"]).toBe(2);
     expect(String(env["message"])).toContain("usage: claudexor daemon");
     expect(env["error"]).toBe(env["message"]);
+  });
+
+  it("`daemon logs` projects typed omission instead of bytes from an oversized legacy log", async () => {
+    mkdirSync(join(configDir, "daemon"), { recursive: true, mode: 0o700 });
+    writeFileSync(logPath(), "x".repeat(256 * 1024 + 1), { mode: 0o600 });
+
+    const { code, env } = await captureJson(() =>
+      daemonCommand(parseArgs(["daemon", "logs"]), true),
+    );
+
+    expect(code).toBe(0);
+    expect(env).toEqual({
+      ok: true,
+      log_tail:
+        "[daemon diagnostic tail omitted: oversize_omitted; 262145 bytes exceeds the 262144-byte safe read limit]\n",
+    });
   });
 
   it("`daemon start` uses the shared detached adapter with explicit-start provenance", async () => {

--- a/packages/cli/src/ops-commands.projector.test.ts
+++ b/packages/cli/src/ops-commands.projector.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ensureToken } from "@claudexor/daemon";
 import { parseArgs } from "./args.js";
+import { CliError } from "./cli-error.js";
 import * as daemonLaunch from "./daemon-launch.js";
 import * as daemonRun from "./daemon-run.js";
 import { daemonCommand } from "./ops-commands.js";
@@ -80,8 +81,12 @@ describe("ops-commands: ad-hoc failure envelopes route through the ONE projector
       pid: 12345,
       failure: () => null,
       markReady,
-      waitForFailure: async () => null,
-      callerError: () => new Error("unused"),
+      waitForFailure: async () => ({
+        kind: "preclaim_exit",
+        exitCode: 0,
+        signal: null,
+      }),
+      callerError: () => new CliError("operational", "unused"),
     });
     vi.spyOn(daemonRun, "waitForDaemonReady").mockResolvedValue({
       client: {} as never,

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -181,7 +181,7 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
   if (sub === "logs") {
     let tail: string;
     try {
-      tail = readDaemonDiagnosticTail({ path: logPath(), lines: 40 });
+      tail = readDaemonDiagnosticTail({ path: logPath(), lines: 40 }).text;
     } catch (err) {
       const message = `no daemon log at ${logPath()} (${err instanceof Error ? err.message : String(err)}); the daemon may not have started on this machine yet`;
       return renderCliFailure(json, new Error(message));

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -3,15 +3,11 @@
  * managed secret store. Thin surfaces — every action delegates to the daemon
  * client, gateway, or SecretStore; --json purity via cli-io.
  */
-import { spawn } from "node:child_process";
-import { closeSync, mkdirSync, openSync, readFileSync } from "node:fs";
-import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   DaemonClient,
   awaitDaemonTermination,
   defaultSocketPath,
-  ensureDaemonRuntimeRoot,
   inspectDaemonWriterLease,
   logPath,
   readToken,
@@ -35,6 +31,7 @@ import {
 import { type ParsedArgs, flagBool, flagStr } from "./args.js";
 import { CliError, controlProblemError, renderCliFailure, usageError } from "./cli-error.js";
 import { profilesCommand, secretsCommand } from "./credential-commands.js";
+import { CLI_DAEMON_LAUNCH_SOURCES, launchDetachedDaemon } from "./daemon-launch.js";
 import {
   authSourceAvailability,
   checksSummary,
@@ -46,6 +43,7 @@ import {
 import { DAEMON_START_READY_TIMEOUT_MS, ensureDaemon, waitForDaemonReady } from "./daemon-run.js";
 import { controlApiFetch } from "./live.js";
 import { streamDurableCodexLogin, terminalLoginFallback } from "./setup-login-inline.js";
+import { readDaemonDiagnosticTail } from "./startup-diagnostics.js";
 
 interface OperatorDaemonStopDeps {
   inspectLease: typeof inspectDaemonWriterLease;
@@ -138,38 +136,52 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
     const daemonScript =
       process.env["CLAUDEXOR_DAEMON_ENTRY"] ??
       fileURLToPath(new URL("./claudexord.js", import.meta.url));
-    // Startup stderr goes to the daemon log (append), not the void — a crash
-    // before the daemon's own logging starts must leave evidence for
-    // `claudexor daemon logs`.
-    ensureDaemonRuntimeRoot();
-    mkdirSync(dirname(logPath()), { recursive: true });
-    const stderrFd = openSync(logPath(), "a");
-    const child = spawn(process.execPath, [daemonScript], {
-      detached: true,
-      stdio: ["ignore", "ignore", stderrFd],
-      env: harnessRuntimeEnv(),
-    });
-    child.unref();
-    closeSync(stderrFd);
+    let launch;
+    try {
+      launch = launchDetachedDaemon({
+        entryPath: daemonScript,
+        launchSource: CLI_DAEMON_LAUNCH_SOURCES.explicitStart,
+        env: harnessRuntimeEnv(),
+      });
+    } catch (error) {
+      return renderCliFailure(json, error);
+    }
     // Block until the daemon (socket + control API) is actually ready, so a
     // follow-up `status`/run can't race the spawn. Fail loudly (exit 1) if it
     // never comes up.
-    const ready = await waitForDaemonReady(DAEMON_START_READY_TIMEOUT_MS);
-    if (json) {
-      printJson({ pid: child.pid ?? null, socket: defaultSocketPath(), ready: ready !== null });
-    } else if (ready) {
-      print(`claudexord ready (pid ${child.pid}); socket ${defaultSocketPath()}`);
-    } else {
-      print(
-        `claudexord started (pid ${child.pid}) but did not become ready within ${Math.round(DAEMON_START_READY_TIMEOUT_MS / 1000)}s; check \`claudexor daemon logs\``,
+    let ready;
+    try {
+      ready = await waitForDaemonReady(DAEMON_START_READY_TIMEOUT_MS, () =>
+        launch.failure()
+          ? launch.callerError("readiness_wait", DAEMON_START_READY_TIMEOUT_MS)
+          : null,
+      );
+    } catch (error) {
+      return renderCliFailure(json, error, {
+        extras: { pid: launch.pid, socket: defaultSocketPath(), ready: false },
+      });
+    }
+    if (!ready) {
+      return renderCliFailure(
+        json,
+        launch.callerError("readiness_wait", DAEMON_START_READY_TIMEOUT_MS),
+        {
+          extras: { pid: launch.pid, socket: defaultSocketPath(), ready: false },
+        },
       );
     }
-    return ready ? 0 : 1;
+    launch.markReady();
+    if (json) {
+      printJson({ pid: launch.pid, socket: defaultSocketPath(), ready: true });
+    } else {
+      print(`claudexord ready (pid ${launch.pid}); socket ${defaultSocketPath()}`);
+    }
+    return 0;
   }
   if (sub === "logs") {
     let tail: string;
     try {
-      tail = readFileSync(logPath(), "utf8").split("\n").slice(-40).join("\n");
+      tail = readDaemonDiagnosticTail({ path: logPath(), lines: 40 });
     } catch (err) {
       const message = `no daemon log at ${logPath()} (${err instanceof Error ? err.message : String(err)}); the daemon may not have started on this machine yet`;
       return renderCliFailure(json, new Error(message));

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -12,6 +12,7 @@ import {
   awaitDaemonTermination,
   defaultSocketPath,
   ensureDaemonRuntimeRoot,
+  inspectDaemonWriterLease,
   logPath,
   readToken,
   rotateToken,
@@ -45,6 +46,28 @@ import {
 import { DAEMON_START_READY_TIMEOUT_MS, ensureDaemon, waitForDaemonReady } from "./daemon-run.js";
 import { controlApiFetch } from "./live.js";
 import { streamDurableCodexLogin, terminalLoginFallback } from "./setup-login-inline.js";
+
+interface OperatorDaemonStopDeps {
+  inspectLease: typeof inspectDaemonWriterLease;
+  shutdown(): Promise<unknown>;
+  awaitTermination: typeof awaitDaemonTermination;
+}
+
+/** Pin strict signal authority before the asynchronous operator-stop RPC. */
+export async function stopDaemonForOperator(
+  socketPath: string,
+  deps: OperatorDaemonStopDeps,
+): ReturnType<typeof awaitDaemonTermination> {
+  const lease = deps.inspectLease(socketPath);
+  const expectedOwner =
+    lease.status === "owned" && lease.capability.status === "capable" ? lease.owner : null;
+  await deps.shutdown();
+  return deps.awaitTermination(socketPath, {
+    allowSigkill: expectedOwner !== null,
+    ...(expectedOwner === null ? {} : { expectedOwner }),
+    requireNoSuccessor: false,
+  });
+}
 
 export function dispatchOpsCommand(
   command: string,
@@ -172,14 +195,13 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
       return 0;
     }
     if (sub === "stop") {
-      await client.shutdown();
       // "stop requested" is not "stopped" (W3.5): confirm the daemon's death
       // before reporting success, so scripts and test disposers can trust the
       // exit code instead of racing a still-live process.
-      const termination = await awaitDaemonTermination(defaultSocketPath(), {
-        // This command is the user's explicit forceful operator stop. Runtime
-        // replacement never inherits this signal authority implicitly.
-        allowSigkill: true,
+      const termination = await stopDaemonForOperator(defaultSocketPath(), {
+        inspectLease: inspectDaemonWriterLease,
+        shutdown: () => client.shutdown(),
+        awaitTermination: awaitDaemonTermination,
       });
       if (termination.outcome === "still_alive") {
         // D-7 projector: one failure envelope; the stop-state facts ride as

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -29,6 +29,7 @@ import {
   GitCapability,
 } from "@claudexor/schema";
 import { type ParsedArgs, flagBool, flagStr } from "./args.js";
+import { harnessListPath, requestedHarnesses, unknownHarnesses } from "./ops-harness-selection.js";
 import { CliError, controlProblemError, renderCliFailure, usageError } from "./cli-error.js";
 import { profilesCommand, secretsCommand } from "./credential-commands.js";
 import { CLI_DAEMON_LAUNCH_SOURCES, launchDetachedDaemon } from "./daemon-launch.js";
@@ -268,31 +269,6 @@ export async function daemonGet(path: string): Promise<unknown> {
     throw new Error(`control API ${path} failed (${response.status}): ${await response.text()}`);
   }
   return response.json();
-}
-
-function requestedHarnesses(args: ParsedArgs): string[] | undefined {
-  const only = flagStr(args, "harness");
-  return only
-    ? only
-        .split(",")
-        .map((id) => id.trim())
-        .filter(Boolean)
-    : undefined;
-}
-
-function harnessListPath(args: ParsedArgs, fresh = false): string {
-  const query = new URLSearchParams();
-  if (fresh) query.set("fresh", "true");
-  if (flagBool(args, "all")) query.set("all", "true");
-  for (const id of requestedHarnesses(args) ?? []) query.append("harness", id);
-  const encoded = query.toString();
-  return `/harnesses${encoded ? `?${encoded}` : ""}`;
-}
-
-function unknownHarnesses(requested: string[] | undefined, observed: string[]): string[] {
-  if (!requested) return [];
-  const known = new Set(observed);
-  return requested.filter((id) => !known.has(id));
 }
 
 export async function doctorCommand(args: ParsedArgs, json: boolean): Promise<number> {

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -109,14 +109,21 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
         await new DaemonClient(defaultSocketPath(), existingToken).health();
         const existingReady = await waitForDaemonReady(5_000);
         if (existingReady) {
+          const servingMode = existingReady.engine.servingMode;
           if (json)
             printJson({
               pid: null,
               socket: defaultSocketPath(),
               ready: true,
               alreadyRunning: true,
+              servingMode,
             });
-          else print(`claudexord already running; socket ${defaultSocketPath()}`);
+          else
+            print(
+              servingMode === "recovery_only"
+                ? `claudexord already running and serving recovery only — product routes are closed until journal recovery completes; socket ${defaultSocketPath()}`
+                : `claudexord already running; socket ${defaultSocketPath()}`,
+            );
           return 0;
         }
         if (json)
@@ -172,10 +179,17 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
       );
     }
     launch.markReady();
+    // C7c: report the admission mode honestly — a recovery-only daemon came
+    // up (exit 0) but product routes are closed until recovery completes.
+    const servingMode = ready.engine.servingMode;
     if (json) {
-      printJson({ pid: launch.pid, socket: defaultSocketPath(), ready: true });
+      printJson({ pid: launch.pid, socket: defaultSocketPath(), ready: true, servingMode });
     } else {
-      print(`claudexord ready (pid ${launch.pid}); socket ${defaultSocketPath()}`);
+      print(
+        servingMode === "recovery_only"
+          ? `claudexord started (pid ${launch.pid}) and is serving recovery only — product routes are closed until journal recovery completes; socket ${defaultSocketPath()}`
+          : `claudexord ready (pid ${launch.pid}); socket ${defaultSocketPath()}`,
+      );
     }
     return 0;
   }

--- a/packages/cli/src/ops-commands.ts
+++ b/packages/cli/src/ops-commands.ts
@@ -33,6 +33,7 @@ import { harnessListPath, requestedHarnesses, unknownHarnesses } from "./ops-har
 import { CliError, controlProblemError, renderCliFailure, usageError } from "./cli-error.js";
 import { profilesCommand, secretsCommand } from "./credential-commands.js";
 import { CLI_DAEMON_LAUNCH_SOURCES, launchDetachedDaemon } from "./daemon-launch.js";
+import { reportDaemonStartReady } from "./daemon-start-report.js";
 import {
   authSourceAvailability,
   checksSummary,
@@ -109,21 +110,13 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
         await new DaemonClient(defaultSocketPath(), existingToken).health();
         const existingReady = await waitForDaemonReady(5_000);
         if (existingReady) {
-          const servingMode = existingReady.engine.servingMode;
-          if (json)
-            printJson({
-              pid: null,
-              socket: defaultSocketPath(),
-              ready: true,
-              alreadyRunning: true,
-              servingMode,
-            });
-          else
-            print(
-              servingMode === "recovery_only"
-                ? `claudexord already running and serving recovery only — product routes are closed until journal recovery completes; socket ${defaultSocketPath()}`
-                : `claudexord already running; socket ${defaultSocketPath()}`,
-            );
+          reportDaemonStartReady({
+            json,
+            socket: defaultSocketPath(),
+            servingMode: existingReady.engine.servingMode,
+            pid: null,
+            alreadyRunning: true,
+          });
           return 0;
         }
         if (json)
@@ -179,18 +172,13 @@ export async function daemonCommand(args: ParsedArgs, json: boolean): Promise<nu
       );
     }
     launch.markReady();
-    // C7c: report the admission mode honestly — a recovery-only daemon came
-    // up (exit 0) but product routes are closed until recovery completes.
-    const servingMode = ready.engine.servingMode;
-    if (json) {
-      printJson({ pid: launch.pid, socket: defaultSocketPath(), ready: true, servingMode });
-    } else {
-      print(
-        servingMode === "recovery_only"
-          ? `claudexord started (pid ${launch.pid}) and is serving recovery only — product routes are closed until journal recovery completes; socket ${defaultSocketPath()}`
-          : `claudexord ready (pid ${launch.pid}); socket ${defaultSocketPath()}`,
-      );
-    }
+    reportDaemonStartReady({
+      json,
+      socket: defaultSocketPath(),
+      servingMode: ready.engine.servingMode,
+      pid: launch.pid,
+      alreadyRunning: false,
+    });
     return 0;
   }
   if (sub === "logs") {

--- a/packages/cli/src/ops-harness-selection.ts
+++ b/packages/cli/src/ops-harness-selection.ts
@@ -1,0 +1,27 @@
+import { type ParsedArgs, flagBool, flagStr } from "./args.js";
+
+/** `--harness a,b` selection shared by doctor/models/auth ops commands. */
+export function requestedHarnesses(args: ParsedArgs): string[] | undefined {
+  const only = flagStr(args, "harness");
+  return only
+    ? only
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean)
+    : undefined;
+}
+
+export function harnessListPath(args: ParsedArgs, fresh = false): string {
+  const query = new URLSearchParams();
+  if (fresh) query.set("fresh", "true");
+  if (flagBool(args, "all")) query.set("all", "true");
+  for (const id of requestedHarnesses(args) ?? []) query.append("harness", id);
+  const encoded = query.toString();
+  return `/harnesses${encoded ? `?${encoded}` : ""}`;
+}
+
+export function unknownHarnesses(requested: string[] | undefined, observed: string[]): string[] {
+  if (!requested) return [];
+  const known = new Set(observed);
+  return requested.filter((id) => !known.has(id));
+}

--- a/packages/cli/src/orphan-sweeper.test.ts
+++ b/packages/cli/src/orphan-sweeper.test.ts
@@ -139,6 +139,24 @@ describe("crash-GC live-owner guard", () => {
     }
   });
 
+  it("is strictly read-only on a clean root: no journal file is created and nothing is swept (C1b)", async () => {
+    const stateDir = mkdtempSync(join(tmpdir(), "claudexor-sweep-state-"));
+    try {
+      // A FRESH root has no journal tree at all. The sweep runs between the
+      // startup's read-only preparation and its prepared activation, so any
+      // file it creates here fails activation's revalidation and traps the
+      // root on the recovery plane.
+      const journalRoot = join(realpathSync(stateDir), "journal");
+      const actions = await sweepOrphanWorkspaces({ journalRoot });
+      // No project root is known on a clean root, so no envelope/branch action
+      // may appear (the shared tmpdir ro-home sweep is environment-owned).
+      expect(actions.filter((action) => !action.includes("stale tmp dir"))).toEqual([]);
+      expect(existsSync(journalRoot)).toBe(false);
+    } finally {
+      rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("startup sweep removes a dead in-place run's marked artifact child and preserves siblings", async () => {
     const root = initRepo();
     const stateDir = mkdtempSync(join(tmpdir(), "claudexor-sweep-state-"));

--- a/packages/cli/src/orphan-sweeper.ts
+++ b/packages/cli/src/orphan-sweeper.ts
@@ -23,7 +23,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WorkspaceManager, git, processStartTime } from "@claudexor/workspace";
 import { projectRuntimeDir } from "@claudexor/util";
-import { DurableJournal } from "@claudexor/journal";
+import { DurableJournal, journalPartitionDirectory } from "@claudexor/journal";
 
 const RO_HOME_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
@@ -46,12 +46,22 @@ export async function sweepOrphanWorkspaces(input: SweepInput): Promise<string[]
   return actions;
 }
 
-/** Project roots this daemon has ever run against (command journal scope roots). */
+/** Project roots this daemon has ever run against (command journal scope roots).
+ *
+ * STRICTLY READ-ONLY: crash-GC runs inside the two-stage startup BETWEEN the
+ * read-only preparation and the prepared activation, so this scan must never
+ * create or open-for-write anything under the journal tree. (Opening a writer
+ * here used to create journal.bin on a clean root, which failed activation's
+ * revalidation and trapped every FRESH root on the recovery plane.) An absent
+ * global journal means no known roots; an unreadable one means no sweep. */
 function knownProjectRoots(journalRoot: string): string[] {
   const roots = new Set<string>();
+  if (!existsSync(join(journalPartitionDirectory(journalRoot, "global"), "journal.bin"))) {
+    return [];
+  }
   let journal: DurableJournal | null = null;
   try {
-    journal = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    journal = DurableJournal.prepare({ rootDir: journalRoot, partition: "global" });
     for (const entry of journal.records()) {
       if (entry.type !== "command.accepted") continue;
       const payload = entry.payload as { record?: { params?: unknown } };

--- a/packages/cli/src/remote-command.test.ts
+++ b/packages/cli/src/remote-command.test.ts
@@ -9,12 +9,28 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { type DaemonWriterLeaseStatus } from "@claudexor/daemon";
 import {
   assertRemoteEngineIdentity,
   claimSetupAttachment,
+  stopRemoteDaemonForRuntimeReplacement,
   switchRemoteRuntimePointer,
 } from "./remote-command.js";
+
+const STALE_LEASE = {
+  status: "owned",
+  path: "/tmp/claudexord.sock.writer",
+  owner: { pid: 4242, token: "stale-owner" },
+  capability: {
+    status: "proven_stale",
+    reason: "process_missing",
+    observation: {
+      identity: { status: "missing", pid: 4242, platform: "linux" },
+      linuxState: null,
+    },
+  },
+} satisfies DaemonWriterLeaseStatus;
 
 describe("remote setup attach", () => {
   it("claims a sealed client PTY job exactly once with a private marker", () => {
@@ -45,6 +61,40 @@ describe("remote runtime lifecycle", () => {
     expect(() =>
       assertRemoteEngineIdentity({ engineVersion: null, engineBuildSha: null }, "3.4.0", sha),
     ).toThrow(/identity mismatch/);
+  });
+
+  it("wires the shared no-Control policy for an unreachable proven-stale lease", async () => {
+    const output: string[] = [];
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation((value: unknown) => {
+      output.push(String(value));
+      return true;
+    });
+    let inspections = 0;
+    try {
+      await expect(
+        stopRemoteDaemonForRuntimeReplacement("3.4.0", "a".repeat(40), {
+          connect: async () => null,
+          socketPath: () => "/tmp/claudexord.sock",
+          socketReachable: async (path) => {
+            expect(path).toBe("/tmp/claudexord.sock");
+            return false;
+          },
+          inspectLease: (path) => {
+            expect(path).toBe("/tmp/claudexord.sock");
+            inspections += 1;
+            return STALE_LEASE;
+          },
+        }),
+      ).resolves.toBe(0);
+      expect(inspections).toBe(1);
+      expect(JSON.parse(output.join(""))).toEqual({
+        ok: true,
+        stopped: true,
+        alreadyStopped: true,
+      });
+    } finally {
+      stdout.mockRestore();
+    }
   });
 
   it("atomically CAS-switches immutable activation and rollback pointers", () => {

--- a/packages/cli/src/remote-command.ts
+++ b/packages/cli/src/remote-command.ts
@@ -14,12 +14,13 @@ import { arch, homedir, platform } from "node:os";
 import { join } from "node:path";
 import { CLAUDEXOR_VERSION } from "@claudexor/util";
 import {
+  type DaemonWriterLeaseStatus,
   type RuntimeReplacementIdentity,
   type RuntimeReplacementTarget,
   awaitDaemonTermination,
-  daemonLeaseOwner,
   daemonDir,
   defaultSocketPath,
+  inspectDaemonWriterLease,
   socketAlive,
 } from "@claudexor/daemon";
 import { type ParsedArgs } from "./args.js";
@@ -27,7 +28,11 @@ import { ensureDaemon, connectDaemonIfRunning } from "./daemon-run.js";
 import { controlApiFetch, CONTROL_PROTOCOL_MAJOR, handshakeControlApi } from "./live.js";
 import { printJson, printUsageError } from "./cli-io.js";
 import { resolveSetupLoginRunnerPath } from "./setup-job-support.js";
-import { admitAndAwaitRuntimeReplacementStop } from "./runtime-replacement-stop.js";
+import {
+  admitAndAwaitRuntimeReplacementStop,
+  decideRuntimeReplacementWithoutControl,
+  runtimeReplacementCapableOwner,
+} from "./runtime-replacement-stop.js";
 
 function runtimeTarget(): string {
   return `${platform()}-${arch()}`;
@@ -92,20 +97,57 @@ export function assertRemoteEngineIdentity(
   return { version: expectedVersion, buildSha: expectedBuildSha };
 }
 
-async function stop(expectedVersion: string, expectedBuildSha: string): Promise<number> {
-  const daemon = await connectDaemonIfRunning();
+interface RemoteRuntimeStopDeps {
+  connect(): ReturnType<typeof connectDaemonIfRunning>;
+  socketPath(): string;
+  socketReachable(path: string): Promise<boolean>;
+  inspectLease(path: string): DaemonWriterLeaseStatus;
+}
+
+const productionRemoteRuntimeStopDeps: RemoteRuntimeStopDeps = {
+  connect: connectDaemonIfRunning,
+  socketPath: defaultSocketPath,
+  socketReachable: socketAlive,
+  inspectLease: inspectDaemonWriterLease,
+};
+
+function runtimeActivityUnknown(message: string): Error {
+  return Object.assign(new Error(message), {
+    code: "runtime_activity_unknown",
+    status: 503,
+    retryable: true,
+  });
+}
+
+export async function stopRemoteDaemonForRuntimeReplacement(
+  expectedVersion: string,
+  expectedBuildSha: string,
+  deps: RemoteRuntimeStopDeps = productionRemoteRuntimeStopDeps,
+): Promise<number> {
+  const socketPath = deps.socketPath();
+  const daemon = await deps.connect();
   if (!daemon) {
-    if (daemonLeaseOwner(defaultSocketPath()) || (await socketAlive(defaultSocketPath()))) {
-      throw new Error("remote daemon is running but its Control API identity cannot be verified");
+    const decision = decideRuntimeReplacementWithoutControl(
+      await deps.socketReachable(socketPath),
+      deps.inspectLease(socketPath),
+    );
+    if (decision.status === "activity_unknown") {
+      throw runtimeActivityUnknown(decision.detail);
     }
     printJson({ ok: true, stopped: true, alreadyStopped: true });
     return 0;
   }
   const identity = await handshakeControlApi(daemon.addr, "claudexor-macos-remote-stop");
   const expectedIdentity = assertRemoteEngineIdentity(identity, expectedVersion, expectedBuildSha);
-  const expectedOwner = daemonLeaseOwner(defaultSocketPath());
+  // Bind the target from a fresh strict inspection immediately before the
+  // target-bound admission RPC. Control reachability cannot upgrade an
+  // absent, stale, or unknown lease into signal authority.
+  const lease = deps.inspectLease(socketPath);
+  const expectedOwner = runtimeReplacementCapableOwner(lease);
   if (!expectedOwner) {
-    throw new Error("remote daemon is live but its writer-lease identity cannot be verified");
+    throw runtimeActivityUnknown(
+      "remote daemon is live but its writer-lease activity cannot be verified",
+    );
   }
   const expectedTarget: RuntimeReplacementTarget = {
     ...expectedIdentity,
@@ -113,7 +155,7 @@ async function stop(expectedVersion: string, expectedBuildSha: string): Promise<
   };
   const termination = await admitAndAwaitRuntimeReplacementStop(
     () => daemon.client.shutdownForRuntimeReplacement(expectedTarget),
-    (options) => awaitDaemonTermination(defaultSocketPath(), options),
+    (options) => awaitDaemonTermination(socketPath, options),
     expectedOwner,
   );
   if (termination.outcome === "still_alive") {
@@ -216,7 +258,7 @@ export async function remoteCommand(args: ParsedArgs, json: boolean): Promise<nu
         "usage: claudexor remote stop <expectedVersion> <expectedBuildSha> --json",
       );
     }
-    return stop(expectedVersion, expectedBuildSha);
+    return stopRemoteDaemonForRuntimeReplacement(expectedVersion, expectedBuildSha);
   }
   if (sub === "activate" || sub === "rollback") {
     const expected = args._[2];

--- a/packages/cli/src/remote-command.ts
+++ b/packages/cli/src/remote-command.ts
@@ -53,6 +53,14 @@ function endpointPort(baseUrl: string): number {
 async function bootstrap(): Promise<number> {
   const { addr } = await ensureDaemon();
   const identity = await handshakeControlApi(addr, "claudexor-macos-remote");
+  // C7b: publication requires NORMAL serving (absent = normal for pre-#165
+  // daemons). A recovery-only remote must never be published to the app.
+  if (identity.servingMode !== "normal") {
+    throw Object.assign(
+      new Error("remote daemon is serving recovery only; publication requires normal serving"),
+      { code: "daemon_recovery_only", status: 503, retryable: true },
+    );
+  }
   printJson({
     ok: true,
     target: runtimeTarget(),

--- a/packages/cli/src/runtime-replacement-stop.ts
+++ b/packages/cli/src/runtime-replacement-stop.ts
@@ -2,11 +2,12 @@ import {
   type AwaitDaemonTerminationOptions,
   type DaemonTerminationOutcome,
   type DaemonLeaseOwner,
+  type DaemonWriterLeaseStatus,
   DaemonClient,
-  daemonLeaseOwner,
   type RuntimeReplacementTarget,
   awaitDaemonTermination,
   defaultSocketPath,
+  inspectDaemonWriterLease,
   readToken,
   socketAlive,
 } from "@claudexor/daemon";
@@ -15,7 +16,7 @@ interface RuntimeReplacementStopDeps {
   socketPath(): string;
   readToken(): string | null;
   socketAlive(path: string): Promise<boolean>;
-  leaseOwner(path: string): DaemonLeaseOwner | null;
+  inspectLease(path: string): DaemonWriterLeaseStatus;
   client(path: string, token: string): Pick<DaemonClient, "shutdownForRuntimeReplacement">;
   awaitTermination(
     path: string,
@@ -28,7 +29,7 @@ const productionDeps: RuntimeReplacementStopDeps = {
   socketPath: defaultSocketPath,
   readToken,
   socketAlive,
-  leaseOwner: daemonLeaseOwner,
+  inspectLease: inspectDaemonWriterLease,
   client: (path, token) => new DaemonClient(path, token),
   awaitTermination: awaitDaemonTermination,
   write: (line) => process.stdout.write(line),
@@ -88,6 +89,47 @@ function writeRefusal(
 ): void {
   deps.write(`${JSON.stringify({ stopped: false, code, retryable: true, detail })}\n`);
   process.exitCode = 1;
+}
+
+/** Shared no-Control decision for local and remote runtime replacement.
+ * This policy never selects a target: only a physically absent or positively
+ * stale lease alongside an unreachable socket proves idempotent stop. */
+export function decideRuntimeReplacementWithoutControl(
+  socketReachable: boolean,
+  lease: DaemonWriterLeaseStatus,
+): { status: "already_stopped" } | { status: "activity_unknown"; detail: string } {
+  if (socketReachable) {
+    return {
+      status: "activity_unknown",
+      detail: "runtime replacement found a reachable daemon socket without verified Control",
+    };
+  }
+  if (
+    lease.status === "absent" ||
+    (lease.status === "owned" && lease.capability.status === "proven_stale")
+  ) {
+    return { status: "already_stopped" };
+  }
+  if (lease.status === "unknown") {
+    return {
+      status: "activity_unknown",
+      detail: `runtime replacement cannot verify writer-lease authority (${lease.reason})`,
+    };
+  }
+  return {
+    status: "activity_unknown",
+    detail:
+      lease.capability.status === "capable"
+        ? "runtime replacement found a capable writer lease but no reachable daemon socket"
+        : "runtime replacement cannot verify writer-lease activity",
+  };
+}
+
+/** Package-private projection for the authenticated local and remote paths. */
+export function runtimeReplacementCapableOwner(
+  lease: DaemonWriterLeaseStatus,
+): DaemonLeaseOwner | null {
+  return lease.status === "owned" && lease.capability.status === "capable" ? lease.owner : null;
 }
 
 /** One owner for the admission/termination uncertainty boundary used by both
@@ -156,16 +198,9 @@ export async function runStopIfRequested(
   const socketPath = deps.socketPath();
   const alive = await deps.socketAlive(socketPath);
   if (!alive) {
-    // A daemon claims the writer lease before it binds the socket. Treating the
-    // boot window as absence would let the installer move the runtime pointer
-    // beneath that live process. Idempotent success therefore requires both
-    // surfaces to prove absence, matching the remote replacement path.
-    if (deps.leaseOwner(socketPath)) {
-      writeRefusal(
-        deps,
-        "runtime_activity_unknown",
-        "runtime replacement found a writer lease but no reachable daemon socket",
-      );
+    const decision = decideRuntimeReplacementWithoutControl(false, deps.inspectLease(socketPath));
+    if (decision.status === "activity_unknown") {
+      writeRefusal(deps, "runtime_activity_unknown", decision.detail);
       return true;
     }
     deps.write(`${JSON.stringify({ stopped: true, alreadyStopped: true })}\n`);
@@ -173,14 +208,17 @@ export async function runStopIfRequested(
   }
   const token = deps.readToken();
   if (!token) {
-    writeRefusal(
-      deps,
-      "runtime_activity_unknown",
-      "runtime replacement cannot authenticate to the live daemon",
-    );
-    return true;
+    const decision = decideRuntimeReplacementWithoutControl(true, deps.inspectLease(socketPath));
+    if (decision.status === "activity_unknown") {
+      writeRefusal(deps, "runtime_activity_unknown", decision.detail);
+      return true;
+    }
+    throw new Error("reachable socket unexpectedly classified as already stopped");
   }
-  const expectedOwner = deps.leaseOwner(socketPath);
+  // Select the target from a fresh strict inspection immediately before the
+  // target-bound admission RPC. Stale, absent, or unknown authority cannot be
+  // turned into a signal target even when the socket itself is reachable.
+  const expectedOwner = runtimeReplacementCapableOwner(deps.inspectLease(socketPath));
   if (!expectedOwner) {
     writeRefusal(
       deps,

--- a/packages/cli/src/setup-lifecycle-binding.test.ts
+++ b/packages/cli/src/setup-lifecycle-binding.test.ts
@@ -187,6 +187,61 @@ describe("SetupLifecycleBinding", () => {
     expect(events).toEqual(["start:1", "drain:1", "shutdown:1", "start:1"]);
   });
 
+  it("keeps the replacement-bound supervisor when startup's start() arrives afterwards (S2-CR2)", async () => {
+    // Global-reopen sequence: the daemon starts recovery_only (start() never
+    // ran), the quarantine route binds+starts supervisor #1 via replaceAfter,
+    // then the in-process reopen's onNormalAdmission calls startSetup() =
+    // start(). start() must NOT create a second supervisor over the same
+    // store and orphan the running one.
+    let generation = 1;
+    const events: string[] = [];
+    const handles: FakeHandle[] = [];
+    const slot = {
+      current: () => ({ generation }),
+      generation: () => generation,
+    };
+    const binding = new SetupLifecycleBinding(slot, (store) => {
+      const handle = new FakeHandle(store.generation, events);
+      handles.push(handle);
+      return handle;
+    });
+
+    await binding.replaceAfter(() => {
+      generation = 2;
+      events.push("quarantine");
+      return "receipt";
+    });
+    const bound = binding.current();
+    await binding.start();
+
+    expect(binding.current()).toBe(bound);
+    expect(handles).toHaveLength(1);
+    await binding.shutdown();
+    // Exactly one live supervisor existed and shutdown drained IT.
+    expect(events).toEqual(["quarantine", "start:2", "drain:2", "shutdown:2"]);
+  });
+
+  it("refuses to bind a fresh supervisor once drain or shutdown began (S2-CR2)", async () => {
+    const events: string[] = [];
+    const handles: FakeHandle[] = [];
+    const slot = {
+      current: () => ({ generation: 1 }),
+      generation: () => 1,
+    };
+    const binding = new SetupLifecycleBinding(slot, (store) => {
+      const handle = new FakeHandle(store.generation, events);
+      handles.push(handle);
+      return handle;
+    });
+    await binding.start();
+    await binding.shutdown();
+
+    await binding.start();
+    expect(handles).toHaveLength(1);
+    expect(() => binding.current()).toThrowError(/unavailable/);
+    expect(events).toEqual(["start:1", "drain:1", "shutdown:1"]);
+  });
+
   it("does not advertise a generation whose replacement supervisor failed to start", async () => {
     let generation = 1;
     const events: string[] = [];

--- a/packages/cli/src/setup-lifecycle-binding.ts
+++ b/packages/cli/src/setup-lifecycle-binding.ts
@@ -29,22 +29,31 @@ export class SetupLifecycleBinding<TStore, THandle extends SetupLifecycleHandle>
     private readonly create: (store: TStore) => THandle,
   ) {}
 
-  /** Start the initial supervisor when the projection is healthy. */
-  async start(): Promise<void> {
-    let store: TStore;
-    try {
-      store = this.slot.current();
-    } catch (error) {
-      // A corrupt partition is a supported degraded startup. Calling
-      // current() later reproduces the typed recovery error for every setup
-      // route while the recovery plane remains available.
-      if (error instanceof JournalRecoveryRequiredError) return;
-      throw error;
-    }
-    const handle = this.create(store);
-    this.active = handle;
-    this.activeGeneration = this.slot.generation();
-    await handle.start();
+  /** Start the initial supervisor when the projection is healthy. Serialized
+   * with replaceAfter/shutdown and IDEMPOTENT (S2-CR2): on the global-reopen
+   * path the quarantine route's replaceAfter already bound and started a
+   * supervisor before onNormalAdmission calls start() — that supervisor stays
+   * the live one instead of being orphaned mid-monitor-loop by a second
+   * handle over the same store. Once draining/shutdown began, start() stays
+   * refused so no undrainable supervisor can appear. */
+  start(): Promise<void> {
+    return this.exclusive(async () => {
+      if (this.active !== null || this.draining) return;
+      let store: TStore;
+      try {
+        store = this.slot.current();
+      } catch (error) {
+        // A corrupt partition is a supported degraded startup. Calling
+        // current() later reproduces the typed recovery error for every setup
+        // route while the recovery plane remains available.
+        if (error instanceof JournalRecoveryRequiredError) return;
+        throw error;
+      }
+      const handle = this.create(store);
+      this.active = handle;
+      this.activeGeneration = this.slot.generation();
+      await handle.start();
+    });
   }
 
   current(): THandle {

--- a/packages/cli/src/sibling-bundle-startup.test.ts
+++ b/packages/cli/src/sibling-bundle-startup.test.ts
@@ -26,7 +26,7 @@ function sha256(path: string): string {
 
 describe("self-contained sibling CLI/daemon bundle startup", () => {
   it.skipIf(process.platform === "win32")(
-    "starts, handshakes, and stops from an isolated root without writing outside config/repo",
+    "starts, handshakes, tails logs, and stops from an isolated sibling bundle",
     async () => {
       // Keep the default daemon socket below macOS' short AF_UNIX path limit.
       const root = mkdtempSync(join(realpathSync("/tmp"), "cx165-"));

--- a/packages/cli/src/sibling-bundle-startup.test.ts
+++ b/packages/cli/src/sibling-bundle-startup.test.ts
@@ -99,6 +99,10 @@ describe("self-contained sibling CLI/daemon bundle startup", () => {
         const status = run(["daemon", "status", "--json"]);
         expect(status.status, `${status.stdout}\n${status.stderr}`).toBe(0);
         expect(JSON.parse(status.stdout)).toMatchObject({ ok: true });
+        const logs = run(["daemon", "logs", "--json"]);
+        expect(logs.status, `${logs.stdout}\n${logs.stderr}`).toBe(0);
+        expect(JSON.parse(logs.stdout)).toMatchObject({ ok: true });
+        expect(JSON.parse(logs.stdout).log_tail).toContain("claudexor");
       } finally {
         const stopped = run(["daemon", "stop", "--json"]);
         if (started?.status === 0)

--- a/packages/cli/src/sibling-bundle-startup.test.ts
+++ b/packages/cli/src/sibling-bundle-startup.test.ts
@@ -1,0 +1,115 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { build } from "esbuild";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [];
+const repoRoot = resolve(import.meta.dirname, "../../..");
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function sha256(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+describe("self-contained sibling CLI/daemon bundle startup", () => {
+  it.skipIf(process.platform === "win32")(
+    "starts, handshakes, and stops from an isolated root without writing outside config/repo",
+    async () => {
+      // Keep the default daemon socket below macOS' short AF_UNIX path limit.
+      const root = mkdtempSync(join(realpathSync("/tmp"), "cx165-"));
+      roots.push(root);
+      const bundleDir = join(root, "bundle");
+      const configDir = join(root, "config");
+      const homeDir = join(root, "home");
+      const projectDir = join(root, "repo");
+      for (const path of [bundleDir, configDir, homeDir, projectDir])
+        mkdirSync(path, { recursive: true, mode: 0o700 });
+      const cli = join(bundleDir, "claudexor-cli.js");
+      const daemon = join(bundleDir, "claudexord.js");
+      const banner =
+        "import { createRequire as __cxCreateRequire } from 'node:module';\n" +
+        "import { fileURLToPath as __cxFileURLToPath } from 'node:url';\n" +
+        "import { dirname as __cxDirname } from 'node:path';\n" +
+        "const require = __cxCreateRequire(import.meta.url);\n" +
+        "const __filename = __cxFileURLToPath(import.meta.url);\n" +
+        "const __dirname = __cxDirname(__filename);";
+      for (const [entry, outfile] of [
+        [join(repoRoot, "packages", "cli", "dist", "cli.js"), cli],
+        [join(repoRoot, "packages", "cli", "dist", "claudexord.js"), daemon],
+      ] as const) {
+        await build({
+          entryPoints: [entry],
+          outfile,
+          bundle: true,
+          platform: "node",
+          format: "esm",
+          target: "node20",
+          banner: { js: banner },
+          logLevel: "silent",
+        });
+      }
+      const bundleHashes = new Map([cli, daemon].map((path) => [path, sha256(path)] as const));
+      const homeSentinel = join(homeDir, "sentinel");
+      writeFileSync(homeSentinel, "unchanged\n");
+      const {
+        CLAUDEXOR_DAEMON_ENTRY: _entry,
+        CLAUDEXOR_DAEMON_SOCK: _sock,
+        ...baseEnv
+      } = process.env;
+      const env = {
+        ...baseEnv,
+        HOME: homeDir,
+        CLAUDEXOR_CONFIG_DIR: configDir,
+        PATH: `${dirname(process.execPath)}:${process.env.PATH ?? ""}`,
+      };
+      const run = (args: string[]) =>
+        spawnSync(process.execPath, [cli, ...args], {
+          cwd: projectDir,
+          env,
+          encoding: "utf8",
+          timeout: 30_000,
+        });
+
+      let started: ReturnType<typeof run> | null = null;
+      try {
+        started = run(["daemon", "start", "--json"]);
+        const daemonLog = join(configDir, "daemon", "claudexord.log");
+        const logTail = (() => {
+          try {
+            return readFileSync(daemonLog, "utf8");
+          } catch {
+            return "<no daemon log>";
+          }
+        })();
+        expect(started.status, `${started.stdout}\n${started.stderr}\n${logTail}`).toBe(0);
+        expect(JSON.parse(started.stdout)).toMatchObject({ ready: true });
+        const status = run(["daemon", "status", "--json"]);
+        expect(status.status, `${status.stdout}\n${status.stderr}`).toBe(0);
+        expect(JSON.parse(status.stdout)).toMatchObject({ ok: true });
+      } finally {
+        const stopped = run(["daemon", "stop", "--json"]);
+        if (started?.status === 0)
+          expect(stopped.status, `${stopped.stdout}\n${stopped.stderr}`).toBe(0);
+      }
+
+      expect(readFileSync(homeSentinel, "utf8")).toBe("unchanged\n");
+      expect(readdirSync(projectDir)).toEqual([]);
+      for (const [path, hash] of bundleHashes) expect(sha256(path)).toBe(hash);
+      expect(readdirSync(root).sort()).toEqual(["bundle", "config", "home", "repo"]);
+    },
+    30_000,
+  );
+});

--- a/packages/cli/src/startup-diagnostics.test.ts
+++ b/packages/cli/src/startup-diagnostics.test.ts
@@ -1,0 +1,255 @@
+import {
+  chmodSync,
+  existsSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  openDaemonStartupDiagnosticsAfterAuthority,
+  readDaemonDiagnosticTail,
+  type DaemonStartupDiagnostics,
+} from "./startup-diagnostics.js";
+
+const roots: string[] = [];
+const writers: DaemonStartupDiagnostics[] = [];
+
+afterEach(() => {
+  for (const writer of writers.splice(0)) writer.close();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function root(): string {
+  const value = mkdtempSync(join(tmpdir(), "claudexor-startup-diagnostics-"));
+  roots.push(value);
+  return value;
+}
+
+function context(dataRoot: string, launchSource = "cli_ensure_daemon") {
+  return {
+    runtimeVersion: "3.3.15",
+    buildSha: "a".repeat(40),
+    entryPath: join(dataRoot, "runtime", "claudexord.js"),
+    pid: 4242,
+    dataRoot,
+    launchSource,
+  };
+}
+
+function open(
+  dataRoot: string,
+  overrides: Partial<{
+    path: string;
+    maxCurrentBytes: number;
+    maxRecordBytes: number;
+    platform: NodeJS.Platform;
+    uid: number;
+  }> = {},
+): DaemonStartupDiagnostics {
+  const path = overrides.path ?? join(dataRoot, "claudexord.log");
+  const writer = openDaemonStartupDiagnosticsAfterAuthority(context(dataRoot), {
+    path,
+    maxCurrentBytes: overrides.maxCurrentBytes ?? 8 * 1024,
+    maxRecordBytes: overrides.maxRecordBytes ?? 2 * 1024,
+    platform: overrides.platform ?? process.platform,
+    uid: overrides.uid ?? process.getuid?.(),
+    now: () => new Date("2026-08-13T12:34:56.000Z"),
+  });
+  writers.push(writer);
+  return writer;
+}
+
+function records(path: string): Record<string, unknown>[] {
+  const text = readFileSync(path, "utf8").trim();
+  return text ? text.split("\n").map((line) => JSON.parse(line) as Record<string, unknown>) : [];
+}
+
+describe("post-authority daemon startup diagnostics", () => {
+  it("creates the canonical current log privately and carries every required launch/stage fact", () => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    const writer = open(dataRoot, { path });
+
+    expect(writer.record({ stage: "root_authority_won", message: "diagnostics online" })).toBe(
+      true,
+    );
+    const [record] = records(path);
+    expect(record).toMatchObject({
+      timestamp: "2026-08-13T12:34:56.000Z",
+      runtimeVersion: "3.3.15",
+      buildSha: "a".repeat(40),
+      entryPath: context(dataRoot).entryPath,
+      pid: 4242,
+      dataRoot,
+      launchSource: "cli_ensure_daemon",
+      stage: "root_authority_won",
+      message: "diagnostics online",
+    });
+    if (process.getuid) expect(lstatSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it("migrates an owner-controlled legacy 0644 current log to 0600 on POSIX", () => {
+    if (!process.getuid) return;
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    writeFileSync(path, "legacy\n", { mode: 0o644 });
+    chmodSync(path, 0o644);
+
+    open(dataRoot, { path });
+
+    expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    expect(readFileSync(path, "utf8")).toBe("legacy\n");
+  });
+
+  it("refuses symlink, non-regular, hard-linked, and foreign-owner ambiguity without repair", () => {
+    const dataRoot = root();
+    const real = join(dataRoot, "real.log");
+    writeFileSync(real, "sentinel\n", { mode: 0o600 });
+
+    const symlink = join(dataRoot, "symlink.log");
+    symlinkSync(real, symlink);
+    expect(() => open(dataRoot, { path: symlink })).toThrow(/safe|symbolic|owner-controlled/i);
+    expect(readFileSync(real, "utf8")).toBe("sentinel\n");
+
+    const directory = join(dataRoot, "directory.log");
+    mkdirSync(directory);
+    expect(() => open(dataRoot, { path: directory })).toThrow(/regular|safe|owner-controlled/i);
+
+    const linked = join(dataRoot, "linked.log");
+    linkSync(real, linked);
+    expect(() => open(dataRoot, { path: linked })).toThrow(/singly-linked|owner-controlled|safe/i);
+
+    if (process.getuid) {
+      const foreign = join(dataRoot, "foreign.log");
+      writeFileSync(foreign, "foreign\n", { mode: 0o600 });
+      expect(() =>
+        open(dataRoot, { path: foreign, platform: process.platform, uid: process.getuid!() + 1 }),
+      ).toThrow(/owner|uid|private/i);
+      expect(readFileSync(foreign, "utf8")).toBe("foreign\n");
+    }
+  });
+
+  it("redacts the full failure before bounding the record and keeps a terminal failure class/stack", () => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    const writer = open(dataRoot, { path, maxCurrentBytes: 4 * 1024, maxRecordBytes: 1024 });
+    const token = `ghp_${"s".repeat(36)}`;
+    const error = new TypeError(`${"x".repeat(700)} ${token} ${"y".repeat(700)}`);
+
+    expect(
+      writer.record({
+        stage: "projection_prepare",
+        message: `${"m".repeat(700)} ${token} ${"n".repeat(700)}`,
+        error,
+      }),
+    ).toBe(true);
+
+    const raw = readFileSync(path, "utf8");
+    expect(Buffer.byteLength(raw)).toBeLessThanOrEqual(1024);
+    expect(raw).not.toContain(token);
+    expect(raw).toContain("[redacted]");
+    expect(records(path)[0]).toMatchObject({ failureClass: "TypeError" });
+  });
+
+  it.each([1023, 1024])("does not rotate a safe existing current file at %i bytes", (size) => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    writeFileSync(path, "x".repeat(size), { mode: 0o600 });
+    open(dataRoot, { path, maxCurrentBytes: 1024, maxRecordBytes: 512 });
+    expect(lstatSync(path).size).toBe(size);
+    expect(existsSync(`${path}.1`)).toBe(false);
+  });
+
+  it("bounds a cap+1 legacy current file without retaining oversized bytes", () => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    writeFileSync(path, "z".repeat(1025), { mode: 0o600 });
+    open(dataRoot, { path, maxCurrentBytes: 1024, maxRecordBytes: 512 });
+
+    expect(lstatSync(path).size).toBe(0);
+    expect(lstatSync(`${path}.1`).size).toBeLessThanOrEqual(1024);
+    expect(readFileSync(`${path}.1`, "utf8")).not.toContain("z".repeat(100));
+  });
+
+  it("retains only bounded current + one rotation across repeated writes", () => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    const writer = open(dataRoot, { path, maxCurrentBytes: 2048, maxRecordBytes: 512 });
+    for (let index = 0; index < 80; index += 1) {
+      expect(
+        writer.record({ stage: "startup_step", message: `${index}:${"payload".repeat(25)}` }),
+      ).toBe(true);
+    }
+
+    expect(lstatSync(path).size).toBeLessThanOrEqual(2048);
+    expect(lstatSync(`${path}.1`).size).toBeLessThanOrEqual(2048);
+    expect(existsSync(`${path}.2`)).toBe(false);
+    for (const candidate of [path, `${path}.1`]) {
+      for (const line of readFileSync(candidate, "utf8").trim().split("\n")) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    }
+  });
+
+  it("serializes same-process writes and refuses a second writer for the same canonical path", async () => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    const writer = open(dataRoot, {
+      path,
+      maxCurrentBytes: 128 * 1024,
+      maxRecordBytes: 1024,
+    });
+    expect(() => open(dataRoot, { path })).toThrow(/already active|one diagnostic writer/i);
+
+    await Promise.all(
+      Array.from({ length: 64 }, (_, index) =>
+        Promise.resolve().then(() =>
+          writer.record({ stage: "parallel_write", message: `record-${index}` }),
+        ),
+      ),
+    );
+
+    const parsed = records(path);
+    expect(parsed).toHaveLength(64);
+    expect(new Set(parsed.map((record) => record.message)).size).toBe(64);
+  });
+
+  it("reads a safe bounded tail through the same no-follow owner", () => {
+    const dataRoot = root();
+    const path = join(dataRoot, "claudexord.log");
+    const writer = open(dataRoot, {
+      path,
+      maxCurrentBytes: 128 * 1024,
+      maxRecordBytes: 1024,
+    });
+    for (let index = 0; index < 45; index += 1) {
+      writer.record({ stage: "tail", message: `line-${index}` });
+    }
+
+    const tail = readDaemonDiagnosticTail({ path, lines: 40 });
+    const parsed = tail
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(parsed).toHaveLength(40);
+    expect(parsed[0].message).toBe("line-5");
+    expect(parsed.at(-1).message).toBe("line-44");
+  });
+
+  it("keeps lifecycle safety independent from a diagnostic write after close", () => {
+    const dataRoot = root();
+    const writer = open(dataRoot);
+    writer.close();
+    expect(() => writer.record({ stage: "shutdown", message: "late" })).not.toThrow();
+    expect(writer.record({ stage: "shutdown", message: "late" })).toBe(false);
+    expect(writer.lastFailure()).toMatch(/closed/i);
+  });
+});

--- a/packages/cli/src/startup-diagnostics.test.ts
+++ b/packages/cli/src/startup-diagnostics.test.ts
@@ -19,6 +19,7 @@ import {
   type DaemonStartupDiagnostics,
 } from "./startup-diagnostics.js";
 
+const DIAGNOSTIC_TAIL_LIMIT_BYTES = 256 * 1024;
 const roots: string[] = [];
 const writers: DaemonStartupDiagnostics[] = [];
 
@@ -70,6 +71,34 @@ function open(
 function records(path: string): Record<string, unknown>[] {
   const text = readFileSync(path, "utf8").trim();
   return text ? text.split("\n").map((line) => JSON.parse(line) as Record<string, unknown>) : [];
+}
+
+function maximumBoundarySecrets(): Array<{ label: string; value: string }> {
+  const budget = DIAGNOSTIC_TAIL_LIMIT_BYTES - 192;
+  const dashes = "-----";
+  const pemHeader = `${dashes}BEGIN OPENSSH PRIVATE KEY${dashes}\n`;
+  const pemFooter = `\n${dashes}END OPENSSH PRIVATE KEY${dashes}`;
+  const jwtSegment = Math.floor((budget - 5) / 3);
+  return [
+    { label: "GitHub", value: `${"gh"}p_${"g".repeat(budget - 4)}` },
+    { label: "Anthropic", value: `${"sk"}-ant-${"a".repeat(budget - 7)}` },
+    { label: "Cursor", value: `${"key"}_${"c".repeat(budget - 4)}` },
+    { label: "Bearer", value: `${"Bear"}er ${"r".repeat(budget - 7)}` },
+    {
+      label: "Authorization Bearer",
+      value: `Authorization: ${"Bear"}er ${"b".repeat(budget - 22)}`,
+    },
+    {
+      label: "JWT",
+      value: `${"ey"}J${"j".repeat(jwtSegment - 3)}.${"k".repeat(jwtSegment)}.${"l".repeat(
+        jwtSegment,
+      )}`,
+    },
+    {
+      label: "multiline private key",
+      value: `${pemHeader}${"m".repeat(budget - pemHeader.length - pemFooter.length)}${pemFooter}`,
+    },
+  ];
 }
 
 describe("post-authority daemon startup diagnostics", () => {
@@ -234,8 +263,9 @@ describe("post-authority daemon startup diagnostics", () => {
       writer.record({ stage: "tail", message: `line-${index}` });
     }
 
-    const tail = readDaemonDiagnosticTail({ path, lines: 40 });
-    const parsed = tail
+    const result = readDaemonDiagnosticTail({ path, lines: 40 });
+    expect(result.kind).toBe("retained");
+    const parsed = result.text
       .trim()
       .split("\n")
       .map((line) => JSON.parse(line));
@@ -243,6 +273,60 @@ describe("post-authority daemon startup diagnostics", () => {
     expect(parsed[0].message).toBe("line-5");
     expect(parsed.at(-1).message).toBe("line-44");
   });
+
+  it.each([DIAGNOSTIC_TAIL_LIMIT_BYTES - 1, DIAGNOSTIC_TAIL_LIMIT_BYTES])(
+    "keeps normal tail behavior unchanged for a safe file of %i bytes",
+    (size) => {
+      const dataRoot = root();
+      const path = join(dataRoot, "claudexord.log");
+      const finalLines = Array.from({ length: 41 }, (_, index) => `safe-line-${index}`).join("\n");
+      const suffix = `\n${finalLines}\n`;
+      const raw = `${"x".repeat(size - Buffer.byteLength(suffix))}${suffix}`;
+      expect(Buffer.byteLength(raw)).toBe(size);
+      writeFileSync(path, raw, { mode: 0o600 });
+
+      const result = readDaemonDiagnosticTail({ path, lines: 40 });
+
+      expect(result).toMatchObject({ kind: "retained" });
+      expect(result.text.split("\n").filter(Boolean)).toEqual(
+        Array.from({ length: 40 }, (_, index) => `safe-line-${index + 1}`),
+      );
+    },
+  );
+
+  it.each(
+    maximumBoundarySecrets().flatMap(({ label, value }) =>
+      (["just_before", "at"] as const).map((position) => ({ label, value, position })),
+    ),
+  )(
+    "omits an oversized legacy log when a maximum-length $label secret starts $position the read window",
+    ({ value, position }) => {
+      const dataRoot = root();
+      const path = join(dataRoot, "claudexord.log");
+      // The historical implementation selected the last 256 KiB. At cap+1,
+      // that window starts at byte 1, so these cases place the secret exactly
+      // one byte before that boundary or exactly on it.
+      const prefix = position === "just_before" ? "" : "x";
+      const suffixBytes = DIAGNOSTIC_TAIL_LIMIT_BYTES + 1 - prefix.length - value.length;
+      expect(suffixBytes).toBeGreaterThan(0);
+      const raw = `${prefix}${value}${"z".repeat(suffixBytes)}`;
+      expect(Buffer.byteLength(raw)).toBe(DIAGNOSTIC_TAIL_LIMIT_BYTES + 1);
+      writeFileSync(path, raw, { mode: 0o600 });
+
+      const result = readDaemonDiagnosticTail({ path, lines: 40 });
+
+      expect(result).toEqual({
+        kind: "oversize_omitted",
+        observedBytes: DIAGNOSTIC_TAIL_LIMIT_BYTES + 1,
+        limitBytes: DIAGNOSTIC_TAIL_LIMIT_BYTES,
+        text: `[daemon diagnostic tail omitted: oversize_omitted; ${DIAGNOSTIC_TAIL_LIMIT_BYTES + 1} bytes exceeds the ${DIAGNOSTIC_TAIL_LIMIT_BYTES}-byte safe read limit]\n`,
+      });
+      expect(result.text).not.toContain(value.slice(0, 64));
+      expect(result.text).not.toContain(value.slice(-64));
+      expect(readFileSync(path, "utf8")).toBe(raw);
+      if (process.getuid) expect(lstatSync(path).mode & 0o777).toBe(0o600);
+    },
+  );
 
   it("keeps lifecycle safety independent from a diagnostic write after close", () => {
     const dataRoot = root();

--- a/packages/cli/src/startup-diagnostics.ts
+++ b/packages/cli/src/startup-diagnostics.ts
@@ -312,6 +312,14 @@ function writeOversizeDiscardReceipt(
   }
 }
 
+/** Coerce an environment-supplied launch source into a SAFE_LABEL value —
+ * "unknown" when absent or unsafe. Diagnostics never fail daemon startup, so
+ * a malformed environment must degrade to a safe label, not a throw. */
+export function safeDaemonLaunchSource(value: string | undefined): string {
+  const trimmed = value?.trim() ?? "";
+  return SAFE_LABEL.test(trimmed) ? trimmed : "unknown";
+}
+
 /** Open the canonical writer only after a separate root-authority owner won. */
 export function openDaemonStartupDiagnosticsAfterAuthority(
   context: DaemonStartupDiagnosticContext,

--- a/packages/cli/src/startup-diagnostics.ts
+++ b/packages/cli/src/startup-diagnostics.ts
@@ -1,0 +1,478 @@
+/**
+ * The bounded, private daemon startup diagnostic owner.
+ *
+ * This module deliberately does not acquire root authority. Its factory name
+ * and required call contract make the ordering explicit: only a daemon that
+ * already owns the data root may open the canonical log. Callers must treat
+ * every diagnostic failure as non-authoritative for daemon lifecycle safety.
+ */
+import {
+  closeSync,
+  constants,
+  fchmodSync,
+  fstatSync,
+  fsyncSync,
+  ftruncateSync,
+  lstatSync,
+  openSync,
+  readSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
+import { logPath as canonicalLogPath } from "@claudexor/daemon";
+import { redactSecrets, safeProblemMessage } from "@claudexor/util";
+
+const DEFAULT_CURRENT_BYTES = 256 * 1024;
+const DEFAULT_RECORD_BYTES = 16 * 1024;
+const MAX_TAIL_BYTES = DEFAULT_CURRENT_BYTES;
+const MAX_TAIL_LINES = 200;
+const MIN_RECORD_BYTES = 256;
+const SAFE_LABEL = /^[a-z0-9][a-z0-9._-]{0,127}$/;
+const activeWriters = new Set<string>();
+
+export interface DaemonStartupDiagnosticContext {
+  runtimeVersion: string;
+  buildSha: string;
+  entryPath: string;
+  pid: number;
+  dataRoot: string;
+  launchSource: string;
+}
+
+export interface DaemonStartupDiagnosticRecord {
+  stage: string;
+  message: string;
+  error?: unknown;
+}
+
+export interface DaemonStartupDiagnostics {
+  readonly path: string;
+  readonly rotatedPath: string;
+  record(record: DaemonStartupDiagnosticRecord): boolean;
+  close(): void;
+  lastFailure(): string | null;
+}
+
+export interface DaemonStartupDiagnosticOptions {
+  path?: string;
+  maxCurrentBytes?: number;
+  maxRecordBytes?: number;
+  platform?: NodeJS.Platform;
+  uid?: number;
+  now?: () => Date;
+}
+
+interface SafeFileOptions {
+  platform: NodeJS.Platform;
+  uid: number | undefined;
+  repairMode: boolean;
+  create: boolean;
+  exclusive?: boolean;
+  readOnly?: boolean;
+}
+
+function boundedPositiveInt(value: number, name: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer >= ${minimum}`);
+  }
+  return value;
+}
+
+function diagnosticError(message: string, error?: unknown): Error {
+  const detail = error === undefined ? "" : `: ${safeProblemMessage(error)}`;
+  return new Error(
+    `daemon diagnostic target is not safe and owner-controlled (${message})${detail}`,
+  );
+}
+
+function validatePrivateParent(path: string, platform: NodeJS.Platform, uid?: number): void {
+  const parent = dirname(path);
+  try {
+    const stat = lstatSync(parent);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw diagnosticError("parent is not a regular directory");
+    }
+    if (platform !== "win32" && uid !== undefined) {
+      if (stat.uid !== uid) throw diagnosticError("parent has a foreign uid");
+      if ((stat.mode & 0o077) !== 0) throw diagnosticError("parent permissions are not private");
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("daemon diagnostic target")) throw error;
+    throw diagnosticError("parent cannot be proven", error);
+  }
+}
+
+function validateOpenedPath(path: string, fd: number, options: SafeFileOptions): void {
+  const opened = fstatSync(fd);
+  const named = lstatSync(path);
+  if (
+    named.isSymbolicLink() ||
+    !opened.isFile() ||
+    !named.isFile() ||
+    opened.nlink !== 1 ||
+    named.nlink !== 1 ||
+    opened.dev !== named.dev ||
+    opened.ino !== named.ino
+  ) {
+    throw diagnosticError("target is not a singly-linked regular file");
+  }
+  if (
+    options.platform !== "win32" &&
+    options.uid !== undefined &&
+    (opened.uid !== options.uid || named.uid !== options.uid)
+  ) {
+    throw diagnosticError("target has a foreign uid");
+  }
+  if (options.platform !== "win32" && options.repairMode && (opened.mode & 0o777) !== 0o600) {
+    fchmodSync(fd, 0o600);
+    fsyncSync(fd);
+  }
+}
+
+function openSafeFile(path: string, options: SafeFileOptions): number {
+  validatePrivateParent(path, options.platform, options.uid);
+  const access = options.readOnly ? constants.O_RDONLY : constants.O_RDWR | constants.O_APPEND;
+  const create = options.create ? constants.O_CREAT : 0;
+  const exclusive = options.exclusive ? constants.O_EXCL : 0;
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, access | create | exclusive | constants.O_NOFOLLOW, 0o600);
+    validateOpenedPath(path, fd, options);
+    return fd;
+  } catch (error) {
+    if (fd !== undefined) closeSync(fd);
+    throw diagnosticError("file proof failed", error);
+  }
+}
+
+function closeQuietly(fd: number | undefined): void {
+  if (fd === undefined) return;
+  try {
+    closeSync(fd);
+  } catch {
+    /* diagnostics never own lifecycle success */
+  }
+}
+
+function pathExistsWithoutFollowing(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function openExistingSafe(path: string, options: SafeFileOptions): number | undefined {
+  if (!pathExistsWithoutFollowing(path)) return undefined;
+  return openSafeFile(path, { ...options, create: false });
+}
+
+function writerIdentity(path: string): string {
+  try {
+    return join(realpathSync.native(dirname(path)), basename(path));
+  } catch {
+    return path;
+  }
+}
+
+function writeAll(fd: number, bytes: Buffer): void {
+  let offset = 0;
+  while (offset < bytes.length) offset += writeSync(fd, bytes, offset, bytes.length - offset);
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value) <= maxBytes) return value;
+  const marker = "[redacted]";
+  const markerAt = value.indexOf(marker);
+  const markerSuffix = `…${marker}`;
+  const preserveMarker = markerAt >= 0 && Buffer.byteLength(markerSuffix) <= maxBytes;
+  const source = preserveMarker ? value.slice(0, markerAt) : value;
+  const suffix = preserveMarker ? markerSuffix : maxBytes >= 3 ? "…" : "";
+  const suffixBytes = Buffer.byteLength(suffix);
+  let low = 0;
+  let high = source.length;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(source.slice(0, mid)) + suffixBytes <= maxBytes) low = mid;
+    else high = mid - 1;
+  }
+  let prefix = source.slice(0, low);
+  if (/\p{Surrogate}$/u.test(prefix)) prefix = prefix.slice(0, -1);
+  return `${prefix}${suffix}`;
+}
+
+function redactedString(value: unknown, maxBytes: number): string {
+  return truncateUtf8(redactSecrets(String(value)), maxBytes);
+}
+
+function diagnosticLine(
+  context: DaemonStartupDiagnosticContext,
+  input: DaemonStartupDiagnosticRecord,
+  now: () => Date,
+  maxRecordBytes: number,
+): Buffer {
+  const error = input.error;
+  const failureClass =
+    error instanceof Error
+      ? error.name || error.constructor?.name || "Error"
+      : error === undefined
+        ? undefined
+        : "NonErrorThrown";
+  const stack =
+    error instanceof Error
+      ? error.stack || `${failureClass}: ${error.message}`
+      : error === undefined
+        ? undefined
+        : String(error);
+  const perField = maxRecordBytes;
+  const record: Record<string, string | number> = {
+    timestamp: redactedString(now().toISOString(), perField),
+    runtimeVersion: redactedString(context.runtimeVersion, perField),
+    buildSha: redactedString(context.buildSha, perField),
+    entryPath: redactedString(context.entryPath, perField),
+    pid: context.pid,
+    dataRoot: redactedString(context.dataRoot, perField),
+    launchSource: redactedString(context.launchSource, perField),
+    stage: redactedString(input.stage, perField),
+    message: redactedString(input.message, perField),
+  };
+  if (failureClass !== undefined) record.failureClass = redactedString(failureClass, 128);
+  if (stack !== undefined) record.stack = redactedString(stack, perField);
+
+  let encoded = Buffer.from(`${JSON.stringify(record)}\n`, "utf8");
+  const shrinkOrder = ["message", "entryPath", "dataRoot", "stack", "runtimeVersion", "buildSha"];
+  const minimumBytes: Record<string, number> = {
+    message: 8,
+    entryPath: 16,
+    dataRoot: 16,
+    stack: 160,
+    runtimeVersion: 8,
+    buildSha: 8,
+  };
+  while (encoded.length > maxRecordBytes) {
+    const key = shrinkOrder.find((candidate) => {
+      const value = record[candidate];
+      return typeof value === "string" && Buffer.byteLength(value) > (minimumBytes[candidate] ?? 8);
+    });
+    if (!key) throw new Error("diagnostic record metadata exceeds the configured bound");
+    const value = record[key] as string;
+    const currentBytes = Buffer.byteLength(value);
+    const nextBytes = Math.max(
+      minimumBytes[key] ?? 8,
+      currentBytes - Math.max(16, encoded.length - maxRecordBytes),
+    );
+    record[key] = truncateUtf8(value, nextBytes);
+    encoded = Buffer.from(`${JSON.stringify(record)}\n`, "utf8");
+  }
+  return encoded;
+}
+
+function writeOversizeDiscardReceipt(
+  path: string,
+  context: DaemonStartupDiagnosticContext,
+  options: Required<Pick<DaemonStartupDiagnosticOptions, "maxRecordBytes" | "platform" | "now">> & {
+    uid?: number;
+  },
+): void {
+  const line = diagnosticLine(
+    context,
+    {
+      stage: "diagnostic_legacy_log_discarded",
+      message: "an oversized legacy diagnostic generation was discarded without copying its bytes",
+    },
+    options.now,
+    options.maxRecordBytes,
+  );
+  let fd = openExistingSafe(path, {
+    platform: options.platform,
+    uid: options.uid,
+    repairMode: true,
+    create: false,
+  });
+  try {
+    if (fd === undefined) {
+      fd = openSafeFile(path, {
+        platform: options.platform,
+        uid: options.uid,
+        repairMode: true,
+        create: true,
+        exclusive: true,
+      });
+    }
+    ftruncateSync(fd, 0);
+    writeAll(fd, line);
+    fsyncSync(fd);
+  } finally {
+    closeQuietly(fd);
+  }
+}
+
+/** Open the canonical writer only after a separate root-authority owner won. */
+export function openDaemonStartupDiagnosticsAfterAuthority(
+  context: DaemonStartupDiagnosticContext,
+  options: DaemonStartupDiagnosticOptions = {},
+): DaemonStartupDiagnostics {
+  if (!Number.isSafeInteger(context.pid) || context.pid <= 0) throw new Error("invalid daemon pid");
+  if (!SAFE_LABEL.test(context.launchSource)) throw new Error("invalid daemon launch source");
+  const path = resolve(options.path ?? canonicalLogPath());
+  const rotatedPath = `${path}.1`;
+  const maxCurrentBytes = boundedPositiveInt(
+    options.maxCurrentBytes ?? DEFAULT_CURRENT_BYTES,
+    "maxCurrentBytes",
+    MIN_RECORD_BYTES,
+  );
+  const maxRecordBytes = boundedPositiveInt(
+    options.maxRecordBytes ?? DEFAULT_RECORD_BYTES,
+    "maxRecordBytes",
+    MIN_RECORD_BYTES,
+  );
+  if (maxRecordBytes > maxCurrentBytes) {
+    throw new Error("maxRecordBytes must not exceed maxCurrentBytes");
+  }
+  const platform = options.platform ?? process.platform;
+  const uid = options.uid ?? process.getuid?.();
+  const now = options.now ?? (() => new Date());
+  const writerKey = writerIdentity(path);
+  if (activeWriters.has(writerKey))
+    throw new Error(`one diagnostic writer is already active for ${path}`);
+
+  let fd: number | undefined;
+  let closed = false;
+  let failure: string | null = null;
+  try {
+    fd = openSafeFile(path, { platform, uid, repairMode: true, create: true });
+    const current = fstatSync(fd);
+    const rotated = openExistingSafe(rotatedPath, {
+      platform,
+      uid,
+      repairMode: true,
+      create: false,
+    });
+    if (rotated !== undefined) {
+      const size = fstatSync(rotated).size;
+      closeQuietly(rotated);
+      if (size > maxCurrentBytes) {
+        writeOversizeDiscardReceipt(rotatedPath, context, {
+          maxRecordBytes,
+          platform,
+          uid,
+          now,
+        });
+      }
+    }
+    if (current.size > maxCurrentBytes) {
+      ftruncateSync(fd, 0);
+      fsyncSync(fd);
+      writeOversizeDiscardReceipt(rotatedPath, context, {
+        maxRecordBytes,
+        platform,
+        uid,
+        now,
+      });
+    }
+    activeWriters.add(writerKey);
+  } catch (error) {
+    closeQuietly(fd);
+    throw error;
+  }
+
+  const rotate = (): void => {
+    if (fd === undefined) throw new Error("diagnostic writer is closed");
+    validateOpenedPath(path, fd, { platform, uid, repairMode: true, create: false });
+    const prior = openExistingSafe(rotatedPath, {
+      platform,
+      uid,
+      repairMode: true,
+      create: false,
+    });
+    closeQuietly(prior);
+    if (prior !== undefined) unlinkSync(rotatedPath);
+    closeSync(fd);
+    fd = undefined;
+    renameSync(path, rotatedPath);
+    fd = openSafeFile(path, {
+      platform,
+      uid,
+      repairMode: true,
+      create: true,
+      exclusive: true,
+    });
+  };
+
+  return {
+    path,
+    rotatedPath,
+    record(input): boolean {
+      if (closed || fd === undefined) {
+        failure = "diagnostic writer is closed";
+        return false;
+      }
+      try {
+        if (!SAFE_LABEL.test(input.stage)) throw new Error("invalid diagnostic stage");
+        const line = diagnosticLine(context, input, now, maxRecordBytes);
+        if (fstatSync(fd).size + line.length > maxCurrentBytes) rotate();
+        if (fd === undefined) throw new Error("diagnostic writer closed during rotation");
+        writeAll(fd, line);
+        return true;
+      } catch (error) {
+        failure = safeProblemMessage(error);
+        return false;
+      }
+    },
+    close(): void {
+      if (closed) return;
+      closed = true;
+      activeWriters.delete(writerKey);
+      closeQuietly(fd);
+      fd = undefined;
+    },
+    lastFailure: () => failure,
+  };
+}
+
+export interface ReadDaemonDiagnosticTailOptions {
+  path?: string;
+  lines?: number;
+  platform?: NodeJS.Platform;
+  uid?: number;
+}
+
+/** Read only a bounded current-generation tail through the same inode proof. */
+export function readDaemonDiagnosticTail(options: ReadDaemonDiagnosticTailOptions = {}): string {
+  const path = resolve(options.path ?? canonicalLogPath());
+  const lines = boundedPositiveInt(options.lines ?? 40, "lines", 1);
+  if (lines > MAX_TAIL_LINES) throw new Error(`lines must not exceed ${MAX_TAIL_LINES}`);
+  const platform = options.platform ?? process.platform;
+  const uid = options.uid ?? process.getuid?.();
+  const fd = openSafeFile(path, {
+    platform,
+    uid,
+    repairMode: false,
+    create: false,
+    readOnly: true,
+  });
+  try {
+    const size = fstatSync(fd).size;
+    const length = Math.min(size, MAX_TAIL_BYTES);
+    const bytes = Buffer.alloc(length);
+    let offset = 0;
+    while (offset < length) {
+      const read = readSync(fd, bytes, offset, length - offset, size - length + offset);
+      if (read === 0) break;
+      offset += read;
+    }
+    const text = redactSecrets(bytes.subarray(0, offset).toString("utf8"));
+    const split = text.split("\n");
+    const terminated = split.at(-1) === "";
+    if (terminated) split.pop();
+    const tail = split.slice(-lines).join("\n");
+    return terminated && tail ? `${tail}\n` : tail;
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/packages/cli/src/startup-diagnostics.ts
+++ b/packages/cli/src/startup-diagnostics.ts
@@ -442,8 +442,31 @@ export interface ReadDaemonDiagnosticTailOptions {
   uid?: number;
 }
 
-/** Read only a bounded current-generation tail through the same inode proof. */
-export function readDaemonDiagnosticTail(options: ReadDaemonDiagnosticTailOptions = {}): string {
+export type DaemonDiagnosticTailRead =
+  | {
+      kind: "retained";
+      text: string;
+    }
+  | {
+      kind: "oversize_omitted";
+      observedBytes: number;
+      limitBytes: number;
+      text: string;
+    };
+
+/**
+ * Read a current-generation tail through the same inode proof.
+ *
+ * A file larger than the writer's current-generation cap is legacy or otherwise
+ * outside the bounded writer contract. Do not select a byte window from it:
+ * that boundary can remove the prefix/header required to redact any token family
+ * or multiline private-key block. Return typed omission evidence without reading
+ * file content instead. Files within the cap are read in full, redacted, and only
+ * then reduced to the requested line tail.
+ */
+export function readDaemonDiagnosticTail(
+  options: ReadDaemonDiagnosticTailOptions = {},
+): DaemonDiagnosticTailRead {
   const path = resolve(options.path ?? canonicalLogPath());
   const lines = boundedPositiveInt(options.lines ?? 40, "lines", 1);
   if (lines > MAX_TAIL_LINES) throw new Error(`lines must not exceed ${MAX_TAIL_LINES}`);
@@ -458,11 +481,18 @@ export function readDaemonDiagnosticTail(options: ReadDaemonDiagnosticTailOption
   });
   try {
     const size = fstatSync(fd).size;
-    const length = Math.min(size, MAX_TAIL_BYTES);
-    const bytes = Buffer.alloc(length);
+    if (size > MAX_TAIL_BYTES) {
+      return {
+        kind: "oversize_omitted",
+        observedBytes: size,
+        limitBytes: MAX_TAIL_BYTES,
+        text: `[daemon diagnostic tail omitted: oversize_omitted; ${size} bytes exceeds the ${MAX_TAIL_BYTES}-byte safe read limit]\n`,
+      };
+    }
+    const bytes = Buffer.alloc(size);
     let offset = 0;
-    while (offset < length) {
-      const read = readSync(fd, bytes, offset, length - offset, size - length + offset);
+    while (offset < size) {
+      const read = readSync(fd, bytes, offset, size - offset, offset);
       if (read === 0) break;
       offset += read;
     }
@@ -471,7 +501,7 @@ export function readDaemonDiagnosticTail(options: ReadDaemonDiagnosticTailOption
     const terminated = split.at(-1) === "";
     if (terminated) split.pop();
     const tail = split.slice(-lines).join("\n");
-    return terminated && tail ? `${tail}\n` : tail;
+    return { kind: "retained", text: terminated && tail ? `${tail}\n` : tail };
   } finally {
     closeSync(fd);
   }

--- a/packages/cli/src/thread-turn-services.ts
+++ b/packages/cli/src/thread-turn-services.ts
@@ -2,7 +2,10 @@ import type { ProjectPartitions, ResourceStore } from "@claudexor/daemon";
 import type { ResourceAttachmentRef, TurnEnqueueProblem } from "@claudexor/schema";
 
 /** Thin Control API bindings over the daemon's durable thread-turn authority. */
-export function threadTurnServices(threads: ProjectPartitions, resources: ResourceStore) {
+export function threadTurnServices(
+  threads: ProjectPartitions,
+  resources: Pick<ResourceStore, "resolve">,
+) {
   return {
     threadDetail: async (id: string) => {
       const thread = threads.getThread(id);

--- a/packages/control-api/src/control-protocol.test.ts
+++ b/packages/control-api/src/control-protocol.test.ts
@@ -1,0 +1,86 @@
+import { CONTROL_PROTOCOL_MAJOR } from "@claudexor/schema";
+import { describe, expect, it } from "vitest";
+import { resolveControlProtocol } from "./control-protocol.js";
+
+const MAJOR = String(CONTROL_PROTOCOL_MAJOR);
+
+function boundary(input: {
+  method?: string;
+  requestPath: string;
+  requestedMajor?: string;
+  servingMode?: "normal" | "recovery_only";
+  body?: unknown;
+}) {
+  return resolveControlProtocol({
+    method: input.method ?? "GET",
+    requestPath: input.requestPath,
+    requestedMajor: input.requestedMajor ?? MAJOR,
+    readBody: async () => input.body ?? {},
+    servingMode: input.servingMode,
+  });
+}
+
+describe("control protocol recovery-only gate (issue #165 D5)", () => {
+  it("carries servingMode in the handshake from the canonical admission snapshot", async () => {
+    const recovery = await boundary({
+      method: "POST",
+      requestPath: "/v2/handshake",
+      servingMode: "recovery_only",
+      body: { protocolMajor: CONTROL_PROTOCOL_MAJOR, client: "test" },
+    });
+    expect(recovery).toMatchObject({
+      kind: "response",
+      status: 200,
+      body: { compatible: true, servingMode: "recovery_only" },
+    });
+    const normal = await boundary({
+      method: "POST",
+      requestPath: "/v2/handshake",
+      body: { protocolMajor: CONTROL_PROTOCOL_MAJOR, client: "test" },
+    });
+    expect(normal).toMatchObject({
+      kind: "response",
+      status: 200,
+      body: { compatible: true, servingMode: "normal" },
+    });
+  });
+
+  it("typed-refuses every product route while serving recovery only", async () => {
+    for (const requestPath of ["/v2/runs", "/v2/threads", "/v2/settings", "/v2/projects"]) {
+      const result = await boundary({ requestPath, servingMode: "recovery_only" });
+      expect(result).toMatchObject({
+        kind: "response",
+        status: 503,
+        contentType: "application/problem+json",
+        body: { code: "daemon_recovery_only", retryable: true },
+      });
+    }
+  });
+
+  it("keeps the journal recovery surface and the operations catalog reachable", async () => {
+    await expect(
+      boundary({ requestPath: "/v2/recovery/partitions/global", servingMode: "recovery_only" }),
+    ).resolves.toEqual({ kind: "route", path: "/recovery/partitions/global" });
+    await expect(
+      boundary({
+        method: "POST",
+        requestPath: "/v2/recovery/partitions/global/quarantine",
+        servingMode: "recovery_only",
+      }),
+    ).resolves.toEqual({ kind: "route", path: "/recovery/partitions/global/quarantine" });
+    await expect(
+      boundary({ requestPath: "/v2/operations", servingMode: "recovery_only" }),
+    ).resolves.toMatchObject({ kind: "response", status: 200 });
+  });
+
+  it("routes product paths normally once admission is open (and when unwired)", async () => {
+    await expect(boundary({ requestPath: "/v2/runs", servingMode: "normal" })).resolves.toEqual({
+      kind: "route",
+      path: "/runs",
+    });
+    await expect(boundary({ requestPath: "/v2/runs" })).resolves.toEqual({
+      kind: "route",
+      path: "/runs",
+    });
+  });
+});

--- a/packages/control-api/src/control-protocol.ts
+++ b/packages/control-api/src/control-protocol.ts
@@ -1,0 +1,128 @@
+import {
+  CONTROL_PROTOCOL_MAJOR,
+  ControlHandshakeRequest,
+  ControlHandshakeResponse,
+  ControlProblem,
+} from "@claudexor/schema";
+import { engineBuildIdentity } from "@claudexor/util";
+import { OPERATION_CATALOG } from "./operation-catalog.js";
+import { pathnameDecodes } from "./operation-parameters.js";
+
+export type ControlProtocolBoundary =
+  | { kind: "route"; path: string }
+  | { kind: "response"; status: number; body: unknown; contentType: string };
+
+/** Product admission mode carried into the protocol boundary (issue #165 D5). */
+export type ControlServingMode = NonNullable<ControlHandshakeResponse["servingMode"]>;
+
+const protocolProblem = (code: string, message: string, requiredActions: string[] = []) =>
+  ControlProblem.parse({
+    code,
+    message,
+    retryable: false,
+    fieldErrors: {},
+    requiredActions,
+    evidenceRefs: [],
+  });
+
+/** Stateless v2 negotiation boundary; product handlers only see unversioned internal paths. */
+export async function resolveControlProtocol(input: {
+  method: string;
+  requestPath: string;
+  requestedMajor: string | string[] | undefined;
+  readBody: () => Promise<unknown>;
+  servingMode?: ControlServingMode;
+}): Promise<ControlProtocolBoundary> {
+  const servingMode = input.servingMode ?? "normal";
+  if (input.method === "POST" && input.requestPath === "/v2/handshake") {
+    const request = ControlHandshakeRequest.parse(await input.readBody());
+    if (request.protocolMajor !== CONTROL_PROTOCOL_MAJOR) {
+      return {
+        kind: "response",
+        status: 426,
+        contentType: "application/problem+json",
+        body: protocolProblem(
+          "incompatible_protocol_major",
+          `control protocol major ${request.protocolMajor} is incompatible; server requires ${CONTROL_PROTOCOL_MAJOR}`,
+          [`use control protocol major ${CONTROL_PROTOCOL_MAJOR}`],
+        ),
+      };
+    }
+    return {
+      kind: "response",
+      status: 200,
+      contentType: "application/json",
+      body: ControlHandshakeResponse.parse({
+        protocolMajor: CONTROL_PROTOCOL_MAJOR,
+        compatible: true,
+        operationsPath: "/v2/operations",
+        engine: engineBuildIdentity(),
+        servingMode,
+      }),
+    };
+  }
+  if (!input.requestPath.startsWith("/v2/")) {
+    return {
+      kind: "response",
+      status: 404,
+      contentType: "application/problem+json",
+      body: protocolProblem("route_not_found", "product routes require the /v2 prefix"),
+    };
+  }
+  if (input.requestedMajor !== String(CONTROL_PROTOCOL_MAJOR)) {
+    return {
+      kind: "response",
+      status: 426,
+      contentType: "application/problem+json",
+      body: protocolProblem(
+        "handshake_required",
+        "a successful v2 handshake is required before product calls",
+        ["POST /v2/handshake", `send X-Claudexor-Protocol-Major: ${CONTROL_PROTOCOL_MAJOR}`],
+      ),
+    };
+  }
+  if (input.method === "GET" && input.requestPath === "/v2/operations") {
+    return {
+      kind: "response",
+      status: 200,
+      contentType: "application/json",
+      body: OPERATION_CATALOG,
+    };
+  }
+  // QA-066: malformed percent-encoding in the path is a CLIENT syntax error —
+  // validate the whole encoded pathname decodes ONCE, centrally, before route
+  // dispatch (typed 400, not a per-route URIError into the 500 handler).
+  // Routes still match on the ENCODED path; `%2F`/`%2e%2e` semantics unchanged.
+  if (!pathnameDecodes(input.requestPath)) {
+    return {
+      kind: "response",
+      status: 400,
+      contentType: "application/problem+json",
+      body: protocolProblem(
+        "malformed_request_path",
+        "request path contains malformed percent-encoding",
+      ),
+    };
+  }
+  const path = input.requestPath.slice(3);
+  // Issue #165 D5: while the daemon serves recovery only, the journal
+  // recovery surface stays reachable and every other product route gets one
+  // typed retryable refusal instead of touching unactivated projections.
+  if (servingMode === "recovery_only" && !path.startsWith("/recovery/")) {
+    return {
+      kind: "response",
+      status: 503,
+      contentType: "application/problem+json",
+      body: ControlProblem.parse({
+        code: "daemon_recovery_only",
+        message:
+          "daemon is serving recovery only; product routes are closed until journal recovery completes",
+        retryable: true,
+        fieldErrors: {},
+        requiredActions: ["retry after recovery completes"],
+        evidenceRefs: [],
+      }),
+    };
+  }
+  return { kind: "route", path };
+}

--- a/packages/control-api/src/daemon-server.ts
+++ b/packages/control-api/src/daemon-server.ts
@@ -201,7 +201,8 @@ import {
   WorkProduct,
 } from "@claudexor/schema";
 
-import { resolveControlProtocol } from "./operation-catalog.js";
+import { resolveControlProtocol, type ControlServingMode } from "./control-protocol.js";
+import { readControlRequestBody } from "./request-body.js";
 import {
   assertNoInlineSecretValues,
   containsSecretLikeToken,
@@ -223,6 +224,8 @@ export interface DaemonControlApiOptions {
   pollMs?: number;
   heartbeatMs?: number;
   runStartTimeoutMs?: number;
+  /** Issue #165 D5 admission snapshot; absent embedders always serve normal. */
+  servingMode?: () => ControlServingMode;
   bus?: { subscribe(listener: (event: { run_id: string }) => void): () => void };
   services?: DeliveryCommandServices &
     Partial<ResourceRouteServices> &
@@ -644,40 +647,8 @@ export class DaemonControlApiServer {
     );
   }
 
-  private async readBody(req: IncomingMessage): Promise<unknown> {
-    const chunks: Buffer[] = [];
-    let size = 0;
-    for await (const chunk of req) {
-      size += (chunk as Buffer).length;
-      if (size > 10 * 1024 * 1024)
-        throw Object.assign(new Error("request body too large"), { status: 413 });
-      chunks.push(chunk as Buffer);
-    }
-    if (chunks.length === 0) return {};
-    // QA-056: decode the complete byte body STRICTLY. `Buffer.toString("utf8")`
-    // is non-fatal — it silently replaces malformed bytes with U+FFFD, so an
-    // invalid octet (FF, a lone continuation byte, overlong/ truncated sequence)
-    // would slip through as a valid JS string and could pass Zod, the secret
-    // fence, idempotency hashing and a durable mutation storing a value that
-    // differs from the wire bytes. TextDecoder({fatal:true}) throws on any
-    // malformed byte; concatenating first keeps valid multibyte chars split
-    // across HTTP chunks intact.
-    let decoded: string;
-    try {
-      decoded = new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks));
-    } catch {
-      throw Object.assign(new Error("request body must be valid UTF-8"), {
-        status: 400,
-        code: "invalid_encoding",
-      });
-    }
-    const raw = decoded.trim();
-    if (!raw) return {};
-    try {
-      return JSON.parse(raw);
-    } catch {
-      throw Object.assign(new Error("invalid JSON body"), { status: 400 });
-    }
+  private readBody(req: IncomingMessage): Promise<unknown> {
+    return readControlRequestBody(req);
   }
 
   private onRequest(req: IncomingMessage, res: ServerResponse): void {
@@ -736,6 +707,7 @@ export class DaemonControlApiServer {
         requestPath,
         requestedMajor: req.headers["x-claudexor-protocol-major"],
         readBody: () => this.readBody(req),
+        servingMode: this.opts.servingMode?.() ?? "normal",
       });
     } catch (error) {
       return this.requestError(res, error);

--- a/packages/control-api/src/index.ts
+++ b/packages/control-api/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./daemon-server.js";
+export * from "./control-protocol.js";
 export * from "./operation-catalog.js";
 export * from "./retention.js";
 export { normalizeExistingProjectRoot } from "./run-start.js";

--- a/packages/control-api/src/operation-catalog.ts
+++ b/packages/control-api/src/operation-catalog.ts
@@ -1,110 +1,13 @@
 import {
   CONTROL_PROTOCOL_MAJOR,
-  ControlHandshakeRequest,
-  ControlHandshakeResponse,
   ControlOperationCatalog,
-  ControlProblem,
   ControlRunState,
   type ControlOperationDescriptor,
 } from "@claudexor/schema";
-import { engineBuildIdentity } from "@claudexor/util";
-import { pathnameDecodes, queryParam, resumeHeader } from "./operation-parameters.js";
+import { queryParam, resumeHeader } from "./operation-parameters.js";
 import { REMOTE_OPERATION_DRAFTS } from "./remote-operation-descriptors.js";
 import type { OperationDraft } from "./operation-draft.js";
 import { OPERATION_SUMMARIES } from "./operation-summaries.js";
-
-export type ControlProtocolBoundary =
-  | { kind: "route"; path: string }
-  | { kind: "response"; status: number; body: unknown; contentType: string };
-
-const protocolProblem = (code: string, message: string, requiredActions: string[] = []) =>
-  ControlProblem.parse({
-    code,
-    message,
-    retryable: false,
-    fieldErrors: {},
-    requiredActions,
-    evidenceRefs: [],
-  });
-
-/** Stateless v2 negotiation boundary; product handlers only see unversioned internal paths. */
-export async function resolveControlProtocol(input: {
-  method: string;
-  requestPath: string;
-  requestedMajor: string | string[] | undefined;
-  readBody: () => Promise<unknown>;
-}): Promise<ControlProtocolBoundary> {
-  if (input.method === "POST" && input.requestPath === "/v2/handshake") {
-    const request = ControlHandshakeRequest.parse(await input.readBody());
-    if (request.protocolMajor !== CONTROL_PROTOCOL_MAJOR) {
-      return {
-        kind: "response",
-        status: 426,
-        contentType: "application/problem+json",
-        body: protocolProblem(
-          "incompatible_protocol_major",
-          `control protocol major ${request.protocolMajor} is incompatible; server requires ${CONTROL_PROTOCOL_MAJOR}`,
-          [`use control protocol major ${CONTROL_PROTOCOL_MAJOR}`],
-        ),
-      };
-    }
-    return {
-      kind: "response",
-      status: 200,
-      contentType: "application/json",
-      body: ControlHandshakeResponse.parse({
-        protocolMajor: CONTROL_PROTOCOL_MAJOR,
-        compatible: true,
-        operationsPath: "/v2/operations",
-        engine: engineBuildIdentity(),
-      }),
-    };
-  }
-  if (!input.requestPath.startsWith("/v2/")) {
-    return {
-      kind: "response",
-      status: 404,
-      contentType: "application/problem+json",
-      body: protocolProblem("route_not_found", "product routes require the /v2 prefix"),
-    };
-  }
-  if (input.requestedMajor !== String(CONTROL_PROTOCOL_MAJOR)) {
-    return {
-      kind: "response",
-      status: 426,
-      contentType: "application/problem+json",
-      body: protocolProblem(
-        "handshake_required",
-        "a successful v2 handshake is required before product calls",
-        ["POST /v2/handshake", `send X-Claudexor-Protocol-Major: ${CONTROL_PROTOCOL_MAJOR}`],
-      ),
-    };
-  }
-  if (input.method === "GET" && input.requestPath === "/v2/operations") {
-    return {
-      kind: "response",
-      status: 200,
-      contentType: "application/json",
-      body: OPERATION_CATALOG,
-    };
-  }
-  // QA-066: malformed percent-encoding in the path is a CLIENT syntax error —
-  // validate the whole encoded pathname decodes ONCE, centrally, before route
-  // dispatch (typed 400, not a per-route URIError into the 500 handler).
-  // Routes still match on the ENCODED path; `%2F`/`%2e%2e` semantics unchanged.
-  if (!pathnameDecodes(input.requestPath)) {
-    return {
-      kind: "response",
-      status: 400,
-      contentType: "application/problem+json",
-      body: protocolProblem(
-        "malformed_request_path",
-        "request path contains malformed percent-encoding",
-      ),
-    };
-  }
-  return { kind: "route", path: input.requestPath.slice(3) };
-}
 
 function descriptor(input: OperationDraft): ControlOperationDescriptor {
   // Resource-family classification (QA-054): an operation is grouped under the

--- a/packages/control-api/src/request-body.ts
+++ b/packages/control-api/src/request-body.ts
@@ -1,0 +1,40 @@
+import type { IncomingMessage } from "node:http";
+
+const MAX_CONTROL_BODY_BYTES = 10 * 1024 * 1024;
+
+/** Reads a bounded JSON request body with strict UTF-8 decoding. */
+export async function readControlRequestBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += (chunk as Buffer).length;
+    if (size > MAX_CONTROL_BODY_BYTES)
+      throw Object.assign(new Error("request body too large"), { status: 413 });
+    chunks.push(chunk as Buffer);
+  }
+  if (chunks.length === 0) return {};
+  // QA-056: decode the complete byte body STRICTLY. `Buffer.toString("utf8")`
+  // is non-fatal — it silently replaces malformed bytes with U+FFFD, so an
+  // invalid octet (FF, a lone continuation byte, overlong/ truncated sequence)
+  // would slip through as a valid JS string and could pass Zod, the secret
+  // fence, idempotency hashing and a durable mutation storing a value that
+  // differs from the wire bytes. TextDecoder({fatal:true}) throws on any
+  // malformed byte; concatenating first keeps valid multibyte chars split
+  // across HTTP chunks intact.
+  let decoded: string;
+  try {
+    decoded = new TextDecoder("utf-8", { fatal: true }).decode(Buffer.concat(chunks));
+  } catch {
+    throw Object.assign(new Error("request body must be valid UTF-8"), {
+      status: 400,
+      code: "invalid_encoding",
+    });
+  }
+  const raw = decoded.trim();
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw Object.assign(new Error("invalid JSON body"), { status: 400 });
+  }
+}

--- a/packages/core/src/process-identity.test.ts
+++ b/packages/core/src/process-identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   ProcessIdentityService,
   compareProcessIdentity,
+  createProcessObservationReader,
   observeProcess,
   parseDarwinHelperOutput,
   parseLinuxProcStat,
@@ -76,24 +77,96 @@ describe("locale-independent process identity", () => {
   it("reads identity and Linux state atomically while caching self identity only", () => {
     let reads = 0;
     let state: LinuxProcessState = "S";
-    const service = new ProcessIdentityService({
+    const options = {
       platform: "linux",
       selfPid: 55,
       readTextFile: () => {
         reads += 1;
         return linuxStat(55, 55, "900", "self", state);
       },
-    });
+    };
+    const service = new ProcessIdentityService(options);
+    const observation = createProcessObservationReader(options);
 
-    expect(service.observe(55)).toMatchObject({ linuxState: "S", identity: { status: "known" } });
+    expect(observation.observe(55)).toMatchObject({
+      linuxState: "S",
+      identity: { status: "known" },
+    });
     expect(reads).toBe(1);
     expect(service.self()).toMatchObject({ status: "known", startToken: "linux:900" });
     expect(reads).toBe(2);
     state = "Z";
     expect(service.self()).toMatchObject({ status: "known", startToken: "linux:900" });
     expect(reads).toBe(2);
-    expect(service.observe(55).linuxState).toBe("Z");
+    expect(observation.observe(55).linuxState).toBe("Z");
     expect(reads).toBe(3);
+  });
+
+  it("preserves legacy ProcessIdentityService subclass member names", () => {
+    expect("observe" in new ProcessIdentityService({ platform: "win32" })).toBe(false);
+    let reads = 0;
+    let privateObserveCalls = 0;
+    class LegacyPrivateObserveService extends ProcessIdentityService {
+      constructor() {
+        super({
+          platform: "linux",
+          readTextFile: () => {
+            reads += 1;
+            return linuxStat(55, 55, "900");
+          },
+        });
+        void this.observe;
+      }
+
+      private observe(_pid: number): void {
+        privateObserveCalls += 1;
+      }
+    }
+
+    let publicObserveCalls = 0;
+    class LegacyPublicObserveService extends ProcessIdentityService {
+      observe(_pid: number): string {
+        publicObserveCalls += 1;
+        return "legacy-observation";
+      }
+    }
+
+    let linuxObservationCalls = 0;
+    class LegacyLinuxObservationService extends ProcessIdentityService {
+      constructor() {
+        super({
+          platform: "linux",
+          readTextFile: () => {
+            reads += 1;
+            return linuxStat(55, 55, "901");
+          },
+        });
+        void this.readLinuxObservation;
+      }
+
+      private readLinuxObservation(_pid: number): void {
+        linuxObservationCalls += 1;
+      }
+    }
+
+    const privateObserve = new LegacyPrivateObserveService();
+    expect(privateObserve.read(55)).toEqual(knownLinux(55, 55, "linux:900"));
+    expect(privateObserveCalls).toBe(0);
+    expect("observe" in privateObserve).toBe(true);
+
+    const publicObserve = new LegacyPublicObserveService({
+      platform: "linux",
+      readTextFile: () => linuxStat(55, 55, "902"),
+    });
+    expect(publicObserve.read(55)).toEqual(knownLinux(55, 55, "linux:902"));
+    expect(publicObserveCalls).toBe(0);
+    expect(publicObserve.observe(55)).toBe("legacy-observation");
+    expect(publicObserveCalls).toBe(1);
+
+    const linuxObservation = new LegacyLinuxObservationService();
+    expect(linuxObservation.read(55)).toEqual(knownLinux(55, 55, "linux:901"));
+    expect(linuxObservationCalls).toBe(0);
+    expect(reads).toBe(2);
   });
 
   it("uses only an explicitly supplied observation capability", () => {
@@ -165,7 +238,7 @@ describe("locale-independent process identity", () => {
     });
     expect(missing.read(90).status).toBe("missing");
 
-    const denied = new ProcessIdentityService({
+    const denied = createProcessObservationReader({
       platform: "linux",
       readTextFile: () => {
         throw Object.assign(new Error("denied"), { code: "EACCES" });
@@ -181,7 +254,7 @@ describe("locale-independent process identity", () => {
       linuxState: null,
     });
 
-    const unsupported = new ProcessIdentityService({ platform: "win32" });
+    const unsupported = createProcessObservationReader({ platform: "win32" });
     expect(unsupported.observe(90)).toEqual({
       identity: {
         status: "unknown",
@@ -194,7 +267,7 @@ describe("locale-independent process identity", () => {
   });
 
   it("keeps Darwin identity observation state-free", () => {
-    const service = new ProcessIdentityService({
+    const service = createProcessObservationReader({
       platform: "darwin",
       darwinHelperPath: "/private/helper",
       runDarwinHelper: () => ({

--- a/packages/core/src/process-identity.test.ts
+++ b/packages/core/src/process-identity.test.ts
@@ -8,6 +8,9 @@ import {
   parseLinuxProcStatObservation,
   type KnownProcessIdentity,
   type LinuxProcessState,
+  type ProcessIdentity,
+  type ProcessIdentityReader,
+  type ProcessObservationReader,
 } from "./process-identity.js";
 import { ProcessGroupService, parseProcessGroupHandle } from "./process-group.js";
 
@@ -93,25 +96,44 @@ describe("locale-independent process identity", () => {
     expect(reads).toBe(3);
   });
 
-  it("uses only an injected reader's optional observation capability", () => {
+  it("uses only an explicitly supplied observation capability", () => {
     const identity = knownLinux(55, 55, "linux:1");
     let reads = 0;
-    const legacyReader = {
-      read: () => {
+    let collidingObserveCalls = 0;
+    class LegacyReaderWithUnrelatedObserve implements ProcessIdentityReader {
+      constructor() {
+        void this.observe;
+      }
+
+      private observe(_pid: number): void {
+        collidingObserveCalls += 1;
+      }
+
+      read(): ProcessIdentity {
         reads += 1;
         return identity;
-      },
-      self: () => identity,
-    };
+      }
+
+      self(): ProcessIdentity {
+        return identity;
+      }
+    }
+    const legacyReader = new LegacyReaderWithUnrelatedObserve();
     expect(observeProcess(legacyReader, 55)).toEqual({ identity, linuxState: null });
     expect(reads).toBe(1);
+    expect(collidingObserveCalls).toBe(0);
 
-    const observationReader = {
-      ...legacyReader,
+    let observations = 0;
+    const observationReader: ProcessObservationReader = {
       observe: () => ({ identity, linuxState: "Z" as const }),
     };
-    expect(observeProcess(observationReader, 55).linuxState).toBe("Z");
+    observationReader.observe = () => {
+      observations += 1;
+      return { identity, linuxState: "Z" };
+    };
+    expect(observeProcess(legacyReader, 55, observationReader).linuxState).toBe("Z");
     expect(reads).toBe(1);
+    expect(observations).toBe(1);
   });
 
   it("strictly parses Darwin PID/PGID/start and rejects localized prose", () => {

--- a/packages/core/src/process-identity.test.ts
+++ b/packages/core/src/process-identity.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   ProcessIdentityService,
   compareProcessIdentity,
+  observeProcess,
   parseDarwinHelperOutput,
   parseLinuxProcStat,
+  parseLinuxProcStatObservation,
   type KnownProcessIdentity,
+  type LinuxProcessState,
 } from "./process-identity.js";
 import { ProcessGroupService, parseProcessGroupHandle } from "./process-group.js";
 
@@ -13,11 +16,12 @@ function linuxStat(
   pgid: number,
   startTicks: string,
   comm = "worker ) with spaces",
+  state: LinuxProcessState | string = "S",
 ): string {
   // fieldsFromState[0]=state, [2]=pgrp/field5, [19]=starttime/field22.
   const fields4Through21 = Array.from({ length: 18 }, (_, index) => String(index + 1));
   fields4Through21[1] = String(pgid);
-  return `${pid} (${comm}) S ${fields4Through21.join(" ")} ${startTicks} 0 0 0\n`;
+  return `${pid} (${comm}) ${state} ${fields4Through21.join(" ")} ${startTicks} 0 0 0\n`;
 }
 
 function knownLinux(pid: number, pgid: number, startToken: string): KnownProcessIdentity {
@@ -44,6 +48,70 @@ describe("locale-independent process identity", () => {
     );
     expect(parseLinuxProcStat(linuxStat(41, 41, "123"), 42)).toMatchObject({ status: "unknown" });
     expect(parseLinuxProcStat(linuxStat(42, 42, "12.3"), 42)).toMatchObject({ status: "unknown" });
+    expect(parseLinuxProcStatObservation(linuxStat(42, 42, "123", "worker", "?"), 42)).toEqual({
+      identity: expect.objectContaining({ status: "unknown", reason: "malformed_response" }),
+      linuxState: null,
+    });
+  });
+
+  it("keeps mutable Linux state separate from byte-compatible birth identity", () => {
+    const sleeping = linuxStat(77, 77, "101", "worker", "S");
+    const zombie = linuxStat(77, 77, "101", "worker", "Z");
+    const sleepingObservation = parseLinuxProcStatObservation(sleeping, 77);
+    const zombieObservation = parseLinuxProcStatObservation(zombie, 77);
+
+    expect(sleepingObservation.identity).toEqual(zombieObservation.identity);
+    expect(parseLinuxProcStat(sleeping, 77)).toEqual(parseLinuxProcStat(zombie, 77));
+    expect(sleepingObservation.linuxState).toBe("S");
+    expect(zombieObservation.linuxState).toBe("Z");
+    if (sleepingObservation.identity.status !== "known") throw new Error("expected known identity");
+    expect(compareProcessIdentity(sleepingObservation.identity, zombieObservation.identity)).toBe(
+      "same",
+    );
+  });
+
+  it("reads identity and Linux state atomically while caching self identity only", () => {
+    let reads = 0;
+    let state: LinuxProcessState = "S";
+    const service = new ProcessIdentityService({
+      platform: "linux",
+      selfPid: 55,
+      readTextFile: () => {
+        reads += 1;
+        return linuxStat(55, 55, "900", "self", state);
+      },
+    });
+
+    expect(service.observe(55)).toMatchObject({ linuxState: "S", identity: { status: "known" } });
+    expect(reads).toBe(1);
+    expect(service.self()).toMatchObject({ status: "known", startToken: "linux:900" });
+    expect(reads).toBe(2);
+    state = "Z";
+    expect(service.self()).toMatchObject({ status: "known", startToken: "linux:900" });
+    expect(reads).toBe(2);
+    expect(service.observe(55).linuxState).toBe("Z");
+    expect(reads).toBe(3);
+  });
+
+  it("uses only an injected reader's optional observation capability", () => {
+    const identity = knownLinux(55, 55, "linux:1");
+    let reads = 0;
+    const legacyReader = {
+      read: () => {
+        reads += 1;
+        return identity;
+      },
+      self: () => identity,
+    };
+    expect(observeProcess(legacyReader, 55)).toEqual({ identity, linuxState: null });
+    expect(reads).toBe(1);
+
+    const observationReader = {
+      ...legacyReader,
+      observe: () => ({ identity, linuxState: "Z" as const }),
+    };
+    expect(observeProcess(observationReader, 55).linuxState).toBe("Z");
+    expect(reads).toBe(1);
   });
 
   it("strictly parses Darwin PID/PGID/start and rejects localized prose", () => {
@@ -74,6 +142,56 @@ describe("locale-independent process identity", () => {
       },
     });
     expect(missing.read(90).status).toBe("missing");
+
+    const denied = new ProcessIdentityService({
+      platform: "linux",
+      readTextFile: () => {
+        throw Object.assign(new Error("denied"), { code: "EACCES" });
+      },
+    });
+    expect(denied.observe(90)).toEqual({
+      identity: {
+        status: "unknown",
+        pid: 90,
+        platform: "linux",
+        reason: "permission_denied",
+      },
+      linuxState: null,
+    });
+
+    const unsupported = new ProcessIdentityService({ platform: "win32" });
+    expect(unsupported.observe(90)).toEqual({
+      identity: {
+        status: "unknown",
+        pid: 90,
+        platform: "win32",
+        reason: "unsupported_platform",
+      },
+      linuxState: null,
+    });
+  });
+
+  it("keeps Darwin identity observation state-free", () => {
+    const service = new ProcessIdentityService({
+      platform: "darwin",
+      darwinHelperPath: "/private/helper",
+      runDarwinHelper: () => ({
+        status: 0,
+        stdout: "claudexor-process-identity-v2\t123\t123\t1777777777\t000042\n",
+        stderr: "",
+      }),
+    });
+    expect(service.observe(123)).toEqual({
+      identity: {
+        status: "known",
+        pid: 123,
+        platform: "darwin",
+        source: "proc_pidinfo",
+        startToken: "darwin:1777777777:000042",
+        processGroupId: 123,
+      },
+      linuxState: null,
+    });
   });
 });
 
@@ -90,6 +208,7 @@ describe("process group handles", () => {
     expect(parseProcessGroupHandle(JSON.parse(JSON.stringify(captured.handle)))).toMatchObject({
       pgid: 55,
     });
+    expect(JSON.stringify(captured.handle)).not.toContain("linuxState");
 
     const memberIdentity = { ...identity, read: () => knownLinux(55, 44, "linux:1") };
     expect(

--- a/packages/core/src/process-identity.ts
+++ b/packages/core/src/process-identity.ts
@@ -284,7 +284,28 @@ function executeDarwinHelper(path: string, pid: number): DarwinHelperExecution {
   };
 }
 
-export class ProcessIdentityService implements ProcessIdentityReader, ProcessObservationReader {
+function readLinuxProcessObservation(
+  readTextFile: (path: string) => string,
+  pid: number,
+): ProcessObservation {
+  try {
+    return parseLinuxProcStatObservation(readTextFile(`/proc/${pid}/stat`), pid);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ESRCH") {
+      return { identity: { status: "missing", pid, platform: "linux" }, linuxState: null };
+    }
+    if (code === "EACCES" || code === "EPERM") {
+      return {
+        identity: unknown(pid, "linux", "permission_denied"),
+        linuxState: null,
+      };
+    }
+    return { identity: unknown(pid, "linux", "io_error"), linuxState: null };
+  }
+}
+
+export class ProcessIdentityService implements ProcessIdentityReader {
   private readonly platform: string;
   private readonly selfPid: number;
   private readonly readTextFile: (path: string) => string;
@@ -302,24 +323,10 @@ export class ProcessIdentityService implements ProcessIdentityReader, ProcessObs
   }
 
   read(pid: number): ProcessIdentity {
-    return this.observe(pid).identity;
-  }
-
-  observe(pid: number): ProcessObservation {
-    if (!validPositiveInteger(pid)) {
-      return {
-        identity: unknown(pid, this.platform, "invalid_pid"),
-        linuxState: null,
-      };
-    }
-    if (this.platform === "linux") return this.readLinuxObservation(pid);
-    if (this.platform === "darwin") {
-      return { identity: this.readDarwin(pid), linuxState: null };
-    }
-    return {
-      identity: unknown(pid, this.platform, "unsupported_platform"),
-      linuxState: null,
-    };
+    if (!validPositiveInteger(pid)) return unknown(pid, this.platform, "invalid_pid");
+    if (this.platform === "linux") return this.readLinux(pid);
+    if (this.platform === "darwin") return this.readDarwin(pid);
+    return unknown(pid, this.platform, "unsupported_platform");
   }
 
   self(): ProcessIdentity {
@@ -327,22 +334,8 @@ export class ProcessIdentityService implements ProcessIdentityReader, ProcessObs
     return this.cachedSelf;
   }
 
-  private readLinuxObservation(pid: number): ProcessObservation {
-    try {
-      return parseLinuxProcStatObservation(this.readTextFile(`/proc/${pid}/stat`), pid);
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException)?.code;
-      if (code === "ENOENT" || code === "ESRCH") {
-        return { identity: { status: "missing", pid, platform: "linux" }, linuxState: null };
-      }
-      if (code === "EACCES" || code === "EPERM") {
-        return {
-          identity: unknown(pid, "linux", "permission_denied"),
-          linuxState: null,
-        };
-      }
-      return { identity: unknown(pid, "linux", "io_error"), linuxState: null };
-    }
+  private readLinux(pid: number): ProcessIdentity {
+    return readLinuxProcessObservation(this.readTextFile, pid).identity;
   }
 
   private readDarwin(pid: number): ProcessIdentity {
@@ -364,3 +357,24 @@ export class ProcessIdentityService implements ProcessIdentityReader, ProcessObs
 }
 
 export const defaultProcessIdentityService = new ProcessIdentityService();
+
+export function createProcessObservationReader(
+  options: ProcessIdentityServiceOptions = {},
+): ProcessObservationReader {
+  const platform = options.platform ?? process.platform;
+  const identity = new ProcessIdentityService(options);
+  const readTextFile = options.readTextFile ?? ((path: string) => readFileSync(path, "utf8"));
+  return {
+    observe(pid: number): ProcessObservation {
+      if (platform === "linux") {
+        if (!validPositiveInteger(pid)) {
+          return { identity: unknown(pid, platform, "invalid_pid"), linuxState: null };
+        }
+        return readLinuxProcessObservation(readTextFile, pid);
+      }
+      return { identity: identity.read(pid), linuxState: null };
+    },
+  };
+}
+
+export const defaultProcessObservationReader = createProcessObservationReader();

--- a/packages/core/src/process-identity.ts
+++ b/packages/core/src/process-identity.ts
@@ -59,9 +59,6 @@ export interface ProcessObservationReader {
   observe(pid: number): ProcessObservation;
 }
 
-/** Additive observation support without widening every existing identity reader. */
-export type ProcessObservationSource = ProcessIdentityReader & Partial<ProcessObservationReader>;
-
 export interface DarwinHelperExecution {
   status: number | null;
   stdout: string;
@@ -168,9 +165,13 @@ export function parseLinuxProcStat(raw: string, expectedPid: number): ProcessIde
   return parseLinuxProcStatObservation(raw, expectedPid).identity;
 }
 
-export function observeProcess(reader: ProcessObservationSource, pid: number): ProcessObservation {
-  if (typeof reader.observe === "function") return reader.observe(pid);
-  return { identity: reader.read(pid), linuxState: null };
+export function observeProcess(
+  identity: ProcessIdentityReader,
+  pid: number,
+  observation?: ProcessObservationReader,
+): ProcessObservation {
+  if (observation) return observation.observe(pid);
+  return { identity: identity.read(pid), linuxState: null };
 }
 
 /** Strict parser for the bundled Darwin helper's locale-independent protocol. */

--- a/packages/core/src/process-identity.ts
+++ b/packages/core/src/process-identity.ts
@@ -41,10 +41,26 @@ export type ProcessIdentity =
   KnownProcessIdentity | MissingProcessIdentity | UnknownProcessIdentity;
 export type ProcessIdentityComparison = "same" | "different" | "missing" | "unknown";
 
+export type LinuxProcessState =
+  "R" | "S" | "D" | "Z" | "T" | "t" | "X" | "x" | "K" | "W" | "P" | "I";
+
+export interface ProcessObservation {
+  readonly identity: ProcessIdentity;
+  /** Mutable Linux execution state from the same proc-stat read as identity. */
+  readonly linuxState: LinuxProcessState | null;
+}
+
 export interface ProcessIdentityReader {
   read(pid: number): ProcessIdentity;
   self(): ProcessIdentity;
 }
+
+export interface ProcessObservationReader {
+  observe(pid: number): ProcessObservation;
+}
+
+/** Additive observation support without widening every existing identity reader. */
+export type ProcessObservationSource = ProcessIdentityReader & Partial<ProcessObservationReader>;
 
 export interface DarwinHelperExecution {
   status: number | null;
@@ -62,7 +78,20 @@ export interface ProcessIdentityServiceOptions {
   runDarwinHelper?: (path: string, pid: number) => DarwinHelperExecution;
 }
 
-const LINUX_PROCESS_STATES = new Set(["R", "S", "D", "Z", "T", "t", "X", "x", "K", "W", "P", "I"]);
+const LINUX_PROCESS_STATES = new Set<LinuxProcessState>([
+  "R",
+  "S",
+  "D",
+  "Z",
+  "T",
+  "t",
+  "X",
+  "x",
+  "K",
+  "W",
+  "P",
+  "I",
+]);
 
 function validPositiveInteger(value: number): boolean {
   return Number.isSafeInteger(value) && value > 0;
@@ -84,19 +113,25 @@ function unknown(
   return { status: "unknown", pid, platform, reason };
 }
 
-/** Parse Linux proc stat field 5 (pgrp) and field 22 (starttime). */
-export function parseLinuxProcStat(raw: string, expectedPid: number): ProcessIdentity {
-  if (!validPositiveInteger(expectedPid)) return unknown(expectedPid, "linux", "invalid_pid");
+/** Parse Linux proc stat fields 3 (state), 5 (pgrp), and 22 (starttime). */
+export function parseLinuxProcStatObservation(
+  raw: string,
+  expectedPid: number,
+): ProcessObservation {
+  const malformed = (reason: ProcessIdentityUnknownReason): ProcessObservation => ({
+    identity: unknown(expectedPid, "linux", reason),
+    linuxState: null,
+  });
+  if (!validPositiveInteger(expectedPid)) return malformed("invalid_pid");
   const firstSpace = raw.indexOf(" ");
   const commEnd = raw.lastIndexOf(")");
-  if (firstSpace <= 0 || commEnd <= firstSpace + 1)
-    return unknown(expectedPid, "linux", "malformed_response");
+  if (firstSpace <= 0 || commEnd <= firstSpace + 1) return malformed("malformed_response");
   const parsedPid = raw.slice(0, firstSpace);
   if (!canonicalPositive(parsedPid) || Number(parsedPid) !== expectedPid) {
-    return unknown(expectedPid, "linux", "malformed_response");
+    return malformed("malformed_response");
   }
   if (raw[firstSpace + 1] !== "(" || raw[commEnd + 1] !== " ") {
-    return unknown(expectedPid, "linux", "malformed_response");
+    return malformed("malformed_response");
   }
   const fieldsFromState = raw
     .slice(commEnd + 2)
@@ -107,22 +142,35 @@ export function parseLinuxProcStat(raw: string, expectedPid: number): ProcessIde
   const startTicks = fieldsFromState[19];
   if (
     !state ||
-    !LINUX_PROCESS_STATES.has(state) ||
+    !LINUX_PROCESS_STATES.has(state as LinuxProcessState) ||
     !processGroup ||
     !canonicalPositive(processGroup) ||
     !startTicks ||
     !canonicalUnsigned(startTicks)
   ) {
-    return unknown(expectedPid, "linux", "malformed_response");
+    return malformed("malformed_response");
   }
   return {
-    status: "known",
-    pid: expectedPid,
-    platform: "linux",
-    source: "procfs_stat",
-    startToken: `linux:${startTicks}`,
-    processGroupId: Number(processGroup),
+    identity: {
+      status: "known",
+      pid: expectedPid,
+      platform: "linux",
+      source: "procfs_stat",
+      startToken: `linux:${startTicks}`,
+      processGroupId: Number(processGroup),
+    },
+    linuxState: state as LinuxProcessState,
   };
+}
+
+/** Legacy identity-only projection; persisted and wire-facing bytes stay unchanged. */
+export function parseLinuxProcStat(raw: string, expectedPid: number): ProcessIdentity {
+  return parseLinuxProcStatObservation(raw, expectedPid).identity;
+}
+
+export function observeProcess(reader: ProcessObservationSource, pid: number): ProcessObservation {
+  if (typeof reader.observe === "function") return reader.observe(pid);
+  return { identity: reader.read(pid), linuxState: null };
 }
 
 /** Strict parser for the bundled Darwin helper's locale-independent protocol. */
@@ -235,7 +283,7 @@ function executeDarwinHelper(path: string, pid: number): DarwinHelperExecution {
   };
 }
 
-export class ProcessIdentityService implements ProcessIdentityReader {
+export class ProcessIdentityService implements ProcessIdentityReader, ProcessObservationReader {
   private readonly platform: string;
   private readonly selfPid: number;
   private readonly readTextFile: (path: string) => string;
@@ -253,10 +301,24 @@ export class ProcessIdentityService implements ProcessIdentityReader {
   }
 
   read(pid: number): ProcessIdentity {
-    if (!validPositiveInteger(pid)) return unknown(pid, this.platform, "invalid_pid");
-    if (this.platform === "linux") return this.readLinux(pid);
-    if (this.platform === "darwin") return this.readDarwin(pid);
-    return unknown(pid, this.platform, "unsupported_platform");
+    return this.observe(pid).identity;
+  }
+
+  observe(pid: number): ProcessObservation {
+    if (!validPositiveInteger(pid)) {
+      return {
+        identity: unknown(pid, this.platform, "invalid_pid"),
+        linuxState: null,
+      };
+    }
+    if (this.platform === "linux") return this.readLinuxObservation(pid);
+    if (this.platform === "darwin") {
+      return { identity: this.readDarwin(pid), linuxState: null };
+    }
+    return {
+      identity: unknown(pid, this.platform, "unsupported_platform"),
+      linuxState: null,
+    };
   }
 
   self(): ProcessIdentity {
@@ -264,15 +326,21 @@ export class ProcessIdentityService implements ProcessIdentityReader {
     return this.cachedSelf;
   }
 
-  private readLinux(pid: number): ProcessIdentity {
+  private readLinuxObservation(pid: number): ProcessObservation {
     try {
-      return parseLinuxProcStat(this.readTextFile(`/proc/${pid}/stat`), pid);
+      return parseLinuxProcStatObservation(this.readTextFile(`/proc/${pid}/stat`), pid);
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;
-      if (code === "ENOENT" || code === "ESRCH")
-        return { status: "missing", pid, platform: "linux" };
-      if (code === "EACCES" || code === "EPERM") return unknown(pid, "linux", "permission_denied");
-      return unknown(pid, "linux", "io_error");
+      if (code === "ENOENT" || code === "ESRCH") {
+        return { identity: { status: "missing", pid, platform: "linux" }, linuxState: null };
+      }
+      if (code === "EACCES" || code === "EPERM") {
+        return {
+          identity: unknown(pid, "linux", "permission_denied"),
+          linuxState: null,
+        };
+      }
+      return { identity: unknown(pid, "linux", "io_error"), linuxState: null };
     }
   }
 

--- a/packages/daemon/src/bootstrap-preparation.test.ts
+++ b/packages/daemon/src/bootstrap-preparation.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -130,12 +131,51 @@ describe("journal bootstrap preparation", () => {
       (slot as unknown as { prepared(): { journal: DurableJournal } }).prepared().journal,
     ).toBeDefined();
     expect(existsSync(join(root, "journal"))).toBe(false);
+    expect(manager.ready()).toBe(false);
+    expect(manager.validate()).toMatchObject({
+      status: "ready",
+      projectionStatus: [{ name: "probe", status: "valid", detail: null }],
+    });
+    expect(slot.prepared().journal.records()).toEqual([]);
+    expect(existsSync(join(root, "journal"))).toBe(false);
 
     manager.revalidatePreparation();
     expect(existsSync(join(root, "journal"))).toBe(false);
     manager.activatePrepared();
     expect(slot.current().journal.state().status).toBe("ready");
     expect(existsSync(join(root, "journal"))).toBe(true);
+    manager.close();
+  });
+
+  it("never activates or writes after semantic preparation enters recovery", () => {
+    const root = tempRoot("manager-semantic-recovery");
+    const sentinel = join(root, "activation-sentinel");
+    writeFileSync(sentinel, "must-stay-byte-identical", { mode: 0o640 });
+    const before = readFileSync(sentinel);
+    const mode = statSync(sentinel).mode & 0o777;
+    const manager = new JournalManager(root);
+    const slot = manager.registerProjection({
+      name: "invalid-projection",
+      create: (journal) => ({ journal }),
+      validate: () => {
+        throw new Error("semantic projection rejection");
+      },
+    });
+
+    expect(manager.prepare()).toMatchObject({
+      inspection: { status: "recovery_required" },
+      validation: {
+        projectionStatus: [
+          expect.objectContaining({ name: "invalid-projection", status: "invalid" }),
+        ],
+      },
+    });
+    expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+    expect(manager.inspect().status).toBe("recovery_required");
+    expect(() => slot.current()).toThrow(/requires recovery/);
+    expect(existsSync(join(root, "journal"))).toBe(false);
+    expect(readFileSync(sentinel)).toEqual(before);
+    expect(statSync(sentinel).mode & 0o777).toBe(mode);
     manager.close();
   });
 

--- a/packages/daemon/src/bootstrap-preparation.test.ts
+++ b/packages/daemon/src/bootstrap-preparation.test.ts
@@ -1,0 +1,264 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DurableJournal, journalPartitionDirectory } from "@claudexor/journal";
+import { afterEach, describe, expect, it } from "vitest";
+import { commandProjection, type CommandStore } from "./command-store.js";
+import { interactionProjection, type InteractionStore } from "./interactions.js";
+import { JournalManager, type JournalProjectionSlot } from "./journal-manager.js";
+import { operatorDecisionProjection, type OperatorDecisionStore } from "./operator-decisions.js";
+import { ProjectPartitions } from "./project-partitions.js";
+import { projectProjection, type ProjectStore } from "./projects.js";
+import { runEventProjection, type RunEventStore } from "./run-events.js";
+import { threadProjection, type ThreadStore } from "./threads.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempRoot(name: string): string {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), `claudexor-${name}-`)));
+  roots.push(root);
+  return root;
+}
+
+interface GlobalSlots {
+  commands: JournalProjectionSlot<CommandStore>;
+  interactions: JournalProjectionSlot<InteractionStore>;
+  decisions: JournalProjectionSlot<OperatorDecisionStore>;
+  runEvents: JournalProjectionSlot<RunEventStore>;
+  projects: JournalProjectionSlot<ProjectStore>;
+  threads: JournalProjectionSlot<ThreadStore>;
+}
+
+interface JournalManagerPreparation {
+  partition: string;
+  coverage: "complete";
+  inspection: { status: "ready" | "recovery_required" };
+  virtual: boolean;
+}
+
+interface ProjectPartitionsPreparation {
+  coverage: "complete" | "global_registry_unavailable";
+  registeredProjectIds: string[];
+  trustedProjectRoots: string[];
+  partitions: Array<{
+    partition: string;
+    status: "ready" | "recovery_required";
+    virtual: boolean;
+  }>;
+  readyPartitions: string[];
+  recoveryRequiredPartitions: string[];
+}
+
+function registerGlobal(manager: JournalManager): GlobalSlots {
+  return {
+    commands: manager.registerProjection(commandProjection()),
+    interactions: manager.registerProjection(interactionProjection()),
+    decisions: manager.registerProjection(operatorDecisionProjection()),
+    runEvents: manager.registerProjection(runEventProjection()),
+    projects: manager.registerProjection(projectProjection()),
+    threads: manager.registerProjection(threadProjection()),
+  };
+}
+
+function prepare(manager: JournalManager): JournalManagerPreparation {
+  return (manager as unknown as { prepare(): JournalManagerPreparation }).prepare();
+}
+
+function preparedProjectStore(slot: JournalProjectionSlot<ProjectStore>): ProjectStore {
+  return (slot as unknown as { prepared(): ProjectStore }).prepared();
+}
+
+function createPartitions(root: string, slots: GlobalSlots): ProjectPartitions {
+  return new ProjectPartitions(
+    root,
+    slots.projects,
+    slots.commands,
+    slots.interactions,
+    slots.decisions,
+    slots.runEvents,
+    slots.threads,
+  );
+}
+
+function preparePartitions(value: ProjectPartitions): ProjectPartitionsPreparation {
+  return (value as unknown as { prepare(): ProjectPartitionsPreparation }).prepare();
+}
+
+function seedProjects(root: string): Array<{ id: string; root: string }> {
+  const firstRoot = join(root, "projects-a");
+  const secondRoot = join(root, "projects-b");
+  mkdirSync(firstRoot);
+  mkdirSync(secondRoot);
+  const manager = new JournalManager(root);
+  const projects = manager.registerProjection(projectProjection());
+  manager.start();
+  const first = projects.current().register({
+    root: firstRoot,
+    idempotencyKey: "register-a",
+    clientId: "test",
+  });
+  const second = projects.current().register({
+    root: secondRoot,
+    idempotencyKey: "register-b",
+    clientId: "test",
+  });
+  manager.close();
+  return [first, second];
+}
+
+function corrupt(path: string): void {
+  const bytes = readFileSync(path);
+  bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+  writeFileSync(path, bytes, { mode: 0o600 });
+}
+
+describe("journal bootstrap preparation", () => {
+  it("keeps JournalManager construction and preparation read-only until activation", () => {
+    const root = tempRoot("manager-prepare");
+    const manager = new JournalManager(root);
+    expect(existsSync(join(root, "journal"))).toBe(false);
+    const slot = manager.registerProjection({
+      name: "probe",
+      create: (journal) => ({ journal }),
+      validate: (value) => value.journal.records(),
+    });
+
+    const result = prepare(manager);
+    expect(result).toMatchObject({
+      partition: "global",
+      coverage: "complete",
+      inspection: { status: "ready" },
+      virtual: true,
+    });
+    expect(
+      (slot as unknown as { prepared(): { journal: DurableJournal } }).prepared().journal,
+    ).toBeDefined();
+    expect(existsSync(join(root, "journal"))).toBe(false);
+
+    (manager as unknown as { revalidatePreparation(): void }).revalidatePreparation();
+    expect(existsSync(join(root, "journal"))).toBe(false);
+    (manager as unknown as { activatePrepared(): void }).activatePrepared();
+    expect(slot.current().journal.state().status).toBe("ready");
+    expect(existsSync(join(root, "journal"))).toBe(true);
+    manager.close();
+  });
+
+  it("uses only the validated global registry for exact project coverage and trusted roots", () => {
+    const root = tempRoot("partition-prepare");
+    const projects = seedProjects(root);
+    const manager = new JournalManager(root);
+    const slots = registerGlobal(manager);
+    const global = prepare(manager);
+    expect(global.inspection.status).toBe("ready");
+    expect(
+      preparedProjectStore(slots.projects)
+        .list()
+        .map((project) => project.id)
+        .sort(),
+    ).toEqual(projects.map((project) => project.id).sort());
+
+    const partitions = createPartitions(root, slots);
+    const before = projects.map((project) =>
+      existsSync(journalPartitionDirectory(join(root, "journal"), `project:${project.id}`)),
+    );
+    expect(before).toEqual([false, false]);
+    const result = preparePartitions(partitions);
+
+    expect(result.coverage).toBe("complete");
+    expect(result.registeredProjectIds.slice().sort()).toEqual(
+      projects.map((project) => project.id).sort(),
+    );
+    expect(result.trustedProjectRoots.slice().sort()).toEqual(
+      projects.map((project) => project.root).sort(),
+    );
+    expect(result.readyPartitions.slice().sort()).toEqual(
+      projects.map((project) => `project:${project.id}`).sort(),
+    );
+    expect(result.recoveryRequiredPartitions).toEqual([]);
+    expect(result.partitions.every((partition) => partition.virtual)).toBe(true);
+    for (const project of projects) {
+      expect(
+        existsSync(journalPartitionDirectory(join(root, "journal"), `project:${project.id}`)),
+      ).toBe(false);
+    }
+    partitions.close();
+    manager.close();
+  });
+
+  it("marks one corrupt registered partition globally ineligible while leaving missing peers virtual", () => {
+    const root = tempRoot("partition-corrupt");
+    const projects = seedProjects(root);
+    const corruptPartition = `project:${projects[0]!.id}`;
+    const writer = new DurableJournal({
+      rootDir: join(root, "journal"),
+      partition: corruptPartition,
+    });
+    writer.append("probe", { value: 1 });
+    const corruptPath = writer.path;
+    writer.close();
+    corrupt(corruptPath);
+
+    const manager = new JournalManager(root);
+    const slots = registerGlobal(manager);
+    prepare(manager);
+    const partitions = createPartitions(root, slots);
+    const result = preparePartitions(partitions);
+
+    expect(result.coverage).toBe("complete");
+    expect(result.recoveryRequiredPartitions).toEqual([corruptPartition]);
+    expect(result.readyPartitions).toEqual([`project:${projects[1]!.id}`]);
+    expect(result.partitions.find((entry) => entry.partition === corruptPartition)).toMatchObject({
+      virtual: false,
+      status: "recovery_required",
+    });
+    expect(
+      result.partitions.find((entry) => entry.partition === `project:${projects[1]!.id}`),
+    ).toMatchObject({ virtual: true, status: "ready" });
+    partitions.close();
+    manager.close();
+  });
+
+  it("exposes global-only recovery with unknown coverage when the registry is unavailable", () => {
+    const root = tempRoot("global-unavailable");
+    seedProjects(root);
+    const globalPath = join(
+      journalPartitionDirectory(join(root, "journal"), "global"),
+      "journal.bin",
+    );
+    corrupt(globalPath);
+    const rogue = join(root, "journal", "project-rogue-on-disk");
+    mkdirSync(rogue);
+    writeFileSync(join(rogue, "journal.bin"), "must-not-be-discovered", { mode: 0o600 });
+    const rogueBefore = readFileSync(join(rogue, "journal.bin"));
+
+    const manager = new JournalManager(root);
+    const slots = registerGlobal(manager);
+    expect(prepare(manager).inspection.status).toBe("recovery_required");
+    const partitions = createPartitions(root, slots);
+    const result = preparePartitions(partitions);
+
+    expect(result).toMatchObject({
+      coverage: "global_registry_unavailable",
+      registeredProjectIds: [],
+      trustedProjectRoots: [],
+      partitions: [],
+      readyPartitions: [],
+      recoveryRequiredPartitions: [],
+    });
+    expect(readFileSync(join(rogue, "journal.bin"))).toEqual(rogueBefore);
+    partitions.close();
+    manager.close();
+  });
+});

--- a/packages/daemon/src/bootstrap-preparation.test.ts
+++ b/packages/daemon/src/bootstrap-preparation.test.ts
@@ -13,9 +13,13 @@ import { DurableJournal, journalPartitionDirectory } from "@claudexor/journal";
 import { afterEach, describe, expect, it } from "vitest";
 import { commandProjection, type CommandStore } from "./command-store.js";
 import { interactionProjection, type InteractionStore } from "./interactions.js";
-import { JournalManager, type JournalProjectionSlot } from "./journal-manager.js";
+import {
+  JournalManager,
+  type JournalManagerPreparation,
+  type JournalProjectionSlot,
+} from "./journal-manager.js";
 import { operatorDecisionProjection, type OperatorDecisionStore } from "./operator-decisions.js";
-import { ProjectPartitions } from "./project-partitions.js";
+import { ProjectPartitions, type ProjectPartitionsPreparation } from "./project-partitions.js";
 import { projectProjection, type ProjectStore } from "./projects.js";
 import { runEventProjection, type RunEventStore } from "./run-events.js";
 import { threadProjection, type ThreadStore } from "./threads.js";
@@ -41,26 +45,6 @@ interface GlobalSlots {
   threads: JournalProjectionSlot<ThreadStore>;
 }
 
-interface JournalManagerPreparation {
-  partition: string;
-  coverage: "complete";
-  inspection: { status: "ready" | "recovery_required" };
-  virtual: boolean;
-}
-
-interface ProjectPartitionsPreparation {
-  coverage: "complete" | "global_registry_unavailable";
-  registeredProjectIds: string[];
-  trustedProjectRoots: string[];
-  partitions: Array<{
-    partition: string;
-    status: "ready" | "recovery_required";
-    virtual: boolean;
-  }>;
-  readyPartitions: string[];
-  recoveryRequiredPartitions: string[];
-}
-
 function registerGlobal(manager: JournalManager): GlobalSlots {
   return {
     commands: manager.registerProjection(commandProjection()),
@@ -73,11 +57,11 @@ function registerGlobal(manager: JournalManager): GlobalSlots {
 }
 
 function prepare(manager: JournalManager): JournalManagerPreparation {
-  return (manager as unknown as { prepare(): JournalManagerPreparation }).prepare();
+  return manager.prepare();
 }
 
 function preparedProjectStore(slot: JournalProjectionSlot<ProjectStore>): ProjectStore {
-  return (slot as unknown as { prepared(): ProjectStore }).prepared();
+  return slot.prepared();
 }
 
 function createPartitions(root: string, slots: GlobalSlots): ProjectPartitions {
@@ -93,7 +77,7 @@ function createPartitions(root: string, slots: GlobalSlots): ProjectPartitions {
 }
 
 function preparePartitions(value: ProjectPartitions): ProjectPartitionsPreparation {
-  return (value as unknown as { prepare(): ProjectPartitionsPreparation }).prepare();
+  return value.prepare();
 }
 
 function seedProjects(root: string): Array<{ id: string; root: string }> {
@@ -147,9 +131,9 @@ describe("journal bootstrap preparation", () => {
     ).toBeDefined();
     expect(existsSync(join(root, "journal"))).toBe(false);
 
-    (manager as unknown as { revalidatePreparation(): void }).revalidatePreparation();
+    manager.revalidatePreparation();
     expect(existsSync(join(root, "journal"))).toBe(false);
-    (manager as unknown as { activatePrepared(): void }).activatePrepared();
+    manager.activatePrepared();
     expect(slot.current().journal.state().status).toBe("ready");
     expect(existsSync(join(root, "journal"))).toBe(true);
     manager.close();
@@ -193,6 +177,13 @@ describe("journal bootstrap preparation", () => {
         existsSync(journalPartitionDirectory(join(root, "journal"), `project:${project.id}`)),
       ).toBe(false);
     }
+    partitions.revalidatePreparation();
+    partitions.activatePrepared();
+    for (const project of projects) {
+      expect(
+        existsSync(journalPartitionDirectory(join(root, "journal"), `project:${project.id}`)),
+      ).toBe(true);
+    }
     partitions.close();
     manager.close();
   });
@@ -226,6 +217,7 @@ describe("journal bootstrap preparation", () => {
     expect(
       result.partitions.find((entry) => entry.partition === `project:${projects[1]!.id}`),
     ).toMatchObject({ virtual: true, status: "ready" });
+    expect(() => partitions.activatePrepared()).toThrow(/require recovery/);
     partitions.close();
     manager.close();
   });
@@ -245,7 +237,16 @@ describe("journal bootstrap preparation", () => {
 
     const manager = new JournalManager(root);
     const slots = registerGlobal(manager);
-    expect(prepare(manager).inspection.status).toBe("recovery_required");
+    const global = prepare(manager);
+    expect(global.inspection.status).toBe("recovery_required");
+    expect(manager.inspect().fingerprint).toBe(global.inspection.fingerprint);
+    expect(
+      manager.preflightQuarantine({
+        idempotencyKey: "inspect-global-recovery",
+        expectedFingerprint: global.inspection.fingerprint,
+        confirmation: "quarantine_and_start_fresh",
+      }),
+    ).toMatchObject({ disposition: "new" });
     const partitions = createPartitions(root, slots);
     const result = preparePartitions(partitions);
 

--- a/packages/daemon/src/bootstrap-preparation.test.ts
+++ b/packages/daemon/src/bootstrap-preparation.test.ts
@@ -262,6 +262,49 @@ describe("journal bootstrap preparation", () => {
     manager.close();
   });
 
+  it("rolls back every sibling writer and reconstructs preparation when one partition activation fails", () => {
+    const root = tempRoot("partition-activation-rollback");
+    seedProjects(root);
+    const manager = new JournalManager(root);
+    const slots = registerGlobal(manager);
+    prepare(manager);
+    const partitions = createPartitions(root, slots);
+    expect(preparePartitions(partitions)).toMatchObject({
+      coverage: "complete",
+      recoveryRequiredPartitions: [],
+    });
+    type Entry = {
+      manager: JournalManager;
+    };
+    const collection = (partitions as unknown as { partitions: Map<string, Entry> }).partitions;
+    const [first, second] = [...collection.values()];
+    if (!first || !second) throw new Error("expected two prepared project partitions");
+    const firstPreparedJournal = (first.manager as unknown as { journal: DurableJournal | null })
+      .journal;
+    if (!firstPreparedJournal) throw new Error("expected a prepared first journal");
+    const activateFirst = first.manager.activatePrepared.bind(first.manager);
+    first.manager.activatePrepared = () => {
+      activateFirst();
+      mkdirSync(second.manager.partitionDir, { mode: 0o700 });
+    };
+
+    let activationError: unknown;
+    try {
+      partitions.activatePrepared();
+    } catch (error) {
+      activationError = error;
+    }
+    expect(activationError).toMatchObject({ code: "journal_recovery_required", status: 503 });
+    expect(() => firstPreparedJournal.append("must-not-write", {})).toThrow(/closed/);
+    expect(() => first.manager.ready()).toThrow(/closed/);
+    expect(() => second.manager.ready()).toThrow(/closed/);
+    expect([...collection.values()]).toHaveLength(2);
+    expect([...collection.values()].every((entry) => entry.manager.ready() === false)).toBe(true);
+
+    partitions.close();
+    manager.close();
+  });
+
   it("exposes global-only recovery with unknown coverage when the registry is unavailable", () => {
     const root = tempRoot("global-unavailable");
     seedProjects(root);

--- a/packages/daemon/src/bootstrap-recovery.test.ts
+++ b/packages/daemon/src/bootstrap-recovery.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DurableJournal } from "@claudexor/journal";
+import { afterEach, describe, expect, it } from "vitest";
+import { CommandStore } from "./command-store.js";
+import { InteractionStore, type InteractionContext } from "./interactions.js";
+import { QuotaRegistry } from "./quota-registry.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function journalRoot(name: string): string {
+  const root = realpathSync(mkdtempSync(join(tmpdir(), `claudexor-${name}-`)));
+  roots.push(root);
+  return join(root, "journal");
+}
+
+function recoverAfterStartup(value: unknown): void {
+  (value as { recoverAfterStartup(): void }).recoverAfterStartup();
+}
+
+function pendingInteraction(): InteractionContext {
+  return {
+    runId: "run-restart",
+    taskId: "task-restart",
+    attemptId: "a01",
+    harnessId: "claude",
+    request: {
+      interaction_id: "question",
+      source_tool: "AskUserQuestion",
+      questions: [],
+    },
+    requestedAt: "2026-08-13T00:00:00.000Z",
+    timeoutAt: null,
+  };
+}
+
+function quotaSnapshot() {
+  return {
+    subject: {
+      harness: "claude",
+      credential_route: "vendor_native" as const,
+      plan_label: null,
+      subject_id: "work",
+    },
+    constraints: [
+      {
+        id: "five-hour",
+        label: "5 hour",
+        used_ratio: 0.4,
+        window_seconds: 18_000,
+        resets_at: "2026-08-13T05:00:00.000Z",
+        cooldown_until: null,
+      },
+    ],
+    source: "claude_oauth_usage" as const,
+    observed_at: "2026-08-13T00:00:00.000Z",
+    freshness: "fresh" as const,
+  };
+}
+
+describe("bootstrap replay and deferred recovery", () => {
+  it("constructs CommandStore by replay only, then interrupts active commands explicitly", () => {
+    const root = journalRoot("command-prepare");
+    const writer = new DurableJournal({ rootDir: root, partition: "global" });
+    const first = new CommandStore(writer);
+    first.accept({
+      id: "job-queued",
+      params: { prompt: "keep queued during preparation" },
+      idempotencyKey: "queued",
+      clientId: "test",
+    });
+    writer.close();
+
+    const replay = new DurableJournal({ rootDir: root, partition: "global" });
+    const before = replay.records().length;
+    const prepared = new CommandStore(replay);
+    expect(prepared.get("job-queued")?.state).toBe("queued");
+    expect(replay.records()).toHaveLength(before);
+
+    recoverAfterStartup(prepared);
+    expect(prepared.get("job-queued")?.state).toBe("interrupted");
+    expect(replay.records()).toHaveLength(before + 1);
+    recoverAfterStartup(prepared);
+    expect(replay.records()).toHaveLength(before + 1);
+    replay.close();
+  });
+
+  it("constructs InteractionStore by replay only, then interrupts pending questions explicitly", () => {
+    const root = journalRoot("interaction-prepare");
+    const writer = new DurableJournal({ rootDir: root, partition: "global" });
+    const first = new InteractionStore(writer);
+    first.request(pendingInteraction());
+    writer.close();
+
+    const replay = new DurableJournal({ rootDir: root, partition: "global" });
+    const before = replay.records().length;
+    const prepared = new InteractionStore(replay);
+    expect(prepared.pendingForRun("run-restart")).toHaveLength(1);
+    expect(replay.records()).toHaveLength(before);
+
+    recoverAfterStartup(prepared);
+    expect(prepared.pendingForRun("run-restart")).toEqual([]);
+    expect(prepared.status("run-restart", "question")).toBe("resolved");
+    expect(replay.records()).toHaveLength(before + 1);
+    recoverAfterStartup(prepared);
+    expect(replay.records()).toHaveLength(before + 1);
+    replay.close();
+  });
+
+  it("constructs QuotaRegistry without publishing a recovered projection marker", () => {
+    const root = journalRoot("quota-prepare");
+    const writer = new DurableJournal({ rootDir: root, partition: "global" });
+    writer.append("quota.snapshot.upserted", quotaSnapshot());
+    writer.close();
+
+    const replay = new DurableJournal({ rootDir: root, partition: "global" });
+    const before = replay.records().length;
+    const prepared = new QuotaRegistry(replay, [], () => new Date("2026-08-13T00:00:01.000Z"));
+    expect(prepared.read().snapshots).toHaveLength(1);
+    expect(replay.records()).toHaveLength(before);
+
+    recoverAfterStartup(prepared);
+    expect(replay.records().map((record) => record.type)).toEqual([
+      "quota.snapshot.upserted",
+      "quota.projection.updated",
+    ]);
+    expect(replay.records().at(-1)?.payload).toMatchObject({ reason: "recovery" });
+    recoverAfterStartup(prepared);
+    expect(replay.records()).toHaveLength(before + 1);
+    replay.close();
+  });
+});

--- a/packages/daemon/src/bootstrap-recovery.test.ts
+++ b/packages/daemon/src/bootstrap-recovery.test.ts
@@ -19,10 +19,6 @@ function journalRoot(name: string): string {
   return join(root, "journal");
 }
 
-function recoverAfterStartup(value: unknown): void {
-  (value as { recoverAfterStartup(): void }).recoverAfterStartup();
-}
-
 function pendingInteraction(): InteractionContext {
   return {
     runId: "run-restart",
@@ -82,10 +78,10 @@ describe("bootstrap replay and deferred recovery", () => {
     expect(prepared.get("job-queued")?.state).toBe("queued");
     expect(replay.records()).toHaveLength(before);
 
-    recoverAfterStartup(prepared);
+    prepared.recoverAfterStartup();
     expect(prepared.get("job-queued")?.state).toBe("interrupted");
     expect(replay.records()).toHaveLength(before + 1);
-    recoverAfterStartup(prepared);
+    prepared.recoverAfterStartup();
     expect(replay.records()).toHaveLength(before + 1);
     replay.close();
   });
@@ -103,11 +99,11 @@ describe("bootstrap replay and deferred recovery", () => {
     expect(prepared.pendingForRun("run-restart")).toHaveLength(1);
     expect(replay.records()).toHaveLength(before);
 
-    recoverAfterStartup(prepared);
+    prepared.recoverAfterStartup();
     expect(prepared.pendingForRun("run-restart")).toEqual([]);
     expect(prepared.status("run-restart", "question")).toBe("resolved");
     expect(replay.records()).toHaveLength(before + 1);
-    recoverAfterStartup(prepared);
+    prepared.recoverAfterStartup();
     expect(replay.records()).toHaveLength(before + 1);
     replay.close();
   });
@@ -124,13 +120,13 @@ describe("bootstrap replay and deferred recovery", () => {
     expect(prepared.read().snapshots).toHaveLength(1);
     expect(replay.records()).toHaveLength(before);
 
-    recoverAfterStartup(prepared);
+    prepared.recoverAfterStartup();
     expect(replay.records().map((record) => record.type)).toEqual([
       "quota.snapshot.upserted",
       "quota.projection.updated",
     ]);
     expect(replay.records().at(-1)?.payload).toMatchObject({ reason: "recovery" });
-    recoverAfterStartup(prepared);
+    prepared.recoverAfterStartup();
     expect(replay.records()).toHaveLength(before + 1);
     replay.close();
   });

--- a/packages/daemon/src/command-store.ts
+++ b/packages/daemon/src/command-store.ts
@@ -53,6 +53,10 @@ export class CommandStore {
     private readonly now: () => Date = () => new Date(),
   ) {
     this.replay();
+  }
+
+  /** Apply crash terminalization only after bootstrap has proved every required partition. */
+  recoverAfterStartup(): void {
     this.interruptUnknownCommands();
   }
 
@@ -521,6 +525,7 @@ export function commandProjection() {
     name: "commands",
     create: (journal: DurableJournal) => new CommandStore(journal),
     validate: (store: CommandStore) => store.validateProjection(),
+    recover: (store: CommandStore) => store.recoverAfterStartup(),
   };
 }
 

--- a/packages/daemon/src/daemon-listen.ts
+++ b/packages/daemon/src/daemon-listen.ts
@@ -1,0 +1,40 @@
+import { chmodSync, lstatSync, unlinkSync } from "node:fs";
+import type { Server } from "node:net";
+import { pathExists } from "@claudexor/util";
+
+/**
+ * Clears a stale Unix socket file so the daemon can bind, refusing paths the
+ * daemon does not own. Windows named pipes are not filesystem entries, so the
+ * caller skips this entirely for pipe endpoints.
+ */
+export function clearStaleUnixSocketPath(socketPath: string): void {
+  if (!pathExists(socketPath)) return;
+  const stale = lstatSync(socketPath);
+  if (!stale.isSocket() || (process.getuid && stale.uid !== process.getuid())) {
+    throw Object.assign(new Error(`refusing to replace non-owned Unix socket path`), {
+      code: "unsafe_daemon_socket_path",
+    });
+  }
+  unlinkSync(socketPath);
+}
+
+/** Binds the server and tightens Unix socket permissions to the owner. */
+export function listenOnDaemonEndpoint(
+  server: Server,
+  socketPath: string,
+  pipeEndpoint: boolean,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      if (!pipeEndpoint) {
+        try {
+          chmodSync(socketPath, 0o600);
+        } catch {
+          /* best-effort on exotic filesystems */
+        }
+      }
+      resolve();
+    });
+  });
+}

--- a/packages/daemon/src/daemon.test.ts
+++ b/packages/daemon/src/daemon.test.ts
@@ -64,6 +64,7 @@ function commandAuthority(
 } {
   const journal = new DurableJournal({ rootDir: join(dir, "journal"), partition });
   const store = new CommandStore(journal);
+  store.recoverAfterStartup();
   return { journal, store, slot: { current: () => store } };
 }
 
@@ -2028,6 +2029,7 @@ describe("InteractionRegistry", () => {
 
     const secondJournal = new DurableJournal({ rootDir, partition: "global" });
     const second = new InteractionStore(secondJournal);
+    second.recoverAfterStartup();
     expect(second.pendingForRun("run-restart")).toEqual([]);
     expect(second.status("run-restart", "question")).toBe("resolved");
     secondJournal.close();

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -3,6 +3,7 @@ export * from "./server.js";
 export * from "./delegation-admission.js";
 export * from "./writer-lease.js";
 export * from "./root-authority.js";
+export * from "./serving-admission.js";
 export * from "./terminate.js";
 export * from "./client.js";
 export * from "./daemon-shutdown-rpc.js";

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -17,4 +17,5 @@ export * from "./command-store.js";
 export * from "./command-authority.js";
 export * from "./resource-store.js";
 export * from "./quota-registry.js";
+export * from "./quota-projection.js";
 export * from "./project-partitions.js";

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -2,6 +2,7 @@ export * from "./token.js";
 export * from "./server.js";
 export * from "./delegation-admission.js";
 export * from "./writer-lease.js";
+export * from "./root-authority.js";
 export * from "./terminate.js";
 export * from "./client.js";
 export * from "./daemon-shutdown-rpc.js";

--- a/packages/daemon/src/interactions.test.ts
+++ b/packages/daemon/src/interactions.test.ts
@@ -72,6 +72,7 @@ describe("InteractionRegistry disabled expiry", () => {
 
     const secondJournal = new DurableJournal({ rootDir: journalRoot, partition: "global" });
     const second = new InteractionStore(secondJournal);
+    second.recoverAfterStartup();
     expect(second.pendingForRun("run-1")).toEqual([]);
     expect(second.status("run-1", "int-1")).toBe("resolved");
     secondJournal.close();

--- a/packages/daemon/src/interactions.ts
+++ b/packages/daemon/src/interactions.ts
@@ -40,6 +40,10 @@ export class InteractionStore {
 
   constructor(private readonly journal: DurableJournal) {
     this.replay();
+  }
+
+  /** Resolve replayed pending interactions only after bootstrap activation. */
+  recoverAfterStartup(): void {
     this.interruptAfterRestart();
   }
 
@@ -248,6 +252,7 @@ export function interactionProjection() {
     name: "interactions",
     create: (journal: DurableJournal) => new InteractionStore(journal),
     validate: (store: InteractionStore) => store.validateProjection(),
+    recover: (store: InteractionStore) => store.recoverAfterStartup(),
   };
 }
 

--- a/packages/daemon/src/journal-manager-lifecycle.ts
+++ b/packages/daemon/src/journal-manager-lifecycle.ts
@@ -1,0 +1,14 @@
+export type JournalManagerFault =
+  | "afterQuarantineRename"
+  | "afterQuarantineReceipt"
+  | "beforeArchiveRename"
+  | "beforeProjectionActivation";
+
+export type JournalManagerLifecycle =
+  "idle" | "prepared" | "active" | "recovery_required" | "closed";
+
+export interface JournalManagerOptions {
+  partition?: string;
+  now?: () => Date;
+  faults?: Partial<Record<JournalManagerFault, () => void>>;
+}

--- a/packages/daemon/src/journal-manager.test.ts
+++ b/packages/daemon/src/journal-manager.test.ts
@@ -267,7 +267,14 @@ describe("JournalManager", () => {
 
     const resumed = new JournalManager(root);
     const slot = registerProbe(resumed);
-    expect(resumed.start().status).toBe("ready");
+    expect(resumed.prepare()).toMatchObject({
+      inspection: { status: "ready" },
+      virtual: true,
+    });
+    expect(storedOperation().status).toBe("prepared");
+    resumed.revalidatePreparation();
+    expect(storedOperation().status).toBe("prepared");
+    resumed.activatePrepared();
     expect(
       slot
         .current()
@@ -300,7 +307,10 @@ describe("JournalManager", () => {
 
     const resumed = new JournalManager(root);
     const slot = registerProbe(resumed);
-    expect(resumed.start().status).toBe("ready");
+    expect(resumed.prepare().inspection.status).toBe("ready");
+    expect(storedOperation().status).toBe("prepared");
+    resumed.revalidatePreparation();
+    resumed.activatePrepared();
     expect(slot.current().journal.records()).toHaveLength(1);
     expect(storedOperation().status).toBe("completed");
     resumed.close();
@@ -331,7 +341,7 @@ describe("JournalManager", () => {
     rogue.close();
     const restarted = new JournalManager(root);
     const slot = registerProbe(restarted);
-    expect(restarted.start().status).toBe("recovery_required");
+    expect(restarted.prepare().inspection.status).toBe("recovery_required");
     expect(() => slot.current()).toThrow(/requires recovery/);
     restarted.close();
   });

--- a/packages/daemon/src/journal-manager.test.ts
+++ b/packages/daemon/src/journal-manager.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   existsSync,
@@ -14,10 +15,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DurableJournal, JournalCursorError } from "@claudexor/journal";
 import { JournalManager } from "./journal-manager.js";
+import { fingerprintPartition } from "./journal-recovery-files.js";
 
 let root: string;
 
@@ -54,6 +56,14 @@ function seedCorruptPartition(partition = "global") {
   const journalPath = slot.current().journal.path;
   first.close();
   return { journalPath, corruptBytes: corruptFirstByte(journalPath) };
+}
+
+function recoveryOperationsDir(manager: JournalManager): string {
+  return join(manager.rootDir, "recovery-operations", basename(manager.partitionDir));
+}
+
+function treeReceipt(path: string): { bytes: Buffer; mode: number } {
+  return { bytes: readFileSync(path), mode: statSync(path).mode & 0o777 };
 }
 
 interface StoredOperation {
@@ -193,6 +203,101 @@ describe("JournalManager", () => {
     expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
     expect(manager.inspect().status).toBe("recovery_required");
     expect(readFileSync(join(original, "journal.bin"))).toEqual(originalBytes);
+    manager.close();
+  });
+
+  it("rejects unsafe recovery-operation roots and ancestors without following or mutating them", () => {
+    for (const kind of [
+      "regular",
+      "symlink",
+      "public",
+      "public-ancestor",
+      "symlink-ancestor",
+    ] as const) {
+      const caseRoot = join(root, `unsafe-operations-${kind}`);
+      mkdirSync(caseRoot, { mode: 0o700 });
+      const manager = new JournalManager(caseRoot);
+      registerProbe(manager);
+      const sentinel = join(caseRoot, "no-write-sentinel");
+      writeFileSync(sentinel, "must-stay-byte-identical", { mode: 0o640 });
+      const sentinelBefore = treeReceipt(sentinel);
+      const operationsDir = recoveryOperationsDir(manager);
+      const operationsParent = join(caseRoot, "recovery-operations");
+      const outside = join(root, `unsafe-operations-outside-${kind}`);
+      mkdirSync(outside, { mode: 0o700 });
+      writeFileSync(join(outside, "sentinel"), "outside-sentinel", { mode: 0o600 });
+      if (kind === "symlink-ancestor") {
+        symlinkSync(outside, operationsParent);
+        mkdirSync(join(outside, basename(operationsDir)), { mode: 0o700 });
+      } else {
+        mkdirSync(operationsParent, { mode: 0o700 });
+        if (kind === "regular") writeFileSync(operationsDir, "not-a-directory", { mode: 0o600 });
+        if (kind === "symlink") symlinkSync(outside, operationsDir);
+        if (kind === "public") {
+          mkdirSync(operationsDir, { mode: 0o700 });
+          chmodSync(operationsDir, 0o755);
+        }
+        if (kind === "public-ancestor") chmodSync(operationsParent, 0o755);
+      }
+      const outsideBefore = readFileSync(join(outside, "sentinel"));
+
+      expect(manager.prepare()).toMatchObject({
+        inspection: { status: "recovery_required" },
+      });
+      expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+      expect(readFileSync(join(outside, "sentinel"))).toEqual(outsideBefore);
+      expect(treeReceipt(sentinel)).toEqual(sentinelBefore);
+      if (kind === "regular") expect(readFileSync(operationsDir, "utf8")).toBe("not-a-directory");
+      if (kind === "public") expect(statSync(operationsDir).mode & 0o777).toBe(0o755);
+      if (kind === "public-ancestor") {
+        expect(statSync(operationsParent).mode & 0o777).toBe(0o755);
+      }
+      manager.close();
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects a FIFO recovery-operation root without opening or replacing it",
+    () => {
+      const caseRoot = join(root, "unsafe-operations-fifo");
+      mkdirSync(caseRoot, { mode: 0o700 });
+      const manager = new JournalManager(caseRoot);
+      registerProbe(manager);
+      const sentinel = join(caseRoot, "no-write-sentinel");
+      writeFileSync(sentinel, "must-stay-byte-identical", { mode: 0o640 });
+      const sentinelBefore = treeReceipt(sentinel);
+      const operationsDir = recoveryOperationsDir(manager);
+      mkdirSync(join(caseRoot, "recovery-operations"), { mode: 0o700 });
+      execFileSync("mkfifo", [operationsDir]);
+
+      expect(manager.prepare()).toMatchObject({
+        inspection: { status: "recovery_required" },
+      });
+      expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+      expect(statSync(operationsDir).isFIFO()).toBe(true);
+      expect(treeReceipt(sentinel)).toEqual(sentinelBefore);
+      manager.close();
+    },
+  );
+
+  it("binds prepared recovery-operation input to its pathname identity", () => {
+    const caseRoot = join(root, "operations-identity-replacement");
+    mkdirSync(caseRoot, { mode: 0o700 });
+    const manager = new JournalManager(caseRoot);
+    registerProbe(manager);
+    const operationsDir = recoveryOperationsDir(manager);
+    mkdirSync(join(caseRoot, "recovery-operations"), { mode: 0o700 });
+    mkdirSync(operationsDir, { mode: 0o700 });
+    expect(manager.prepare()).toMatchObject({ inspection: { status: "ready" } });
+    const contentFingerprint = fingerprintPartition(operationsDir, caseRoot).fingerprint;
+    renameSync(operationsDir, `${operationsDir}.original`);
+    mkdirSync(operationsDir, { mode: 0o700 });
+
+    expect(fingerprintPartition(operationsDir, caseRoot).fingerprint).toBe(contentFingerprint);
+    expect(() => manager.revalidatePreparation()).toThrow(/requires recovery/);
+    expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+    expect(manager.inspect().status).toBe("recovery_required");
+    expect(readdirSync(operationsDir)).toEqual([]);
     manager.close();
   });
 

--- a/packages/daemon/src/journal-manager.test.ts
+++ b/packages/daemon/src/journal-manager.test.ts
@@ -1,10 +1,13 @@
 import {
+  chmodSync,
   existsSync,
   linkSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   realpathSync,
   readdirSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -129,6 +132,95 @@ describe("JournalManager", () => {
     expect(() => registerProbe(manager, "late")).toThrow(/registration is closed/);
     manager.close();
   });
+
+  it("fails closed and revokes the writer when prepared projection activation throws", () => {
+    const manager = new JournalManager(root, {
+      faults: {
+        beforeProjectionActivation: () => {
+          throw new Error("simulated projection activation failure");
+        },
+      },
+    });
+    const slot = registerProbe(manager);
+    expect(manager.prepare().inspection.status).toBe("ready");
+    const preparedProjection = slot.prepared();
+
+    expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+    expect(manager.inspect().status).toBe("recovery_required");
+    expect(manager.ready()).toBe(false);
+    expect(() => slot.current()).toThrow(/requires recovery/);
+    expect(() => preparedProjection.journal.append("probe", {})).toThrow(/closed/);
+    manager.close();
+  });
+
+  it("turns a disappeared prepared partition into recovery without recreating it", () => {
+    const seeded = new DurableJournal({ rootDir: join(root, "journal"), partition: "global" });
+    seeded.append("probe.saved", { value: 1 });
+    const original = seeded.partitionDir;
+    const bytes = readFileSync(seeded.path);
+    seeded.close();
+    const manager = new JournalManager(root);
+    registerProbe(manager);
+    expect(manager.prepare().inspection.status).toBe("ready");
+    const moved = `${original}.moved`;
+    renameSync(original, moved);
+
+    expect(() => manager.revalidatePreparation()).toThrow(/requires recovery/);
+    expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+    expect(manager.inspect().status).toBe("recovery_required");
+    expect(existsSync(original)).toBe(false);
+    expect(readFileSync(join(moved, "journal.bin"))).toEqual(bytes);
+    manager.close();
+  });
+
+  it("turns a pathname replacement race into recovery without touching replacement bytes", () => {
+    const seeded = new DurableJournal({ rootDir: join(root, "journal"), partition: "global" });
+    seeded.append("probe.saved", { value: 1 });
+    const original = seeded.partitionDir;
+    const originalBytes = readFileSync(seeded.path);
+    seeded.close();
+    const manager = new JournalManager(root);
+    registerProbe(manager);
+    expect(manager.prepare().inspection.status).toBe("ready");
+    renameSync(original, `${original}.original`);
+    mkdirSync(original, { mode: 0o700 });
+    writeFileSync(join(original, "journal.bin"), originalBytes, { mode: 0o600 });
+
+    expect(manager.validate()).toMatchObject({
+      status: "recovery_required",
+      projectionStatus: [expect.objectContaining({ name: "probe", status: "invalid" })],
+    });
+    expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+    expect(manager.inspect().status).toBe("recovery_required");
+    expect(readFileSync(join(original, "journal.bin"))).toEqual(originalBytes);
+    manager.close();
+  });
+
+  it.runIf(process.platform !== "win32" && process.getuid?.() !== 0)(
+    "reports an unreadable partition as recovery instead of throwing from fingerprinting",
+    () => {
+      const seeded = new DurableJournal({ rootDir: join(root, "journal"), partition: "global" });
+      seeded.append("probe.saved", { value: 1 });
+      const path = seeded.path;
+      const partitionDir = seeded.partitionDir;
+      const bytes = readFileSync(path);
+      seeded.close();
+      chmodSync(partitionDir, 0o000);
+      const manager = new JournalManager(root);
+      registerProbe(manager);
+      try {
+        expect(manager.prepare()).toMatchObject({
+          inspection: { status: "recovery_required" },
+        });
+        expect(() => manager.activatePrepared()).toThrow(/requires recovery/);
+      } finally {
+        chmodSync(partitionDir, 0o700);
+      }
+      expect(readFileSync(path)).toEqual(bytes);
+      expect(manager.inspect().status).toBe("recovery_required");
+      manager.close();
+    },
+  );
 
   it("keeps inspect, validate and secret-safe export online without mutating corrupt bytes", () => {
     const { journalPath, corruptBytes } = seedCorruptPartition();

--- a/packages/daemon/src/journal-manager.test.ts
+++ b/packages/daemon/src/journal-manager.test.ts
@@ -280,6 +280,69 @@ describe("JournalManager", () => {
     },
   );
 
+  it("keeps a still-prepared sibling partition valid across another partition's quarantine (S2-CR1)", () => {
+    // Mixed root: healthy global (prepared, still-prepared at quarantine
+    // time) + corrupt project. The FIRST quarantine on a root creates the
+    // shared recovery-operations/ parent; that daemon-owned infrastructure
+    // write must not poison the sibling's read-only preparation identity.
+    const global = new JournalManager(root);
+    const globalSlot = registerProbe(global);
+    global.start();
+    globalSlot.current().journal.append("probe.saved", { partition: "global" });
+    global.close();
+    seedCorruptPartition("project:victim");
+
+    const preparedGlobal = new JournalManager(root);
+    registerProbe(preparedGlobal);
+    expect(preparedGlobal.prepare().inspection.status).toBe("ready");
+    const project = new JournalManager(root, { partition: "project:victim" });
+    registerProbe(project);
+    const projectInspection = project.prepare().inspection;
+    expect(projectInspection.status).toBe("recovery_required");
+
+    const receipt = project.quarantineAndStartFresh({
+      idempotencyKey: "recover-project-victim",
+      expectedFingerprint: projectInspection.fingerprint,
+      confirmation: "quarantine_and_start_fresh",
+    });
+    expect(receipt.partition).toBe("project:victim");
+    expect(project.inspect().status).toBe("ready");
+
+    // The sibling's preparation must still revalidate and activate.
+    preparedGlobal.revalidatePreparation();
+    preparedGlobal.activatePrepared();
+    expect(preparedGlobal.ready()).toBe(true);
+    expect(preparedGlobal.inspect().status).toBe("ready");
+    project.close();
+    preparedGlobal.close();
+  });
+
+  it("still fails revalidation when the shared recovery-operations parent appears TAMPERED (S2-CR1)", () => {
+    // The quarantine-infrastructure exemption is existence-only: a shared
+    // parent that appears with a non-private mode (or as a symlink) after
+    // read-only preparation is genuine ancestry tampering and must still
+    // fail closed.
+    for (const kind of ["public", "symlink"] as const) {
+      const caseRoot = join(root, `tampered-shared-parent-${kind}`);
+      mkdirSync(caseRoot, { mode: 0o700 });
+      const manager = new JournalManager(caseRoot);
+      registerProbe(manager);
+      expect(manager.prepare().inspection.status).toBe("ready");
+      const operationsParent = join(caseRoot, "recovery-operations");
+      if (kind === "public") {
+        mkdirSync(operationsParent, { mode: 0o755 });
+      } else {
+        const outside = join(root, `tampered-shared-parent-outside-${kind}`);
+        mkdirSync(outside, { mode: 0o700 });
+        symlinkSync(outside, operationsParent);
+      }
+
+      expect(() => manager.revalidatePreparation()).toThrow(/requires recovery/);
+      expect(manager.inspect().status).toBe("recovery_required");
+      manager.close();
+    }
+  });
+
   it("binds prepared recovery-operation input to its pathname identity", () => {
     const caseRoot = join(root, "operations-identity-replacement");
     mkdirSync(caseRoot, { mode: 0o700 });

--- a/packages/daemon/src/journal-manager.ts
+++ b/packages/daemon/src/journal-manager.ts
@@ -23,6 +23,7 @@ import {
   safeMessage,
   sha256,
   writeAtomicPrivateJson,
+  type PartitionFingerprint,
 } from "./journal-recovery-files.js";
 import {
   conflict,
@@ -45,23 +46,20 @@ import {
   type PreparedOperationPlan,
 } from "./journal-prepared-operation.js";
 import type { JournalProjectionDescriptor, JournalProjectionSlot } from "./journal-projection.js";
+import {
+  prepareProjectionSlots,
+  ProjectionSlot,
+  type ProjectionRegistration,
+} from "./journal-projection-slot.js";
+import type {
+  JournalManagerFault,
+  JournalManagerLifecycle,
+  JournalManagerOptions,
+} from "./journal-manager-lifecycle.js";
 export type { JournalProjectionDescriptor, JournalProjectionSlot } from "./journal-projection.js";
+export type { JournalManagerOptions } from "./journal-manager-lifecycle.js";
 
 export type { JournalQuarantineRequest } from "./journal-recovery-operation.js";
-
-interface ProjectionRegistration<T = unknown> {
-  descriptor: JournalProjectionDescriptor<T>;
-  slot: ProjectionSlot<T>;
-}
-
-type JournalManagerFault =
-  "afterQuarantineRename" | "afterQuarantineReceipt" | "beforeArchiveRename";
-
-export interface JournalManagerOptions {
-  partition?: string;
-  now?: () => Date;
-  faults?: Partial<Record<JournalManagerFault, () => void>>;
-}
 
 export interface JournalManagerPreparation {
   partition: string;
@@ -88,8 +86,7 @@ export class JournalManager {
   private generationValue = 0;
   private preparedOperation: PreparedOperationPlan | null = null;
   private preparationResult: JournalManagerPreparation | null = null;
-  private started = false;
-  private closed = false;
+  private lifecycle: JournalManagerLifecycle = "idle";
 
   constructor(rootDir: string, options: JournalManagerOptions = {}) {
     this.partition = options.partition?.trim() || "global";
@@ -105,7 +102,7 @@ export class JournalManager {
 
   registerProjection<T>(descriptor: JournalProjectionDescriptor<T>): JournalProjectionSlot<T> {
     this.assertOpen();
-    if (this.started) throw new Error("journal projection registration is closed");
+    if (this.lifecycle !== "idle") throw new Error("journal projection registration is closed");
     if (!/^[A-Za-z0-9._-]+$/.test(descriptor.name) || this.registrations.has(descriptor.name)) {
       throw new Error(`invalid or duplicate journal projection '${descriptor.name}'`);
     }
@@ -116,21 +113,24 @@ export class JournalManager {
 
   start(): ControlJournalInspection {
     this.assertOpen();
-    if (this.started) return this.inspect();
+    if (this.lifecycle !== "idle") return this.inspect();
     if (this.registrations.size === 0) throw new Error("journal partition requires a projection");
     ensureCanonicalPrivateDirectory(this.rootDir);
     ensureCanonicalPrivateDirectory(this.journalRoot);
-    this.started = true;
     if (!this.reconcilePrepared()) this.openGeneration();
     return this.inspect();
   }
 
   prepare(): JournalManagerPreparation {
     this.assertOpen();
-    if (this.preparationResult) return structuredClone(this.preparationResult);
-    if (this.started) throw new Error("journal manager is already running");
+    if (
+      this.preparationResult &&
+      (this.lifecycle === "prepared" || this.lifecycle === "recovery_required")
+    ) {
+      return structuredClone(this.preparationResult);
+    }
+    if (this.lifecycle !== "idle") throw new Error("journal manager is already running");
     if (this.registrations.size === 0) throw new Error("journal partition requires a projection");
-    this.started = true;
     this.generationValue += 1;
     const projectionStatus: ControlJournalValidation["projectionStatus"] = [];
     try {
@@ -149,71 +149,74 @@ export class JournalManager {
         journal: this.journal,
       });
       if (this.recovery.status === "ready") {
-        for (const registration of this.registrations.values()) {
-          try {
-            const projection = registration.descriptor.create(this.journal);
-            registration.descriptor.validate(projection);
-            registration.slot.bindPrepared(projection);
-            projectionStatus.push({
-              name: registration.descriptor.name,
-              status: "valid",
-              detail: null,
-            });
-          } catch (error) {
-            this.enterRecovery(
-              recoveryFrom(error, `projection '${registration.descriptor.name}' failed`),
-            );
-            projectionStatus.push({
-              name: registration.descriptor.name,
-              status: "invalid",
-              detail: safeMessage(error),
-            });
-            break;
-          }
-        }
+        const prepared = prepareProjectionSlots(this.registrations.values(), this.journal);
+        projectionStatus.push(...prepared.status);
+        if (prepared.recovery) this.enterRecovery(prepared.recovery);
       }
     } catch (error) {
       this.enterRecovery(recoveryFrom(error, `${this.partition} journal could not be prepared`));
     }
+    const partitionFingerprint = this.observeFingerprint(this.partitionDir, "journal partition");
+    const operationsFingerprint = this.observeFingerprint(
+      this.operationsDir,
+      "journal recovery operations",
+    );
     const journalFingerprint =
-      this.journal?.preparation().fingerprint ?? fingerprintPartition(this.partitionDir);
+      this.journal?.preparation().fingerprint ?? partitionFingerprint.fingerprint;
     const preparedFingerprint = preparationFingerprint(
       journalFingerprint,
-      this.preparedOperation?.fingerprint ?? fingerprintPartition(this.operationsDir),
+      this.preparedOperation?.fingerprint ?? operationsFingerprint.fingerprint,
     );
-    const inspection = this.inspection(fingerprintPartition(this.partitionDir));
+    const inspection = this.inspection(partitionFingerprint.fingerprint);
     this.preparationResult = {
       partition: this.partition,
       coverage: "complete",
       inspection,
       validation: { ...inspection, projectionStatus },
       preparationFingerprint: preparedFingerprint,
-      virtual: this.journal?.preparation().virtual ?? !existsSync(this.partitionDir),
+      virtual: this.journal?.preparation().virtual ?? !partitionFingerprint.exists,
     };
+    if (this.recovery.status === "ready") this.lifecycle = "prepared";
+    else this.enterRecovery(this.recovery);
     return structuredClone(this.preparationResult);
   }
 
   revalidatePreparation(): void {
     this.assertStarted();
+    if (this.lifecycle === "recovery_required") {
+      throw new JournalRecoveryRequiredError(this.recovery as never);
+    }
+    if (this.lifecycle !== "prepared") throw new Error("journal manager is not prepared");
     if (!this.preparationResult || !this.journal) throw new Error("journal is not prepared");
-    this.preparedOperation = revalidatePreparedState({
-      operationsDir: this.operationsDir,
-      quarantineDir: this.quarantineDir,
-      partitionDir: this.partitionDir,
-      partition: this.partition,
-      artifactPrefix: this.artifactPrefix,
-      journal: this.journal,
-      expectedFingerprint: this.preparationResult.preparationFingerprint,
-    });
+    try {
+      this.preparedOperation = revalidatePreparedState({
+        operationsDir: this.operationsDir,
+        quarantineDir: this.quarantineDir,
+        partitionDir: this.partitionDir,
+        partition: this.partition,
+        artifactPrefix: this.artifactPrefix,
+        journal: this.journal,
+        expectedFingerprint: this.preparationResult.preparationFingerprint,
+      });
+    } catch (error) {
+      const recovery = recoveryFrom(error, `${this.partition} preparation revalidation failed`);
+      this.enterRecovery(recovery);
+      throw new JournalRecoveryRequiredError(recovery);
+    }
   }
 
   activatePrepared(): void {
     this.assertStarted();
+    if (this.lifecycle === "active") return;
+    if (this.lifecycle === "recovery_required") {
+      throw new JournalRecoveryRequiredError(this.recovery as never);
+    }
+    if (this.lifecycle !== "prepared") throw new Error("journal manager is not prepared");
     if (!this.preparationResult || !this.journal) throw new Error("journal is not prepared");
-    this.revalidatePreparation();
-    this.journal.activatePrepared();
-    if (!this.preparedOperation) throw new Error("journal recovery operation is not prepared");
     try {
+      this.revalidatePreparation();
+      this.journal.activatePrepared();
+      if (!this.preparedOperation) throw new Error("journal recovery operation is not prepared");
       applyPreparedOperation({
         plan: this.preparedOperation,
         journal: this.journal,
@@ -222,19 +225,28 @@ export class JournalManager {
         now: this.now,
         afterReceipt: this.faults.afterQuarantineReceipt,
       });
+      const activatedRecovery = this.journal.state();
+      if (activatedRecovery.status === "recovery_required") {
+        throw new JournalRecoveryRequiredError(activatedRecovery);
+      }
+      for (const registration of this.registrations.values()) {
+        this.faults.beforeProjectionActivation?.();
+        registration.slot.activate(this.generationValue);
+      }
+      this.recovery = activatedRecovery;
+      this.lifecycle = "active";
     } catch (error) {
-      const recovery = recoveryFrom(error, `${this.partition} prepared operation failed`);
+      const recovery = recoveryFrom(error, `${this.partition} prepared activation failed`);
+      this.journal?.close();
+      this.journal = null;
       this.enterRecovery(recovery);
       throw new JournalRecoveryRequiredError(recovery);
-    }
-    this.recovery = this.journal.state();
-    for (const registration of this.registrations.values()) {
-      registration.slot.activate(this.generationValue);
     }
   }
 
   recoverAfterStartup(): void {
     this.assertStarted();
+    if (this.lifecycle !== "active") throw new Error("journal manager is not active");
     try {
       for (const registration of this.registrations.values()) {
         registration.descriptor.recover?.(registration.slot.current());
@@ -252,7 +264,9 @@ export class JournalManager {
       const state = this.journal.state();
       if (state.status === "recovery_required") this.enterRecovery(state);
     }
-    return this.inspection(fingerprintPartition(this.partitionDir));
+    return this.inspection(
+      this.observeFingerprint(this.partitionDir, "journal partition").fingerprint,
+    );
   }
 
   ready(): boolean {
@@ -261,16 +275,21 @@ export class JournalManager {
       const state = this.journal.state();
       if (state.status === "recovery_required") this.enterRecovery(state);
     }
-    return this.recovery.status === "ready";
+    return this.lifecycle === "active" && this.recovery.status === "ready";
   }
 
   validate(): ControlJournalValidation {
     this.assertStarted();
-    const before = fingerprintPartition(this.partitionDir);
+    if (this.lifecycle === "prepared") {
+      try {
+        this.revalidatePreparation();
+      } catch {}
+    }
+    const before = this.observeFingerprint(this.partitionDir, "journal validation input");
     const projectionStatus: ControlJournalValidation["projectionStatus"] = [];
     for (const registration of this.registrations.values()) {
       try {
-        const projection = registration.slot.current();
+        const projection = registration.slot.prepared();
         registration.descriptor.validate(projection);
         projectionStatus.push({
           name: registration.descriptor.name,
@@ -288,9 +307,11 @@ export class JournalManager {
         });
       }
     }
-    const after = fingerprintPartition(this.partitionDir);
-    if (before !== after) this.enterRecovery(recoveryAt(0, "journal changed during validation"));
-    return { ...this.inspection(after), projectionStatus };
+    const after = this.observeFingerprint(this.partitionDir, "journal validation input");
+    if (before.fingerprint !== after.fingerprint) {
+      this.enterRecovery(recoveryAt(0, "journal changed during validation"));
+    }
+    return { ...this.inspection(after.fingerprint), projectionStatus };
   }
 
   events(afterCursor?: string) {
@@ -333,7 +354,10 @@ export class JournalManager {
         "only a corrupt partition can be quarantined",
       );
     }
-    if (fingerprintPartition(this.partitionDir) !== input.expectedFingerprint) {
+    if (
+      this.stableFingerprint(this.partitionDir, "journal recovery source").fingerprint !==
+      input.expectedFingerprint
+    ) {
       throw conflict("recovery_fingerprint_mismatch");
     }
     return { disposition: "new", receipt: null };
@@ -371,8 +395,8 @@ export class JournalManager {
   }
 
   close(): void {
-    if (this.closed) return;
-    this.closed = true;
+    if (this.lifecycle === "closed") return;
+    this.lifecycle = "closed";
     this.clearSlots();
     this.journal?.close();
     this.journal = null;
@@ -416,7 +440,7 @@ export class JournalManager {
       this.openGeneration();
       throw error;
     }
-    this.closed = true;
+    this.lifecycle = "closed";
     fsyncDirectory(this.journalRoot);
     fsyncDirectory(archiveDir);
     return dest;
@@ -441,7 +465,7 @@ export class JournalManager {
     }
     renameSync(archivedPath, this.partitionDir);
     fsyncDirectory(this.journalRoot);
-    this.closed = false;
+    this.lifecycle = "idle";
     this.openGeneration();
   }
 
@@ -458,12 +482,16 @@ export class JournalManager {
         now: this.now,
       });
       this.recovery = this.journal.state();
-      if (this.recovery.status === "recovery_required") return;
+      if (this.recovery.status === "recovery_required") {
+        this.enterRecovery(this.recovery);
+        return;
+      }
       for (const registration of this.registrations.values()) {
         const projection = registration.descriptor.create(this.journal);
         registration.descriptor.validate(projection);
         registration.slot.bind(projection, this.generationValue);
       }
+      this.lifecycle = "active";
       this.recoverAfterStartup();
     } catch (error) {
       const failed = this.journal;
@@ -482,11 +510,13 @@ export class JournalManager {
     operation: QuarantineOperation,
     operationPath: string,
   ): ControlJournalQuarantineReceipt {
-    const sourceExists = existsSync(this.partitionDir);
-    const targetExists = existsSync(operation.quarantinePath);
+    const source = this.stableFingerprint(this.partitionDir, "journal recovery source");
+    const target = this.stableFingerprint(operation.quarantinePath, "journal quarantine target");
+    const sourceExists = source.exists;
+    const targetExists = target.exists;
     if (sourceExists && targetExists) return this.completeFromReceipt(operation, operationPath);
     if (sourceExists) {
-      if (fingerprintPartition(this.partitionDir) !== operation.expectedFingerprint) {
+      if (source.fingerprint !== operation.expectedFingerprint) {
         throw conflict("recovery_fingerprint_mismatch");
       }
       this.clearSlots();
@@ -495,13 +525,16 @@ export class JournalManager {
       renameSync(this.partitionDir, operation.quarantinePath);
       fsyncDirectory(this.journalRoot);
       fsyncDirectory(dirname(operation.quarantinePath));
-      if (fingerprintPartition(operation.quarantinePath) !== operation.expectedFingerprint) {
+      if (
+        this.stableFingerprint(operation.quarantinePath, "journal quarantine target")
+          .fingerprint !== operation.expectedFingerprint
+      ) {
         throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
       }
       this.faults.afterQuarantineRename?.();
     } else if (!targetExists) {
       throw typedError("recovery_operation_missing", 503, "recovery source and target are missing");
-    } else if (fingerprintPartition(operation.quarantinePath) !== operation.expectedFingerprint) {
+    } else if (target.fingerprint !== operation.expectedFingerprint) {
       throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
     }
 
@@ -577,8 +610,26 @@ export class JournalManager {
   }
 
   private enterRecovery(state: Extract<JournalRecoveryState, { status: "recovery_required" }>) {
+    const closeWriter = this.lifecycle === "active";
     this.recovery = cloneRecovery(state) as typeof state;
+    this.lifecycle = "recovery_required";
     this.clearSlots();
+    if (closeWriter) {
+      this.journal?.close();
+      this.journal = null;
+    }
+  }
+
+  private observeFingerprint(path: string, context: string): PartitionFingerprint {
+    const observed = fingerprintPartition(path);
+    if (observed.problem) this.enterRecovery(recoveryAt(0, `${context}: ${observed.problem}`));
+    return observed;
+  }
+
+  private stableFingerprint(path: string, context: string): PartitionFingerprint {
+    const observed = this.observeFingerprint(path, context);
+    if (observed.problem) throw new JournalRecoveryRequiredError(this.recovery as never);
+    return observed;
   }
 
   private clearSlots(): void {
@@ -587,60 +638,10 @@ export class JournalManager {
 
   private assertStarted(): void {
     this.assertOpen();
-    if (!this.started) throw new Error("journal manager is not running");
+    if (this.lifecycle === "idle") throw new Error("journal manager is not running");
   }
 
   private assertOpen(): void {
-    if (this.closed) throw new Error("journal manager is closed");
-  }
-}
-
-class ProjectionSlot<T> implements JournalProjectionSlot<T> {
-  private value: T | null = null;
-  private preparedValue: T | null = null;
-  private generationValue = 0;
-
-  constructor(private readonly recovery: () => JournalRecoveryState) {}
-
-  current(): T {
-    if (this.value !== null) return this.value;
-    const state = this.recovery();
-    throw new JournalRecoveryRequiredError(
-      state.status === "recovery_required"
-        ? state
-        : recoveryAt(0, "journal projection is unavailable"),
-    );
-  }
-
-  prepared(): T {
-    if (this.preparedValue !== null) return this.preparedValue;
-    return this.current();
-  }
-
-  generation(): number {
-    return this.generationValue;
-  }
-
-  bind(value: T, generation: number): void {
-    this.value = value;
-    this.generationValue = generation;
-  }
-
-  bindPrepared(value: T): void {
-    this.preparedValue = value;
-  }
-
-  activate(generation: number): void {
-    if (this.preparedValue === null) {
-      if (this.value !== null) return;
-      throw new Error("journal projection is not prepared");
-    }
-    this.bind(this.preparedValue, generation);
-    this.preparedValue = null;
-  }
-
-  clear(): void {
-    this.value = null;
-    this.preparedValue = null;
+    if (this.lifecycle === "closed") throw new Error("journal manager is closed");
   }
 }

--- a/packages/daemon/src/journal-manager.ts
+++ b/packages/daemon/src/journal-manager.ts
@@ -181,10 +181,6 @@ export class JournalManager {
 
   revalidatePreparation(): void {
     this.assertStarted();
-    // An ACTIVE manager's preparation was already consumed by activation; the
-    // live single-writer journal is self-fencing (C6 in-process reopen runs
-    // the stage-4 revalidation over a mix of prepared and reopened managers).
-    if (this.lifecycle === "active") return;
     if (this.lifecycle === "recovery_required") {
       throw new JournalRecoveryRequiredError(this.recovery as never);
     }

--- a/packages/daemon/src/journal-manager.ts
+++ b/packages/daemon/src/journal-manager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, readdirSync, realpathSync, renameSync, rmSync } from "node:fs";
+import { existsSync, realpathSync, renameSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 import {
   DurableJournal,
@@ -8,49 +8,50 @@ import {
   type JournalRecoveryState,
 } from "@claudexor/journal";
 import {
-  ControlJournalQuarantineReceipt as QuarantineReceiptSchema,
   type ControlJournalExportReceipt,
   type ControlJournalInspection,
   type ControlJournalQuarantineReceipt,
-  type ControlJournalQuarantineRequest,
   type ControlJournalValidation,
 } from "@claudexor/schema";
 import { ensureCanonicalPrivateDirectory, fsyncDirectory } from "@claudexor/util";
 import {
-  exportPartitionEntries,
+  exportJournalRecovery,
   fingerprintPartition,
   cloneRecovery,
-  readOwnedFile,
   recoveryAt,
   recoveryFrom,
   safeMessage,
   sha256,
-  sha256File,
   writeAtomicPrivateJson,
-  writeExclusiveFile,
 } from "./journal-recovery-files.js";
+import {
+  conflict,
+  matchingReceipt,
+  quarantineRequestDigest,
+  readOperation,
+  typedError,
+  validateRequest,
+  type JournalQuarantineRequest,
+  type QuarantineOperation,
+} from "./journal-recovery-operation.js";
 import { journalEvents } from "./journal-events.js";
+import {
+  applyPreparedOperation,
+  completePreparedReceipt,
+  inspectPreparedOperation,
+  preparationFingerprint,
+  reconcilePreparedOperationOnStart,
+  revalidatePreparedState,
+  type PreparedOperationPlan,
+} from "./journal-prepared-operation.js";
 import type { JournalProjectionDescriptor, JournalProjectionSlot } from "./journal-projection.js";
 export type { JournalProjectionDescriptor, JournalProjectionSlot } from "./journal-projection.js";
 
-export type JournalQuarantineRequest = ControlJournalQuarantineRequest & {
-  idempotencyKey: string;
-};
+export type { JournalQuarantineRequest } from "./journal-recovery-operation.js";
 
 interface ProjectionRegistration<T = unknown> {
   descriptor: JournalProjectionDescriptor<T>;
   slot: ProjectionSlot<T>;
-}
-
-interface QuarantineOperation {
-  schemaVersion: 1;
-  operationId: string;
-  keyDigest: string;
-  requestDigest: string;
-  expectedFingerprint: string;
-  quarantinePath: string;
-  status: "prepared" | "completed";
-  receipt: ControlJournalQuarantineReceipt | null;
 }
 
 type JournalManagerFault =
@@ -62,7 +63,17 @@ export interface JournalManagerOptions {
   faults?: Partial<Record<JournalManagerFault, () => void>>;
 }
 
+export interface JournalManagerPreparation {
+  partition: string;
+  coverage: "complete";
+  inspection: ControlJournalInspection;
+  validation: ControlJournalValidation;
+  preparationFingerprint: string;
+  virtual: boolean;
+}
+
 export class JournalManager {
+  readonly rootDir: string;
   readonly partition: string;
   readonly journalRoot: string;
   readonly partitionDir: string;
@@ -75,19 +86,17 @@ export class JournalManager {
   private journal: DurableJournal | null = null;
   private recovery: JournalRecoveryState = { status: "ready", discardedTailBytes: 0 };
   private generationValue = 0;
+  private preparedOperation: PreparedOperationPlan | null = null;
+  private preparationResult: JournalManagerPreparation | null = null;
   private started = false;
   private closed = false;
 
-  constructor(
-    readonly rootDir: string,
-    options: JournalManagerOptions = {},
-  ) {
+  constructor(rootDir: string, options: JournalManagerOptions = {}) {
     this.partition = options.partition?.trim() || "global";
     this.now = options.now ?? (() => new Date());
     this.faults = options.faults ?? {};
-    ensureCanonicalPrivateDirectory(rootDir);
-    this.journalRoot = join(realpathSync(rootDir), "journal");
-    ensureCanonicalPrivateDirectory(this.journalRoot);
+    this.rootDir = realpathSync(rootDir);
+    this.journalRoot = join(this.rootDir, "journal");
     this.partitionDir = journalPartitionDirectory(this.journalRoot, this.partition);
     this.artifactPrefix = basename(this.partitionDir);
     this.operationsDir = join(this.rootDir, "recovery-operations", basename(this.partitionDir));
@@ -109,9 +118,132 @@ export class JournalManager {
     this.assertOpen();
     if (this.started) return this.inspect();
     if (this.registrations.size === 0) throw new Error("journal partition requires a projection");
+    ensureCanonicalPrivateDirectory(this.rootDir);
+    ensureCanonicalPrivateDirectory(this.journalRoot);
     this.started = true;
     if (!this.reconcilePrepared()) this.openGeneration();
     return this.inspect();
+  }
+
+  prepare(): JournalManagerPreparation {
+    this.assertOpen();
+    if (this.preparationResult) return structuredClone(this.preparationResult);
+    if (this.started) throw new Error("journal manager is already running");
+    if (this.registrations.size === 0) throw new Error("journal partition requires a projection");
+    this.started = true;
+    this.generationValue += 1;
+    const projectionStatus: ControlJournalValidation["projectionStatus"] = [];
+    try {
+      this.journal = DurableJournal.prepare({
+        rootDir: this.journalRoot,
+        partition: this.partition,
+        now: this.now,
+      });
+      this.recovery = this.journal.state();
+      this.preparedOperation = inspectPreparedOperation({
+        operationsDir: this.operationsDir,
+        quarantineDir: this.quarantineDir,
+        partitionDir: this.partitionDir,
+        partition: this.partition,
+        artifactPrefix: this.artifactPrefix,
+        journal: this.journal,
+      });
+      if (this.recovery.status === "ready") {
+        for (const registration of this.registrations.values()) {
+          try {
+            const projection = registration.descriptor.create(this.journal);
+            registration.descriptor.validate(projection);
+            registration.slot.bindPrepared(projection);
+            projectionStatus.push({
+              name: registration.descriptor.name,
+              status: "valid",
+              detail: null,
+            });
+          } catch (error) {
+            this.enterRecovery(
+              recoveryFrom(error, `projection '${registration.descriptor.name}' failed`),
+            );
+            projectionStatus.push({
+              name: registration.descriptor.name,
+              status: "invalid",
+              detail: safeMessage(error),
+            });
+            break;
+          }
+        }
+      }
+    } catch (error) {
+      this.enterRecovery(recoveryFrom(error, `${this.partition} journal could not be prepared`));
+    }
+    const journalFingerprint =
+      this.journal?.preparation().fingerprint ?? fingerprintPartition(this.partitionDir);
+    const preparedFingerprint = preparationFingerprint(
+      journalFingerprint,
+      this.preparedOperation?.fingerprint ?? fingerprintPartition(this.operationsDir),
+    );
+    const inspection = this.inspection(fingerprintPartition(this.partitionDir));
+    this.preparationResult = {
+      partition: this.partition,
+      coverage: "complete",
+      inspection,
+      validation: { ...inspection, projectionStatus },
+      preparationFingerprint: preparedFingerprint,
+      virtual: this.journal?.preparation().virtual ?? !existsSync(this.partitionDir),
+    };
+    return structuredClone(this.preparationResult);
+  }
+
+  revalidatePreparation(): void {
+    this.assertStarted();
+    if (!this.preparationResult || !this.journal) throw new Error("journal is not prepared");
+    this.preparedOperation = revalidatePreparedState({
+      operationsDir: this.operationsDir,
+      quarantineDir: this.quarantineDir,
+      partitionDir: this.partitionDir,
+      partition: this.partition,
+      artifactPrefix: this.artifactPrefix,
+      journal: this.journal,
+      expectedFingerprint: this.preparationResult.preparationFingerprint,
+    });
+  }
+
+  activatePrepared(): void {
+    this.assertStarted();
+    if (!this.preparationResult || !this.journal) throw new Error("journal is not prepared");
+    this.revalidatePreparation();
+    this.journal.activatePrepared();
+    if (!this.preparedOperation) throw new Error("journal recovery operation is not prepared");
+    try {
+      applyPreparedOperation({
+        plan: this.preparedOperation,
+        journal: this.journal,
+        partition: this.partition,
+        artifactPrefix: this.artifactPrefix,
+        now: this.now,
+        afterReceipt: this.faults.afterQuarantineReceipt,
+      });
+    } catch (error) {
+      const recovery = recoveryFrom(error, `${this.partition} prepared operation failed`);
+      this.enterRecovery(recovery);
+      throw new JournalRecoveryRequiredError(recovery);
+    }
+    this.recovery = this.journal.state();
+    for (const registration of this.registrations.values()) {
+      registration.slot.activate(this.generationValue);
+    }
+  }
+
+  recoverAfterStartup(): void {
+    this.assertStarted();
+    try {
+      for (const registration of this.registrations.values()) {
+        registration.descriptor.recover?.(registration.slot.current());
+      }
+    } catch (error) {
+      const recovery = recoveryFrom(error, `${this.partition} projection recovery failed`);
+      this.enterRecovery(recovery);
+      throw new JournalRecoveryRequiredError(recovery);
+    }
   }
 
   inspect(): ControlJournalInspection {
@@ -168,53 +300,13 @@ export class JournalManager {
 
   exportRecovery(): ControlJournalExportReceipt {
     this.assertStarted();
-    const fingerprint = fingerprintPartition(this.partitionDir);
-    const exportId = `journal-export-${this.now().getTime().toString(36)}-${randomUUID()}`;
-    const exportsRoot = join(this.rootDir, "recovery-exports");
-    ensureCanonicalPrivateDirectory(exportsRoot);
-    const bundlePath = join(exportsRoot, exportId);
-    ensureCanonicalPrivateDirectory(bundlePath);
-    try {
-      const entries = exportPartitionEntries(this.partitionDir, bundlePath);
-      const createdAt = this.now().toISOString();
-      const manifestPath = join(bundlePath, "manifest.json");
-      writeExclusiveFile(
-        manifestPath,
-        Buffer.from(
-          `${JSON.stringify(
-            {
-              schemaVersion: 1,
-              exportId,
-              partition: this.partition,
-              fingerprint,
-              recovery: this.recovery,
-              createdAt,
-              entries,
-            },
-            null,
-            2,
-          )}\n`,
-        ),
-        0o400,
-      );
-      fsyncDirectory(bundlePath);
-      if (fingerprintPartition(this.partitionDir) !== fingerprint) {
-        throw new Error("journal changed during recovery export");
-      }
-      return {
-        schemaVersion: 1,
-        exportId,
-        partition: this.partition,
-        fingerprint,
-        bundlePath,
-        manifestSha256: sha256File(manifestPath),
-        createdAt,
-      };
-    } catch (error) {
-      rmSync(bundlePath, { recursive: true, force: true });
-      fsyncDirectory(exportsRoot);
-      throw error;
-    }
+    return exportJournalRecovery({
+      rootDir: this.rootDir,
+      partitionDir: this.partitionDir,
+      partition: this.partition,
+      recovery: this.recovery,
+      now: this.now,
+    });
   }
 
   preflightQuarantine(input: JournalQuarantineRequest) {
@@ -372,6 +464,7 @@ export class JournalManager {
         registration.descriptor.validate(projection);
         registration.slot.bind(projection, this.generationValue);
       }
+      this.recoverAfterStartup();
     } catch (error) {
       const failed = this.journal;
       this.journal = null;
@@ -443,55 +536,31 @@ export class JournalManager {
     operation: QuarantineOperation,
     operationPath: string,
   ): ControlJournalQuarantineReceipt {
-    if (fingerprintPartition(operation.quarantinePath) !== operation.expectedFingerprint) {
-      throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
-    }
     if (!this.journal) this.openGeneration();
     if (!this.journal || this.recovery.status === "recovery_required") {
       throw typedError("recovery_operation_ambiguous", 503, "fresh journal is unreadable");
     }
-    const records = this.journal.records();
-    if (records.length !== 1 || records[0]?.type !== "journal.partition_quarantined") {
-      throw typedError("recovery_operation_ambiguous", 503, "fresh receipt is missing");
-    }
-    const receipt = matchingReceipt(
+    return completePreparedReceipt({
       operation,
-      records[0].payload,
-      this.partition,
-      this.artifactPrefix,
-    );
-    writeAtomicPrivateJson(operationPath, { ...operation, status: "completed", receipt }, false);
-    return receipt;
+      operationPath,
+      journal: this.journal,
+      partition: this.partition,
+      artifactPrefix: this.artifactPrefix,
+    });
   }
 
   private reconcilePrepared(): boolean {
-    if (!existsSync(this.operationsDir)) return false;
-    try {
-      const prepared = readdirSync(this.operationsDir)
-        .filter((name) => /^[a-f0-9]{64}\.json$/.test(name))
-        .map((name) => {
-          const path = join(this.operationsDir, name);
-          return {
-            path,
-            operation: readOperation(path, this.quarantineDir, this.partition, this.artifactPrefix),
-          };
-        })
-        .filter(
-          (entry): entry is { path: string; operation: QuarantineOperation } =>
-            entry.operation?.status === "prepared",
-        );
-      if (prepared.length === 0) return false;
-      if (prepared.length !== 1) throw new Error("multiple prepared recovery operations");
-      const pending = prepared[0]!;
-      if (existsSync(this.partitionDir) && !existsSync(pending.operation.quarantinePath)) {
-        this.openGeneration();
-      } else {
-        this.resume(pending.operation, pending.path);
-      }
-    } catch (error) {
-      this.enterRecovery(recoveryFrom(error, "prepared quarantine reconciliation failed"));
-    }
-    return true;
+    return reconcilePreparedOperationOnStart({
+      operationsDir: this.operationsDir,
+      quarantineDir: this.quarantineDir,
+      partitionDir: this.partitionDir,
+      partition: this.partition,
+      artifactPrefix: this.artifactPrefix,
+      openGeneration: () => this.openGeneration(),
+      resume: (operation, path) => void this.resume(operation, path),
+      failed: (error) =>
+        this.enterRecovery(recoveryFrom(error, "prepared quarantine reconciliation failed")),
+    });
   }
 
   private inspection(fingerprint: string): ControlJournalInspection {
@@ -528,6 +597,7 @@ export class JournalManager {
 
 class ProjectionSlot<T> implements JournalProjectionSlot<T> {
   private value: T | null = null;
+  private preparedValue: T | null = null;
   private generationValue = 0;
 
   constructor(private readonly recovery: () => JournalRecoveryState) {}
@@ -542,6 +612,11 @@ class ProjectionSlot<T> implements JournalProjectionSlot<T> {
     );
   }
 
+  prepared(): T {
+    if (this.preparedValue !== null) return this.preparedValue;
+    return this.current();
+  }
+
   generation(): number {
     return this.generationValue;
   }
@@ -551,98 +626,21 @@ class ProjectionSlot<T> implements JournalProjectionSlot<T> {
     this.generationValue = generation;
   }
 
+  bindPrepared(value: T): void {
+    this.preparedValue = value;
+  }
+
+  activate(generation: number): void {
+    if (this.preparedValue === null) {
+      if (this.value !== null) return;
+      throw new Error("journal projection is not prepared");
+    }
+    this.bind(this.preparedValue, generation);
+    this.preparedValue = null;
+  }
+
   clear(): void {
     this.value = null;
+    this.preparedValue = null;
   }
-}
-
-function readOperation(
-  path: string,
-  quarantineDir: string,
-  partition: string,
-  artifactPrefix: string,
-): QuarantineOperation | null {
-  if (!existsSync(path)) return null;
-  const value = JSON.parse(readOwnedFile(path).toString("utf8")) as unknown;
-  if (
-    !isRecord(value) ||
-    value.schemaVersion !== 1 ||
-    typeof value.operationId !== "string" ||
-    typeof value.keyDigest !== "string" ||
-    basename(path) !== `${value.keyDigest}.json` ||
-    typeof value.requestDigest !== "string" ||
-    typeof value.expectedFingerprint !== "string" ||
-    typeof value.quarantinePath !== "string" ||
-    value.quarantinePath !== join(quarantineDir, `${artifactPrefix}-${value.operationId}`) ||
-    (value.status !== "prepared" && value.status !== "completed")
-  ) {
-    throw new Error("recovery operation is malformed");
-  }
-  const operation = value as unknown as QuarantineOperation;
-  if (operation.status === "prepared" && operation.receipt !== null) {
-    throw new Error("prepared recovery operation contains a receipt");
-  }
-  if (operation.status === "completed") {
-    matchingReceipt(operation, undefined, partition, artifactPrefix);
-  }
-  return operation;
-}
-
-function matchingReceipt(
-  operation: QuarantineOperation,
-  value: unknown,
-  partition: string,
-  artifactPrefix: string,
-): ControlJournalQuarantineReceipt {
-  const receipt = QuarantineReceiptSchema.parse(value ?? operation.receipt);
-  if (
-    receipt.operationId !== operation.operationId ||
-    receipt.partition !== partition ||
-    receipt.previousFingerprint !== operation.expectedFingerprint ||
-    receipt.quarantinePath !== operation.quarantinePath ||
-    receipt.quarantineArtifactId !== `${artifactPrefix}-${operation.operationId}`
-  ) {
-    throw typedError("recovery_receipt_mismatch", 503, "quarantine receipt does not match intent");
-  }
-  return receipt;
-}
-
-function validateRequest(input: JournalQuarantineRequest): void {
-  if (!input.idempotencyKey || input.idempotencyKey.length > 256) {
-    throw typedError(
-      "invalid_idempotency_key",
-      400,
-      "Idempotency-Key must contain 1-256 characters",
-    );
-  }
-  if (input.confirmation !== "quarantine_and_start_fresh") {
-    throw typedError("quarantine_confirmation_required", 400, "explicit confirmation is required");
-  }
-  if (!/^[a-f0-9]{64}$/.test(input.expectedFingerprint)) {
-    throw typedError("invalid_recovery_fingerprint", 400, "expectedFingerprint must be SHA-256");
-  }
-}
-
-function quarantineRequestDigest(partition: string, input: JournalQuarantineRequest): string {
-  return sha256(
-    Buffer.from(
-      JSON.stringify({
-        partition,
-        expectedFingerprint: input.expectedFingerprint,
-        confirmation: input.confirmation,
-      }),
-    ),
-  );
-}
-
-function conflict(code: string): Error & { code: string; status: number } {
-  return typedError(code, 409, code.replaceAll("_", " "));
-}
-
-function typedError(code: string, status: number, message: string) {
-  return Object.assign(new Error(message), { code, status });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/daemon/src/journal-manager.ts
+++ b/packages/daemon/src/journal-manager.ts
@@ -87,7 +87,6 @@ export class JournalManager {
   private preparedOperation: PreparedOperationPlan | null = null;
   private preparationResult: JournalManagerPreparation | null = null;
   private lifecycle: JournalManagerLifecycle = "idle";
-
   constructor(rootDir: string, options: JournalManagerOptions = {}) {
     this.partition = options.partition?.trim() || "global";
     this.now = options.now ?? (() => new Date());
@@ -141,6 +140,7 @@ export class JournalManager {
       });
       this.recovery = this.journal.state();
       this.preparedOperation = inspectPreparedOperation({
+        rootDir: this.rootDir,
         operationsDir: this.operationsDir,
         quarantineDir: this.quarantineDir,
         partitionDir: this.partitionDir,
@@ -161,11 +161,9 @@ export class JournalManager {
       this.operationsDir,
       "journal recovery operations",
     );
-    const journalFingerprint =
-      this.journal?.preparation().fingerprint ?? partitionFingerprint.fingerprint;
     const preparedFingerprint = preparationFingerprint(
-      journalFingerprint,
-      this.preparedOperation?.fingerprint ?? operationsFingerprint.fingerprint,
+      this.journal?.preparation().preparationIdentity ?? partitionFingerprint.preparationIdentity,
+      this.preparedOperation?.fingerprint ?? operationsFingerprint.preparationIdentity,
     );
     const inspection = this.inspection(partitionFingerprint.fingerprint);
     this.preparationResult = {
@@ -190,6 +188,7 @@ export class JournalManager {
     if (!this.preparationResult || !this.journal) throw new Error("journal is not prepared");
     try {
       this.preparedOperation = revalidatePreparedState({
+        rootDir: this.rootDir,
         operationsDir: this.operationsDir,
         quarantineDir: this.quarantineDir,
         partitionDir: this.partitionDir,
@@ -218,6 +217,7 @@ export class JournalManager {
       this.journal.activatePrepared();
       if (!this.preparedOperation) throw new Error("journal recovery operation is not prepared");
       applyPreparedOperation({
+        rootDir: this.rootDir,
         plan: this.preparedOperation,
         journal: this.journal,
         partition: this.partition,
@@ -574,6 +574,7 @@ export class JournalManager {
       throw typedError("recovery_operation_ambiguous", 503, "fresh journal is unreadable");
     }
     return completePreparedReceipt({
+      rootDir: this.rootDir,
       operation,
       operationPath,
       journal: this.journal,
@@ -621,7 +622,7 @@ export class JournalManager {
   }
 
   private observeFingerprint(path: string, context: string): PartitionFingerprint {
-    const observed = fingerprintPartition(path);
+    const observed = fingerprintPartition(path, this.rootDir);
     if (observed.problem) this.enterRecovery(recoveryAt(0, `${context}: ${observed.problem}`));
     return observed;
   }

--- a/packages/daemon/src/journal-manager.ts
+++ b/packages/daemon/src/journal-manager.ts
@@ -181,6 +181,10 @@ export class JournalManager {
 
   revalidatePreparation(): void {
     this.assertStarted();
+    // An ACTIVE manager's preparation was already consumed by activation; the
+    // live single-writer journal is self-fencing (C6 in-process reopen runs
+    // the stage-4 revalidation over a mix of prepared and reopened managers).
+    if (this.lifecycle === "active") return;
     if (this.lifecycle === "recovery_required") {
       throw new JournalRecoveryRequiredError(this.recovery as never);
     }

--- a/packages/daemon/src/journal-prepared-operation.ts
+++ b/packages/daemon/src/journal-prepared-operation.ts
@@ -6,6 +6,7 @@ import type { ControlJournalQuarantineReceipt } from "@claudexor/schema";
 import {
   fingerprintPartition,
   requireStableFingerprint,
+  requireStablePreparationIdentity,
   writeAtomicPrivateJson,
 } from "./journal-recovery-files.js";
 import {
@@ -25,6 +26,7 @@ export type PreparedOperationPlan =
     };
 
 export function inspectPreparedOperation(input: {
+  rootDir: string;
   operationsDir: string;
   quarantineDir: string;
   partitionDir: string;
@@ -32,13 +34,13 @@ export function inspectPreparedOperation(input: {
   artifactPrefix: string;
   journal: DurableJournal | null;
 }): PreparedOperationPlan {
-  const operations = fingerprintPartition(input.operationsDir);
-  const operationsFingerprint = requireStableFingerprint(
+  const operations = fingerprintPartition(input.operationsDir, input.rootDir);
+  const operationsIdentity = requireStablePreparationIdentity(
     operations,
     "journal recovery operations are unavailable",
   );
   if (!operations.exists) {
-    return { kind: "none", fingerprint: operationFingerprint(operationsFingerprint, null) };
+    return { kind: "none", fingerprint: operationFingerprint(operationsIdentity, null) };
   }
   const prepared = readdirSync(input.operationsDir)
     .filter((name) => /^[a-f0-9]{64}\.json$/.test(name))
@@ -54,12 +56,12 @@ export function inspectPreparedOperation(input: {
         entry.operation?.status === "prepared",
     );
   if (prepared.length === 0) {
-    return { kind: "none", fingerprint: operationFingerprint(operationsFingerprint, null) };
+    return { kind: "none", fingerprint: operationFingerprint(operationsIdentity, null) };
   }
   if (prepared.length !== 1) throw new Error("multiple prepared recovery operations");
   const pending = prepared[0]!;
-  const source = fingerprintPartition(input.partitionDir);
-  const target = fingerprintPartition(pending.operation.quarantinePath);
+  const source = fingerprintPartition(input.partitionDir, input.rootDir);
+  const target = fingerprintPartition(pending.operation.quarantinePath, input.rootDir);
   requireStableFingerprint(source, "journal recovery source is unavailable");
   const stableTargetFingerprint = requireStableFingerprint(
     target,
@@ -68,8 +70,8 @@ export function inspectPreparedOperation(input: {
   const sourceExists = source.exists;
   const targetExists = target.exists;
   const fingerprint = operationFingerprint(
-    operationsFingerprint,
-    targetExists ? stableTargetFingerprint : null,
+    operationsIdentity,
+    requireStablePreparationIdentity(target, "journal recovery quarantine is unavailable"),
   );
   if (targetExists && stableTargetFingerprint !== pending.operation.expectedFingerprint) {
     throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
@@ -105,7 +107,7 @@ export function revalidatePreparedState(
   input.journal.revalidatePreparation();
   const operation = inspectPreparedOperation(input);
   const actual = preparationFingerprint(
-    input.journal.preparation().fingerprint,
+    input.journal.preparation().preparationIdentity,
     operation.fingerprint,
   );
   if (actual !== input.expectedFingerprint) {
@@ -115,6 +117,7 @@ export function revalidatePreparedState(
 }
 
 export function applyPreparedOperation(input: {
+  rootDir: string;
   plan: PreparedOperationPlan;
   journal: DurableJournal;
   partition: string;
@@ -124,12 +127,12 @@ export function applyPreparedOperation(input: {
 }): void {
   if (input.plan.kind === "none" || input.plan.kind === "source_intact") return;
   const currentFingerprint = operationFingerprint(
-    requireStableFingerprint(
-      fingerprintPartition(dirname(input.plan.path)),
+    requireStablePreparationIdentity(
+      fingerprintPartition(dirname(input.plan.path), input.rootDir),
       "journal recovery operations changed",
     ),
-    requireStableFingerprint(
-      fingerprintPartition(input.plan.operation.quarantinePath),
+    requireStablePreparationIdentity(
+      fingerprintPartition(input.plan.operation.quarantinePath, input.rootDir),
       "journal recovery quarantine changed",
     ),
   );
@@ -138,7 +141,7 @@ export function applyPreparedOperation(input: {
   }
   if (
     requireStableFingerprint(
-      fingerprintPartition(input.plan.operation.quarantinePath),
+      fingerprintPartition(input.plan.operation.quarantinePath, input.rootDir),
       "journal recovery quarantine changed",
     ) !== input.plan.operation.expectedFingerprint
   ) {
@@ -177,6 +180,7 @@ export function applyPreparedOperation(input: {
 }
 
 export function completePreparedReceipt(input: {
+  rootDir: string;
   operation: QuarantineOperation;
   operationPath: string;
   journal: DurableJournal;
@@ -185,7 +189,7 @@ export function completePreparedReceipt(input: {
 }): ControlJournalQuarantineReceipt {
   if (
     requireStableFingerprint(
-      fingerprintPartition(input.operation.quarantinePath),
+      fingerprintPartition(input.operation.quarantinePath, input.rootDir),
       "journal recovery quarantine changed",
     ) !== input.operation.expectedFingerprint
   ) {

--- a/packages/daemon/src/journal-prepared-operation.ts
+++ b/packages/daemon/src/journal-prepared-operation.ts
@@ -3,7 +3,11 @@ import { existsSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { DurableJournal } from "@claudexor/journal";
 import type { ControlJournalQuarantineReceipt } from "@claudexor/schema";
-import { fingerprintPartition, writeAtomicPrivateJson } from "./journal-recovery-files.js";
+import {
+  fingerprintPartition,
+  requireStableFingerprint,
+  writeAtomicPrivateJson,
+} from "./journal-recovery-files.js";
 import {
   matchingReceipt,
   readOperation,
@@ -28,8 +32,12 @@ export function inspectPreparedOperation(input: {
   artifactPrefix: string;
   journal: DurableJournal | null;
 }): PreparedOperationPlan {
-  const operationsFingerprint = fingerprintPartition(input.operationsDir);
-  if (!existsSync(input.operationsDir)) {
+  const operations = fingerprintPartition(input.operationsDir);
+  const operationsFingerprint = requireStableFingerprint(
+    operations,
+    "journal recovery operations are unavailable",
+  );
+  if (!operations.exists) {
     return { kind: "none", fingerprint: operationFingerprint(operationsFingerprint, null) };
   }
   const prepared = readdirSync(input.operationsDir)
@@ -50,13 +58,20 @@ export function inspectPreparedOperation(input: {
   }
   if (prepared.length !== 1) throw new Error("multiple prepared recovery operations");
   const pending = prepared[0]!;
-  const sourceExists = existsSync(input.partitionDir);
-  const targetExists = existsSync(pending.operation.quarantinePath);
-  const targetFingerprint = targetExists
-    ? fingerprintPartition(pending.operation.quarantinePath)
-    : null;
-  const fingerprint = operationFingerprint(operationsFingerprint, targetFingerprint);
-  if (targetExists && targetFingerprint !== pending.operation.expectedFingerprint) {
+  const source = fingerprintPartition(input.partitionDir);
+  const target = fingerprintPartition(pending.operation.quarantinePath);
+  requireStableFingerprint(source, "journal recovery source is unavailable");
+  const stableTargetFingerprint = requireStableFingerprint(
+    target,
+    "journal recovery quarantine is unavailable",
+  );
+  const sourceExists = source.exists;
+  const targetExists = target.exists;
+  const fingerprint = operationFingerprint(
+    operationsFingerprint,
+    targetExists ? stableTargetFingerprint : null,
+  );
+  if (targetExists && stableTargetFingerprint !== pending.operation.expectedFingerprint) {
     throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
   }
   if (sourceExists && !targetExists) {
@@ -109,15 +124,23 @@ export function applyPreparedOperation(input: {
 }): void {
   if (input.plan.kind === "none" || input.plan.kind === "source_intact") return;
   const currentFingerprint = operationFingerprint(
-    fingerprintPartition(dirname(input.plan.path)),
-    fingerprintPartition(input.plan.operation.quarantinePath),
+    requireStableFingerprint(
+      fingerprintPartition(dirname(input.plan.path)),
+      "journal recovery operations changed",
+    ),
+    requireStableFingerprint(
+      fingerprintPartition(input.plan.operation.quarantinePath),
+      "journal recovery quarantine changed",
+    ),
   );
   if (currentFingerprint !== input.plan.fingerprint) {
     throw typedError("recovery_fingerprint_mismatch", 409, "prepared recovery input changed");
   }
   if (
-    fingerprintPartition(input.plan.operation.quarantinePath) !==
-    input.plan.operation.expectedFingerprint
+    requireStableFingerprint(
+      fingerprintPartition(input.plan.operation.quarantinePath),
+      "journal recovery quarantine changed",
+    ) !== input.plan.operation.expectedFingerprint
   ) {
     throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
   }
@@ -161,7 +184,10 @@ export function completePreparedReceipt(input: {
   artifactPrefix: string;
 }): ControlJournalQuarantineReceipt {
   if (
-    fingerprintPartition(input.operation.quarantinePath) !== input.operation.expectedFingerprint
+    requireStableFingerprint(
+      fingerprintPartition(input.operation.quarantinePath),
+      "journal recovery quarantine changed",
+    ) !== input.operation.expectedFingerprint
   ) {
     throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
   }

--- a/packages/daemon/src/journal-prepared-operation.ts
+++ b/packages/daemon/src/journal-prepared-operation.ts
@@ -1,0 +1,246 @@
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { DurableJournal } from "@claudexor/journal";
+import type { ControlJournalQuarantineReceipt } from "@claudexor/schema";
+import { fingerprintPartition, writeAtomicPrivateJson } from "./journal-recovery-files.js";
+import {
+  matchingReceipt,
+  readOperation,
+  typedError,
+  type QuarantineOperation,
+} from "./journal-recovery-operation.js";
+
+export type PreparedOperationPlan =
+  | { kind: "none"; fingerprint: string }
+  | {
+      kind: "source_intact" | "resume_after_activation" | "complete_after_activation";
+      fingerprint: string;
+      path: string;
+      operation: QuarantineOperation;
+    };
+
+export function inspectPreparedOperation(input: {
+  operationsDir: string;
+  quarantineDir: string;
+  partitionDir: string;
+  partition: string;
+  artifactPrefix: string;
+  journal: DurableJournal | null;
+}): PreparedOperationPlan {
+  const operationsFingerprint = fingerprintPartition(input.operationsDir);
+  if (!existsSync(input.operationsDir)) {
+    return { kind: "none", fingerprint: operationFingerprint(operationsFingerprint, null) };
+  }
+  const prepared = readdirSync(input.operationsDir)
+    .filter((name) => /^[a-f0-9]{64}\.json$/.test(name))
+    .map((name) => {
+      const path = join(input.operationsDir, name);
+      return {
+        path,
+        operation: readOperation(path, input.quarantineDir, input.partition, input.artifactPrefix),
+      };
+    })
+    .filter(
+      (entry): entry is { path: string; operation: QuarantineOperation } =>
+        entry.operation?.status === "prepared",
+    );
+  if (prepared.length === 0) {
+    return { kind: "none", fingerprint: operationFingerprint(operationsFingerprint, null) };
+  }
+  if (prepared.length !== 1) throw new Error("multiple prepared recovery operations");
+  const pending = prepared[0]!;
+  const sourceExists = existsSync(input.partitionDir);
+  const targetExists = existsSync(pending.operation.quarantinePath);
+  const targetFingerprint = targetExists
+    ? fingerprintPartition(pending.operation.quarantinePath)
+    : null;
+  const fingerprint = operationFingerprint(operationsFingerprint, targetFingerprint);
+  if (targetExists && targetFingerprint !== pending.operation.expectedFingerprint) {
+    throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
+  }
+  if (sourceExists && !targetExists) {
+    return { kind: "source_intact", fingerprint, ...pending };
+  }
+  if (!sourceExists && targetExists) {
+    if (input.journal?.state().status === "ready") {
+      if (!input.journal.preparation().virtual || input.journal.records().length !== 0) {
+        throw typedError("recovery_operation_ambiguous", 503, "fresh journal is not empty");
+      }
+    }
+    return { kind: "resume_after_activation", fingerprint, ...pending };
+  }
+  if (sourceExists && targetExists) {
+    assertExactReceipt(input.journal, pending.operation, input.partition, input.artifactPrefix);
+    return { kind: "complete_after_activation", fingerprint, ...pending };
+  }
+  throw typedError("recovery_operation_missing", 503, "recovery source and target are missing");
+}
+
+export function preparationFingerprint(journalFingerprint: string, operationFingerprint: string) {
+  return createHash("sha256")
+    .update(`${journalFingerprint}\0${operationFingerprint}\0`)
+    .digest("hex");
+}
+
+export function revalidatePreparedState(
+  input: Parameters<typeof inspectPreparedOperation>[0] & { expectedFingerprint: string },
+): PreparedOperationPlan {
+  if (!input.journal) throw new Error("journal is not prepared");
+  input.journal.revalidatePreparation();
+  const operation = inspectPreparedOperation(input);
+  const actual = preparationFingerprint(
+    input.journal.preparation().fingerprint,
+    operation.fingerprint,
+  );
+  if (actual !== input.expectedFingerprint) {
+    throw new Error("journal manager changed since read-only preparation");
+  }
+  return operation;
+}
+
+export function applyPreparedOperation(input: {
+  plan: PreparedOperationPlan;
+  journal: DurableJournal;
+  partition: string;
+  artifactPrefix: string;
+  now: () => Date;
+  afterReceipt?: () => void;
+}): void {
+  if (input.plan.kind === "none" || input.plan.kind === "source_intact") return;
+  const currentFingerprint = operationFingerprint(
+    fingerprintPartition(dirname(input.plan.path)),
+    fingerprintPartition(input.plan.operation.quarantinePath),
+  );
+  if (currentFingerprint !== input.plan.fingerprint) {
+    throw typedError("recovery_fingerprint_mismatch", 409, "prepared recovery input changed");
+  }
+  if (
+    fingerprintPartition(input.plan.operation.quarantinePath) !==
+    input.plan.operation.expectedFingerprint
+  ) {
+    throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
+  }
+  let receipt: ControlJournalQuarantineReceipt;
+  if (input.plan.kind === "resume_after_activation") {
+    if (input.journal.records().length !== 0) {
+      throw typedError("recovery_operation_ambiguous", 503, "fresh journal is not empty");
+    }
+    receipt = {
+      schemaVersion: 1,
+      operationId: input.plan.operation.operationId,
+      partition: input.partition,
+      previousFingerprint: input.plan.operation.expectedFingerprint,
+      quarantineArtifactId: `${input.artifactPrefix}-${input.plan.operation.operationId}`,
+      quarantinePath: input.plan.operation.quarantinePath,
+      newEpoch: input.journal.currentEpoch(),
+      completedAt: input.now().toISOString(),
+    };
+    input.journal.append("journal.partition_quarantined", receipt);
+    input.afterReceipt?.();
+  } else {
+    receipt = assertExactReceipt(
+      input.journal,
+      input.plan.operation,
+      input.partition,
+      input.artifactPrefix,
+    );
+  }
+  writeAtomicPrivateJson(
+    input.plan.path,
+    { ...input.plan.operation, status: "completed", receipt },
+    false,
+  );
+}
+
+export function completePreparedReceipt(input: {
+  operation: QuarantineOperation;
+  operationPath: string;
+  journal: DurableJournal;
+  partition: string;
+  artifactPrefix: string;
+}): ControlJournalQuarantineReceipt {
+  if (
+    fingerprintPartition(input.operation.quarantinePath) !== input.operation.expectedFingerprint
+  ) {
+    throw typedError("recovery_quarantine_mismatch", 503, "quarantined bytes changed");
+  }
+  const receipt = assertExactReceipt(
+    input.journal,
+    input.operation,
+    input.partition,
+    input.artifactPrefix,
+  );
+  writeAtomicPrivateJson(
+    input.operationPath,
+    { ...input.operation, status: "completed", receipt },
+    false,
+  );
+  return receipt;
+}
+
+export function reconcilePreparedOperationOnStart(input: {
+  operationsDir: string;
+  quarantineDir: string;
+  partitionDir: string;
+  partition: string;
+  artifactPrefix: string;
+  openGeneration(): void;
+  resume(operation: QuarantineOperation, path: string): void;
+  failed(error: unknown): void;
+}): boolean {
+  if (!existsSync(input.operationsDir)) return false;
+  try {
+    const prepared = readdirSync(input.operationsDir)
+      .filter((name) => /^[a-f0-9]{64}\.json$/.test(name))
+      .map((name) => {
+        const path = join(input.operationsDir, name);
+        return {
+          path,
+          operation: readOperation(
+            path,
+            input.quarantineDir,
+            input.partition,
+            input.artifactPrefix,
+          ),
+        };
+      })
+      .filter(
+        (entry): entry is { path: string; operation: QuarantineOperation } =>
+          entry.operation?.status === "prepared",
+      );
+    if (prepared.length === 0) return false;
+    if (prepared.length !== 1) throw new Error("multiple prepared recovery operations");
+    const pending = prepared[0]!;
+    if (existsSync(input.partitionDir) && !existsSync(pending.operation.quarantinePath)) {
+      input.openGeneration();
+    } else {
+      input.resume(pending.operation, pending.path);
+    }
+  } catch (error) {
+    input.failed(error);
+  }
+  return true;
+}
+
+function assertExactReceipt(
+  journal: DurableJournal | null,
+  operation: QuarantineOperation,
+  partition: string,
+  artifactPrefix: string,
+): ControlJournalQuarantineReceipt {
+  if (!journal || journal.state().status === "recovery_required") {
+    throw typedError("recovery_operation_ambiguous", 503, "fresh journal is unreadable");
+  }
+  const records = journal.records();
+  if (records.length !== 1 || records[0]?.type !== "journal.partition_quarantined") {
+    throw typedError("recovery_operation_ambiguous", 503, "fresh receipt is missing");
+  }
+  return matchingReceipt(operation, records[0].payload, partition, artifactPrefix);
+}
+
+function operationFingerprint(operations: string, quarantine: string | null): string {
+  return createHash("sha256")
+    .update(`${operations}\0${quarantine ?? "missing"}\0`)
+    .digest("hex");
+}

--- a/packages/daemon/src/journal-projection-slot.ts
+++ b/packages/daemon/src/journal-projection-slot.ts
@@ -1,0 +1,92 @@
+import {
+  type DurableJournal,
+  JournalRecoveryRequiredError,
+  type JournalRecoveryState,
+} from "@claudexor/journal";
+import type { ControlJournalValidation } from "@claudexor/schema";
+import type { JournalProjectionDescriptor, JournalProjectionSlot } from "./journal-projection.js";
+import { recoveryAt, recoveryFrom, safeMessage } from "./journal-recovery-files.js";
+
+export interface ProjectionRegistration<T = unknown> {
+  descriptor: JournalProjectionDescriptor<T>;
+  slot: ProjectionSlot<T>;
+}
+
+export function prepareProjectionSlots(
+  registrations: Iterable<ProjectionRegistration>,
+  journal: DurableJournal,
+): {
+  status: ControlJournalValidation["projectionStatus"];
+  recovery: Extract<JournalRecoveryState, { status: "recovery_required" }> | null;
+} {
+  const status: ControlJournalValidation["projectionStatus"] = [];
+  for (const registration of registrations) {
+    try {
+      const projection = registration.descriptor.create(journal);
+      registration.descriptor.validate(projection);
+      registration.slot.bindPrepared(projection);
+      status.push({ name: registration.descriptor.name, status: "valid", detail: null });
+    } catch (error) {
+      status.push({
+        name: registration.descriptor.name,
+        status: "invalid",
+        detail: safeMessage(error),
+      });
+      return {
+        status,
+        recovery: recoveryFrom(error, `projection '${registration.descriptor.name}' failed`),
+      };
+    }
+  }
+  return { status, recovery: null };
+}
+
+export class ProjectionSlot<T> implements JournalProjectionSlot<T> {
+  private value: T | null = null;
+  private preparedValue: T | null = null;
+  private generationValue = 0;
+
+  constructor(private readonly recovery: () => JournalRecoveryState) {}
+
+  current(): T {
+    if (this.value !== null) return this.value;
+    const state = this.recovery();
+    throw new JournalRecoveryRequiredError(
+      state.status === "recovery_required"
+        ? state
+        : recoveryAt(0, "journal projection is unavailable"),
+    );
+  }
+
+  prepared(): T {
+    if (this.preparedValue !== null) return this.preparedValue;
+    return this.current();
+  }
+
+  generation(): number {
+    return this.generationValue;
+  }
+
+  bind(value: T, generation: number): void {
+    this.value = value;
+    this.generationValue = generation;
+  }
+
+  bindPrepared(value: T): void {
+    this.preparedValue = value;
+  }
+
+  activate(generation: number): void {
+    if (this.preparedValue === null) {
+      if (this.value !== null) return;
+      throw new Error("journal projection is not prepared");
+    }
+    this.bind(this.preparedValue, generation);
+    this.preparedValue = null;
+  }
+
+  clear(): void {
+    this.value = null;
+    this.preparedValue = null;
+  }
+}

--- a/packages/daemon/src/journal-projection.ts
+++ b/packages/daemon/src/journal-projection.ts
@@ -4,9 +4,11 @@ export interface JournalProjectionDescriptor<T> {
   name: string;
   create(journal: DurableJournal): T;
   validate(projection: T): void;
+  recover?(projection: T): void;
 }
 
 export interface JournalProjectionSlot<T> {
   current(): T;
+  prepared(): T;
   generation(): number;
 }

--- a/packages/daemon/src/journal-recovery-files.ts
+++ b/packages/daemon/src/journal-recovery-files.ts
@@ -19,6 +19,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { JournalRecoveryRequiredError, type JournalRecoveryState } from "@claudexor/journal";
+import type { ControlJournalExportReceipt } from "@claudexor/schema";
 import { ensureCanonicalPrivateDirectory, fsyncDirectory } from "@claudexor/util";
 
 export function recoveryFrom(
@@ -122,6 +123,62 @@ export function exportPartitionEntries(source: string, destination: string) {
         ...(stat.isSymbolicLink() ? { linkTarget: readlinkSync(path) } : {}),
       };
     });
+}
+
+export function exportJournalRecovery(input: {
+  rootDir: string;
+  partitionDir: string;
+  partition: string;
+  recovery: JournalRecoveryState;
+  now: () => Date;
+}): ControlJournalExportReceipt {
+  const fingerprint = fingerprintPartition(input.partitionDir);
+  const exportId = `journal-export-${input.now().getTime().toString(36)}-${randomUUID()}`;
+  const exportsRoot = join(input.rootDir, "recovery-exports");
+  ensureCanonicalPrivateDirectory(exportsRoot);
+  const bundlePath = join(exportsRoot, exportId);
+  ensureCanonicalPrivateDirectory(bundlePath);
+  try {
+    const entries = exportPartitionEntries(input.partitionDir, bundlePath);
+    const createdAt = input.now().toISOString();
+    const manifestPath = join(bundlePath, "manifest.json");
+    writeExclusiveFile(
+      manifestPath,
+      Buffer.from(
+        `${JSON.stringify(
+          {
+            schemaVersion: 1,
+            exportId,
+            partition: input.partition,
+            fingerprint,
+            recovery: input.recovery,
+            createdAt,
+            entries,
+          },
+          null,
+          2,
+        )}\n`,
+      ),
+      0o400,
+    );
+    fsyncDirectory(bundlePath);
+    if (fingerprintPartition(input.partitionDir) !== fingerprint) {
+      throw new Error("journal changed during recovery export");
+    }
+    return {
+      schemaVersion: 1,
+      exportId,
+      partition: input.partition,
+      fingerprint,
+      bundlePath,
+      manifestSha256: sha256File(manifestPath),
+      createdAt,
+    };
+  } catch (error) {
+    rmSync(bundlePath, { recursive: true, force: true });
+    fsyncDirectory(exportsRoot);
+    throw error;
+  }
 }
 
 export function readOwnedFile(path: string): Buffer {

--- a/packages/daemon/src/journal-recovery-files.ts
+++ b/packages/daemon/src/journal-recovery-files.ts
@@ -50,26 +50,51 @@ export function safeMessage(value: unknown): string {
   return value instanceof Error ? value.message : String(value);
 }
 
-export function fingerprintPartition(path: string): string {
+export interface PartitionFingerprint {
+  fingerprint: string;
+  exists: boolean;
+  problem: string | null;
+}
+
+/** Observe a recovery tree without throwing. Callers must reject `problem`
+ * before trusting the fingerprint for activation or mutation. */
+export function fingerprintPartition(path: string): PartitionFingerprint {
   const hash = createHash("sha256");
-  if (!existsSync(path)) return hash.update("missing\0").digest("hex");
-  const root = lstatSync(path, { bigint: true });
-  if (root.isSymbolicLink()) {
-    hash.update(`symlink\0${readlinkSync(path)}\0`);
-    return hash.digest("hex");
+  let exists = false;
+  try {
+    let root: BigIntStats;
+    try {
+      root = lstatSync(path, { bigint: true });
+      exists = true;
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") throw error;
+      assertStillMissing(path);
+      hash.update("missing\0");
+      return { fingerprint: hash.digest("hex"), exists, problem: null };
+    }
+    if (root.isSymbolicLink()) {
+      hash.update(`symlink\0${readlinkSync(path)}\0`);
+      assertUnchanged(path, root);
+    } else if (!root.isDirectory()) {
+      hash.update(`other\0${metadata(root)}\0`);
+      assertUnchanged(path, root);
+    } else {
+      // Root identity/timestamps are checked for races but excluded from the
+      // content digest so an atomic quarantine rename preserves the receipt.
+      hash.update("directory\0");
+      fingerprintDirectory(path, hash, root);
+    }
+    return { fingerprint: hash.digest("hex"), exists, problem: null };
+  } catch (error) {
+    const problem = `journal tree could not be fingerprinted safely: ${safeMessage(error)}`;
+    hash.update(`fingerprint-error\0${problem}\0`);
+    return { fingerprint: hash.digest("hex"), exists, problem };
   }
-  if (!root.isDirectory()) return hash.update(`other\0${metadata(root)}\0`).digest("hex");
-  // Deliberately exclude the root inode/timestamps: this content fingerprint
-  // must remain stable when the owned partition is atomically quarantined.
-  hash.update("directory\0");
-  for (const name of readdirSync(path).sort()) {
-    const entryPath = join(path, name);
-    const stat = lstatSync(entryPath, { bigint: true });
-    hash.update(`entry\0${name}\0${metadata(stat)}\0`);
-    if (stat.isSymbolicLink()) hash.update(`target\0${readlinkSync(entryPath)}\0`);
-    else if (stat.isFile() && stat.nlink === 1n) hash.update(hashOwnedFile(entryPath));
-  }
-  return hash.digest("hex");
+}
+
+export function requireStableFingerprint(observed: PartitionFingerprint, context: string): string {
+  if (observed.problem) throw new Error(`${context}: ${observed.problem}`);
+  return observed.fingerprint;
 }
 
 export function exportPartitionEntries(source: string, destination: string) {
@@ -132,7 +157,10 @@ export function exportJournalRecovery(input: {
   recovery: JournalRecoveryState;
   now: () => Date;
 }): ControlJournalExportReceipt {
-  const fingerprint = fingerprintPartition(input.partitionDir);
+  const fingerprint = requireStableFingerprint(
+    fingerprintPartition(input.partitionDir),
+    "journal recovery export input is unavailable",
+  );
   const exportId = `journal-export-${input.now().getTime().toString(36)}-${randomUUID()}`;
   const exportsRoot = join(input.rootDir, "recovery-exports");
   ensureCanonicalPrivateDirectory(exportsRoot);
@@ -162,7 +190,12 @@ export function exportJournalRecovery(input: {
       0o400,
     );
     fsyncDirectory(bundlePath);
-    if (fingerprintPartition(input.partitionDir) !== fingerprint) {
+    if (
+      requireStableFingerprint(
+        fingerprintPartition(input.partitionDir),
+        "journal recovery export input became unavailable",
+      ) !== fingerprint
+    ) {
       throw new Error("journal changed during recovery export");
     }
     return {
@@ -227,10 +260,13 @@ export function sha256File(path: string): string {
   return hashOwnedFile(path).toString("hex");
 }
 
-function hashOwnedFile(path: string): Buffer {
+function hashOwnedFile(path: string, expected?: BigIntStats): Buffer {
   const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
   try {
     const before = fstatSync(fd, { bigint: true });
+    if (expected && metadata(expected) !== metadata(before)) {
+      throw new Error(`journal file changed before hashing: ${path}`);
+    }
     assertOwnedRegular(path, before);
     const hash = createHash("sha256");
     const buffer = Buffer.allocUnsafe(64 * 1024);
@@ -269,6 +305,55 @@ function metadata(stat: BigIntStats): string {
   return [stat.dev, stat.ino, stat.mode, stat.nlink, stat.size, stat.mtimeNs, stat.ctimeNs].join(
     ":",
   );
+}
+
+function fingerprintDirectory(
+  path: string,
+  hash: ReturnType<typeof createHash>,
+  before: BigIntStats,
+): void {
+  const names = readdirSync(path).sort();
+  for (const name of names) {
+    const entryPath = join(path, name);
+    const stat = lstatSync(entryPath, { bigint: true });
+    hash.update(`entry\0${name}\0${metadata(stat)}\0`);
+    if (stat.isSymbolicLink()) {
+      hash.update(`target\0${readlinkSync(entryPath)}\0`);
+      assertUnchanged(entryPath, stat);
+    } else if (stat.isFile() && stat.nlink === 1n) {
+      hash.update(hashOwnedFile(entryPath, stat));
+      assertUnchanged(entryPath, stat);
+    } else {
+      assertUnchanged(entryPath, stat);
+    }
+  }
+  if (readdirSync(path).sort().join("\0") !== names.join("\0")) {
+    throw new Error(`journal directory entries changed while hashing: ${path}`);
+  }
+  assertUnchanged(path, before);
+}
+
+function assertStillMissing(path: string): void {
+  try {
+    lstatSync(path);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return;
+    throw error;
+  }
+  throw new Error(`journal tree appeared while hashing: ${path}`);
+}
+
+function assertUnchanged(path: string, before: BigIntStats): void {
+  const after = lstatSync(path, { bigint: true });
+  if (metadata(before) !== metadata(after)) {
+    throw new Error(`journal tree changed while hashing: ${path}`);
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
 }
 
 export function writeExclusiveFile(path: string, bytes: Buffer, mode: number): void {

--- a/packages/daemon/src/journal-recovery-files.ts
+++ b/packages/daemon/src/journal-recovery-files.ts
@@ -117,6 +117,18 @@ interface AncestryObservation {
   missingPath: string | null;
 }
 
+/**
+ * S2-CR1: the shared parent of every partition's recovery-operations dir is
+ * DAEMON-OWNED MUTABLE INFRASTRUCTURE — the first quarantine on a root
+ * creates it (journal-manager quarantineAndStartFresh). Its existence must
+ * not bear preparation identity, or that legitimate write would poison the
+ * missing-ancestry suffix of every OTHER still-prepared partition and flip a
+ * healthy sibling into recovery_required. Its privacy/canonical form is
+ * still fully validated whenever it is present, and it stays identity-BEARING
+ * when it is the fingerprinted target itself.
+ */
+const IDENTITY_EXEMPT_INFRASTRUCTURE = "recovery-operations";
+
 function inspectCanonicalAncestry(
   path: string,
   trustedRoot: string,
@@ -137,6 +149,9 @@ function inspectCanonicalAncestry(
       paths.push(cursor);
     }
   }
+  const identityExempt = (index: number): boolean =>
+    index !== paths.length - 1 &&
+    relative(absoluteRoot, paths[index]!) === IDENTITY_EXEMPT_INFRASTRUCTURE;
   const entries: AncestryObservation["entries"] = [];
   let missingPath: string | null = null;
   for (const [index, entryPath] of paths.entries()) {
@@ -149,13 +164,18 @@ function inspectCanonicalAncestry(
       identityHash.update(
         `missing\0${paths
           .slice(index)
+          .filter((_, offset) => !identityExempt(index + offset))
           .map((value) => relative(absoluteRoot, value))
           .join("\0")}\0`,
       );
       break;
     }
     entries.push({ path: entryPath, stat });
-    identityHash.update(`path\0${relative(absoluteRoot, entryPath)}\0${identityMetadata(stat)}\0`);
+    if (!identityExempt(index)) {
+      identityHash.update(
+        `path\0${relative(absoluteRoot, entryPath)}\0${identityMetadata(stat)}\0`,
+      );
+    }
     if (stat.isSymbolicLink()) {
       problems.push(`journal tree ancestry is a symbolic link: ${entryPath}`);
       break;

--- a/packages/daemon/src/journal-recovery-files.ts
+++ b/packages/daemon/src/journal-recovery-files.ts
@@ -13,11 +13,12 @@ import {
   readdirSync,
   readlinkSync,
   readSync,
+  realpathSync,
   renameSync,
   rmSync,
   writeSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { JournalRecoveryRequiredError, type JournalRecoveryState } from "@claudexor/journal";
 import type { ControlJournalExportReceipt } from "@claudexor/schema";
 import { ensureCanonicalPrivateDirectory, fsyncDirectory } from "@claudexor/util";
@@ -52,43 +53,164 @@ export function safeMessage(value: unknown): string {
 
 export interface PartitionFingerprint {
   fingerprint: string;
+  preparationIdentity: string;
   exists: boolean;
   problem: string | null;
 }
 
 /** Observe a recovery tree without throwing. Callers must reject `problem`
  * before trusting the fingerprint for activation or mutation. */
-export function fingerprintPartition(path: string): PartitionFingerprint {
-  const hash = createHash("sha256");
+export function fingerprintPartition(
+  path: string,
+  trustedRoot = dirname(path),
+): PartitionFingerprint {
+  const contentHash = createHash("sha256");
+  const identityHash = createHash("sha256");
   let exists = false;
+  const problems: string[] = [];
   try {
-    let root: BigIntStats;
+    const ancestry = inspectCanonicalAncestry(path, trustedRoot, identityHash, problems);
+    const root = ancestry.target;
+    exists = root !== null;
+    if (!root) {
+      contentHash.update("missing\0");
+    } else if (root.isSymbolicLink()) {
+      contentHash.update(`symlink\0${safeReadlink(path)}\0`);
+      problems.push("journal tree root is a symbolic link");
+    } else if (!root.isDirectory()) {
+      contentHash.update(`other\0${metadata(root)}\0`);
+      problems.push("journal tree root is not a directory");
+    } else {
+      // Preserve the public recovery fingerprint across an atomic quarantine
+      // rename and across this preparation hardening. Path/security identity
+      // is intentionally separate below.
+      contentHash.update("directory\0");
+      fingerprintDirectory(path, contentHash, root);
+    }
+    revalidateAncestry(ancestry, problems);
+  } catch (error) {
+    problems.push(`journal tree could not be fingerprinted safely: ${safeMessage(error)}`);
+    contentHash.update(`fingerprint-error\0${safeMessage(error)}\0`);
+    identityHash.update(`fingerprint-error\0${safeMessage(error)}\0`);
+  }
+  const fingerprint = contentHash.digest("hex");
+  identityHash.update(`content\0${fingerprint}\0`);
+  return {
+    fingerprint,
+    preparationIdentity: identityHash.digest("hex"),
+    exists,
+    problem: problems[0] ?? null,
+  };
+}
+
+export function requireStablePreparationIdentity(
+  observed: PartitionFingerprint,
+  context: string,
+): string {
+  if (observed.problem) throw new Error(`${context}: ${observed.problem}`);
+  return observed.preparationIdentity;
+}
+
+interface AncestryObservation {
+  target: BigIntStats | null;
+  entries: Array<{ path: string; stat: BigIntStats }>;
+  missingPath: string | null;
+}
+
+function inspectCanonicalAncestry(
+  path: string,
+  trustedRoot: string,
+  identityHash: ReturnType<typeof createHash>,
+  problems: string[],
+): AncestryObservation {
+  const absolutePath = resolve(path);
+  const absoluteRoot = resolve(trustedRoot);
+  const rel = relative(absoluteRoot, absolutePath);
+  if (isAbsolute(rel) || rel === ".." || rel.startsWith(`..${sep}`)) {
+    throw new Error(`journal tree escapes trusted root: ${absolutePath}`);
+  }
+  const paths = [absoluteRoot];
+  if (rel) {
+    let cursor = absoluteRoot;
+    for (const component of rel.split(sep)) {
+      cursor = join(cursor, component);
+      paths.push(cursor);
+    }
+  }
+  const entries: AncestryObservation["entries"] = [];
+  let missingPath: string | null = null;
+  for (const [index, entryPath] of paths.entries()) {
+    let stat: BigIntStats;
     try {
-      root = lstatSync(path, { bigint: true });
-      exists = true;
+      stat = lstatSync(entryPath, { bigint: true });
     } catch (error) {
       if (errorCode(error) !== "ENOENT") throw error;
-      assertStillMissing(path);
-      hash.update("missing\0");
-      return { fingerprint: hash.digest("hex"), exists, problem: null };
+      missingPath = entryPath;
+      identityHash.update(
+        `missing\0${paths
+          .slice(index)
+          .map((value) => relative(absoluteRoot, value))
+          .join("\0")}\0`,
+      );
+      break;
     }
-    if (root.isSymbolicLink()) {
-      hash.update(`symlink\0${readlinkSync(path)}\0`);
-      assertUnchanged(path, root);
-    } else if (!root.isDirectory()) {
-      hash.update(`other\0${metadata(root)}\0`);
-      assertUnchanged(path, root);
-    } else {
-      // Root identity/timestamps are checked for races but excluded from the
-      // content digest so an atomic quarantine rename preserves the receipt.
-      hash.update("directory\0");
-      fingerprintDirectory(path, hash, root);
+    entries.push({ path: entryPath, stat });
+    identityHash.update(`path\0${relative(absoluteRoot, entryPath)}\0${identityMetadata(stat)}\0`);
+    if (stat.isSymbolicLink()) {
+      problems.push(`journal tree ancestry is a symbolic link: ${entryPath}`);
+      break;
     }
-    return { fingerprint: hash.digest("hex"), exists, problem: null };
+    const isTarget = index === paths.length - 1;
+    if (!isTarget && !stat.isDirectory()) {
+      problems.push(`journal tree ancestry is not a directory: ${entryPath}`);
+      break;
+    }
+    if (stat.isDirectory()) validatePrivateDirectory(entryPath, stat, problems);
+  }
+  const final = entries.at(-1);
+  return {
+    target: !missingPath && final?.path === absolutePath ? final.stat : null,
+    entries,
+    missingPath,
+  };
+}
+
+function validatePrivateDirectory(path: string, stat: BigIntStats, problems: string[]): void {
+  if (typeof process.getuid === "function" && stat.uid !== BigInt(process.getuid())) {
+    problems.push(`journal tree directory is not owned by the current user: ${path}`);
+  }
+  if (process.platform !== "win32" && Number(stat.mode & 0o777n) !== 0o700) {
+    problems.push(`journal tree directory is not private: ${path}`);
+  }
+  try {
+    if (realpathSync.native(path) !== resolve(path)) {
+      problems.push(`journal tree directory is not canonical: ${path}`);
+    }
   } catch (error) {
-    const problem = `journal tree could not be fingerprinted safely: ${safeMessage(error)}`;
-    hash.update(`fingerprint-error\0${problem}\0`);
-    return { fingerprint: hash.digest("hex"), exists, problem };
+    problems.push(`journal tree directory cannot be resolved canonically: ${safeMessage(error)}`);
+  }
+}
+
+function revalidateAncestry(observed: AncestryObservation, problems: string[]): void {
+  for (const entry of observed.entries) {
+    try {
+      const after = lstatSync(entry.path, { bigint: true });
+      if (observationMetadata(entry.stat) !== observationMetadata(after)) {
+        problems.push(`journal tree ancestry changed while fingerprinting: ${entry.path}`);
+      }
+    } catch (error) {
+      problems.push(`journal tree ancestry became unavailable: ${safeMessage(error)}`);
+    }
+  }
+  if (observed.missingPath) {
+    try {
+      lstatSync(observed.missingPath);
+      problems.push(`journal tree appeared while fingerprinting: ${observed.missingPath}`);
+    } catch (error) {
+      if (errorCode(error) !== "ENOENT") {
+        problems.push(`journal tree missing state is ambiguous: ${safeMessage(error)}`);
+      }
+    }
   }
 }
 
@@ -158,7 +280,7 @@ export function exportJournalRecovery(input: {
   now: () => Date;
 }): ControlJournalExportReceipt {
   const fingerprint = requireStableFingerprint(
-    fingerprintPartition(input.partitionDir),
+    fingerprintPartition(input.partitionDir, input.rootDir),
     "journal recovery export input is unavailable",
   );
   const exportId = `journal-export-${input.now().getTime().toString(36)}-${randomUUID()}`;
@@ -192,7 +314,7 @@ export function exportJournalRecovery(input: {
     fsyncDirectory(bundlePath);
     if (
       requireStableFingerprint(
-        fingerprintPartition(input.partitionDir),
+        fingerprintPartition(input.partitionDir, input.rootDir),
         "journal recovery export input became unavailable",
       ) !== fingerprint
     ) {
@@ -307,6 +429,35 @@ function metadata(stat: BigIntStats): string {
   );
 }
 
+function securityMetadata(stat: BigIntStats): string {
+  const base = [entryType(stat), stat.mode & 0o777n, stat.uid, stat.gid];
+  if (!stat.isDirectory()) base.push(stat.nlink);
+  return base.join(":");
+}
+
+function identityMetadata(stat: BigIntStats): string {
+  return [stat.dev, stat.ino, securityMetadata(stat)].join(":");
+}
+
+function observationMetadata(stat: BigIntStats): string {
+  return [identityMetadata(stat), stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+}
+
+function entryType(stat: BigIntStats): string {
+  if (stat.isDirectory()) return "directory";
+  if (stat.isFile()) return "file";
+  if (stat.isSymbolicLink()) return "symlink";
+  return "other";
+}
+
+function safeReadlink(path: string): string {
+  try {
+    return readlinkSync(path);
+  } catch (error) {
+    return `unavailable:${errorCode(error) ?? "unknown"}`;
+  }
+}
+
 function fingerprintDirectory(
   path: string,
   hash: ReturnType<typeof createHash>,
@@ -331,16 +482,6 @@ function fingerprintDirectory(
     throw new Error(`journal directory entries changed while hashing: ${path}`);
   }
   assertUnchanged(path, before);
-}
-
-function assertStillMissing(path: string): void {
-  try {
-    lstatSync(path);
-  } catch (error) {
-    if (errorCode(error) === "ENOENT") return;
-    throw error;
-  }
-  throw new Error(`journal tree appeared while hashing: ${path}`);
 }
 
 function assertUnchanged(path: string, before: BigIntStats): void {

--- a/packages/daemon/src/journal-recovery-operation.ts
+++ b/packages/daemon/src/journal-recovery-operation.ts
@@ -1,0 +1,117 @@
+import { existsSync } from "node:fs";
+import { basename, join } from "node:path";
+import {
+  ControlJournalQuarantineReceipt as QuarantineReceiptSchema,
+  type ControlJournalQuarantineReceipt,
+  type ControlJournalQuarantineRequest,
+} from "@claudexor/schema";
+import { readOwnedFile, sha256 } from "./journal-recovery-files.js";
+
+export type JournalQuarantineRequest = ControlJournalQuarantineRequest & {
+  idempotencyKey: string;
+};
+
+export interface QuarantineOperation {
+  schemaVersion: 1;
+  operationId: string;
+  keyDigest: string;
+  requestDigest: string;
+  expectedFingerprint: string;
+  quarantinePath: string;
+  status: "prepared" | "completed";
+  receipt: ControlJournalQuarantineReceipt | null;
+}
+
+export function readOperation(
+  path: string,
+  quarantineDir: string,
+  partition: string,
+  artifactPrefix: string,
+): QuarantineOperation | null {
+  if (!existsSync(path)) return null;
+  const value = JSON.parse(readOwnedFile(path).toString("utf8")) as unknown;
+  if (
+    !isRecord(value) ||
+    value.schemaVersion !== 1 ||
+    typeof value.operationId !== "string" ||
+    typeof value.keyDigest !== "string" ||
+    basename(path) !== `${value.keyDigest}.json` ||
+    typeof value.requestDigest !== "string" ||
+    typeof value.expectedFingerprint !== "string" ||
+    typeof value.quarantinePath !== "string" ||
+    value.quarantinePath !== join(quarantineDir, `${artifactPrefix}-${value.operationId}`) ||
+    (value.status !== "prepared" && value.status !== "completed")
+  ) {
+    throw new Error("recovery operation is malformed");
+  }
+  const operation = value as unknown as QuarantineOperation;
+  if (operation.status === "prepared" && operation.receipt !== null) {
+    throw new Error("prepared recovery operation contains a receipt");
+  }
+  if (operation.status === "completed") {
+    matchingReceipt(operation, undefined, partition, artifactPrefix);
+  }
+  return operation;
+}
+
+export function matchingReceipt(
+  operation: QuarantineOperation,
+  value: unknown,
+  partition: string,
+  artifactPrefix: string,
+): ControlJournalQuarantineReceipt {
+  const receipt = QuarantineReceiptSchema.parse(value ?? operation.receipt);
+  if (
+    receipt.operationId !== operation.operationId ||
+    receipt.partition !== partition ||
+    receipt.previousFingerprint !== operation.expectedFingerprint ||
+    receipt.quarantinePath !== operation.quarantinePath ||
+    receipt.quarantineArtifactId !== `${artifactPrefix}-${operation.operationId}`
+  ) {
+    throw typedError("recovery_receipt_mismatch", 503, "quarantine receipt does not match intent");
+  }
+  return receipt;
+}
+
+export function validateRequest(input: JournalQuarantineRequest): void {
+  if (!input.idempotencyKey || input.idempotencyKey.length > 256) {
+    throw typedError(
+      "invalid_idempotency_key",
+      400,
+      "Idempotency-Key must contain 1-256 characters",
+    );
+  }
+  if (input.confirmation !== "quarantine_and_start_fresh") {
+    throw typedError("quarantine_confirmation_required", 400, "explicit confirmation is required");
+  }
+  if (!/^[a-f0-9]{64}$/.test(input.expectedFingerprint)) {
+    throw typedError("invalid_recovery_fingerprint", 400, "expectedFingerprint must be SHA-256");
+  }
+}
+
+export function quarantineRequestDigest(
+  partition: string,
+  input: JournalQuarantineRequest,
+): string {
+  return sha256(
+    Buffer.from(
+      JSON.stringify({
+        partition,
+        expectedFingerprint: input.expectedFingerprint,
+        confirmation: input.confirmation,
+      }),
+    ),
+  );
+}
+
+export function conflict(code: string): Error & { code: string; status: number } {
+  return typedError(code, 409, code.replaceAll("_", " "));
+}
+
+export function typedError(code: string, status: number, message: string) {
+  return Object.assign(new Error(message), { code, status });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/daemon/src/project-partition-preparation.ts
+++ b/packages/daemon/src/project-partition-preparation.ts
@@ -1,7 +1,9 @@
 import { createHash } from "node:crypto";
+import { JournalRecoveryRequiredError } from "@claudexor/journal";
 import { commandProjection, type CommandStore } from "./command-store.js";
 import { interactionProjection, type InteractionStore } from "./interactions.js";
 import { JournalManager, type JournalProjectionSlot } from "./journal-manager.js";
+import { recoveryFrom } from "./journal-recovery-files.js";
 import { operatorDecisionProjection, type OperatorDecisionStore } from "./operator-decisions.js";
 import type { ProjectStore } from "./projects.js";
 import { runEventProjection, type RunEventStore } from "./run-events.js";
@@ -152,6 +154,34 @@ export function prepareProjectPartitions(input: {
     },
     entries,
   };
+}
+
+export function activatePreparedProjectPartitions(input: {
+  rootDir: string;
+  projects: JournalProjectionSlot<ProjectStore>;
+  headPing?: ThreadHeadPingSink;
+  receipt: ProjectPartitionsPreparation;
+  entries: ProjectPartitionCollection;
+  resetReceipt(receipt: ProjectPartitionsPreparation): void;
+}): void {
+  if (
+    input.receipt.coverage !== "complete" ||
+    input.receipt.recoveryRequiredPartitions.length > 0
+  ) {
+    throw new Error("project partitions require recovery before activation");
+  }
+  try {
+    for (const entry of input.entries.values()) entry.manager.revalidatePreparation();
+    for (const entry of input.entries.values()) entry.manager.activatePrepared();
+  } catch (error) {
+    const recovery = recoveryFrom(error, "project partition activation failed");
+    for (const entry of input.entries.values()) entry.manager.close();
+    input.entries.clear();
+    const rebuilt = prepareProjectPartitions(input);
+    for (const [id, entry] of rebuilt.entries) input.entries.set(id, entry);
+    input.resetReceipt(rebuilt.receipt);
+    throw new JournalRecoveryRequiredError(recovery);
+  }
 }
 
 function createProjectPartition(

--- a/packages/daemon/src/project-partition-preparation.ts
+++ b/packages/daemon/src/project-partition-preparation.ts
@@ -1,0 +1,193 @@
+import { createHash } from "node:crypto";
+import { commandProjection, type CommandStore } from "./command-store.js";
+import { interactionProjection, type InteractionStore } from "./interactions.js";
+import { JournalManager, type JournalProjectionSlot } from "./journal-manager.js";
+import { operatorDecisionProjection, type OperatorDecisionStore } from "./operator-decisions.js";
+import type { ProjectStore } from "./projects.js";
+import { runEventProjection, type RunEventStore } from "./run-events.js";
+import { threadProjection, type ThreadHeadPingSink, type ThreadStore } from "./threads.js";
+
+export interface ProjectPartitionEntry {
+  manager: JournalManager;
+  commands: JournalProjectionSlot<CommandStore>;
+  interactions: JournalProjectionSlot<InteractionStore>;
+  decisions: JournalProjectionSlot<OperatorDecisionStore>;
+  runEvents: JournalProjectionSlot<RunEventStore>;
+  threads: JournalProjectionSlot<ThreadStore>;
+}
+
+export interface ProjectPartitionPreparationEntry {
+  projectId: string;
+  partition: string;
+  status: "ready" | "recovery_required";
+  virtual: boolean;
+  fingerprint: string;
+  manager: JournalManager;
+}
+
+export interface ProjectPartitionsPreparation {
+  coverage: "complete" | "global_registry_unavailable";
+  fingerprint: string | null;
+  registeredProjectIds: string[];
+  trustedProjectRoots: string[];
+  partitions: ProjectPartitionPreparationEntry[];
+  readyPartitions: string[];
+  recoveryRequiredPartitions: string[];
+}
+
+export interface PreparedProjectPartitions {
+  receipt: ProjectPartitionsPreparation;
+  entries: Map<string, ProjectPartitionEntry>;
+}
+
+export class ProjectPartitionCollection extends Map<string, ProjectPartitionEntry> {
+  constructor(
+    private readonly rootDir: string,
+    private readonly projects: JournalProjectionSlot<ProjectStore>,
+    private readonly headPing?: ThreadHeadPingSink,
+  ) {
+    super();
+  }
+
+  sync(): void {
+    const ids = new Set(
+      this.projects
+        .current()
+        .list()
+        .map((project) => project.id),
+    );
+    for (const id of ids) this.ensure(id);
+    for (const [id, entry] of this) {
+      if (ids.has(id)) continue;
+      entry.manager.close();
+      this.delete(id);
+    }
+  }
+
+  ensure(projectId: string): ProjectPartitionEntry {
+    const existing = this.get(projectId);
+    if (existing) return existing;
+    const entry = createProjectPartition(this.rootDir, `project:${projectId}`, this.headPing);
+    entry.manager.start();
+    this.set(projectId, entry);
+    return entry;
+  }
+
+  healthy(): ProjectPartitionEntry[] {
+    this.sync();
+    return [...this.values()].filter((entry) => entry.manager.ready());
+  }
+
+  healthyRoots(): string[] {
+    this.sync();
+    const registry = this.projects.current();
+    const roots: string[] = [];
+    for (const [id, entry] of this) {
+      if (!entry.manager.ready()) continue;
+      const root = registry.get(id)?.root;
+      if (root) roots.push(root);
+    }
+    return roots;
+  }
+}
+
+export function prepareProjectPartitions(input: {
+  rootDir: string;
+  projects: JournalProjectionSlot<ProjectStore>;
+  headPing?: ThreadHeadPingSink;
+}): PreparedProjectPartitions {
+  let projects: ReturnType<ProjectStore["list"]>;
+  try {
+    const registry = input.projects.prepared();
+    registry.validateProjection();
+    projects = registry.list();
+  } catch {
+    return {
+      receipt: {
+        coverage: "global_registry_unavailable",
+        fingerprint: null,
+        registeredProjectIds: [],
+        trustedProjectRoots: [],
+        partitions: [],
+        readyPartitions: [],
+        recoveryRequiredPartitions: [],
+      },
+      entries: new Map(),
+    };
+  }
+
+  const entries = new Map<string, ProjectPartitionEntry>();
+  const partitions: ProjectPartitionPreparationEntry[] = [];
+  for (const project of projects) {
+    const partition = `project:${project.id}`;
+    const value = createProjectPartition(input.rootDir, partition, input.headPing);
+    const preparation = value.manager.prepare();
+    entries.set(project.id, value);
+    partitions.push({
+      projectId: project.id,
+      partition,
+      status: preparation.inspection.status,
+      virtual: preparation.virtual,
+      fingerprint: preparation.preparationFingerprint,
+      manager: value.manager,
+    });
+  }
+  const readyPartitions = partitions
+    .filter((entry) => entry.status === "ready")
+    .map((entry) => entry.partition);
+  const recoveryRequiredPartitions = partitions
+    .filter((entry) => entry.status === "recovery_required")
+    .map((entry) => entry.partition);
+  const registeredProjectIds = projects.map((project) => project.id);
+  const trustedProjectRoots = projects.map((project) => project.root);
+  return {
+    receipt: {
+      coverage: "complete",
+      fingerprint: preparationFingerprint(registeredProjectIds, trustedProjectRoots, partitions),
+      registeredProjectIds,
+      trustedProjectRoots,
+      partitions,
+      readyPartitions,
+      recoveryRequiredPartitions,
+    },
+    entries,
+  };
+}
+
+function createProjectPartition(
+  rootDir: string,
+  partition: string,
+  headPing?: ThreadHeadPingSink,
+): ProjectPartitionEntry {
+  const manager = new JournalManager(rootDir, { partition });
+  const value: ProjectPartitionEntry = {
+    manager,
+    commands: manager.registerProjection(commandProjection()),
+    interactions: manager.registerProjection(interactionProjection()),
+    decisions: manager.registerProjection(operatorDecisionProjection()),
+    runEvents: manager.registerProjection(runEventProjection()),
+    threads: manager.registerProjection(threadProjection(headPing)),
+  };
+  return value;
+}
+
+function preparationFingerprint(
+  projectIds: string[],
+  projectRoots: string[],
+  partitions: ProjectPartitionPreparationEntry[],
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        projectIds,
+        projectRoots,
+        partitions: partitions.map((entry) => ({
+          partition: entry.partition,
+          status: entry.status,
+          virtual: entry.virtual,
+          fingerprint: entry.fingerprint,
+        })),
+      }),
+    )
+    .digest("hex");
+}

--- a/packages/daemon/src/project-partition-preparation.ts
+++ b/packages/daemon/src/project-partition-preparation.ts
@@ -156,6 +156,76 @@ export function prepareProjectPartitions(input: {
   };
 }
 
+/**
+ * Live re-verdict for the in-process reopen (C6): recompute the stage-2
+ * receipt from CURRENT partition state. A partition the operator quarantined
+ * over the recovery route was reopened by its manager (openGeneration) and
+ * now inspects ready; a registry that became readable after a global reopen
+ * restores coverage. Read-only for everything still prepared — a registered
+ * project without an entry gets a read-only prepare, never a write.
+ */
+export function refreshProjectPartitionsPreparation(input: {
+  rootDir: string;
+  projects: JournalProjectionSlot<ProjectStore>;
+  headPing?: ThreadHeadPingSink;
+  previous: ProjectPartitionsPreparation;
+  entries: ProjectPartitionCollection;
+}): ProjectPartitionsPreparation {
+  let projects: ReturnType<ProjectStore["list"]>;
+  try {
+    const registry = input.projects.prepared();
+    registry.validateProjection();
+    projects = registry.list();
+  } catch {
+    return {
+      coverage: "global_registry_unavailable",
+      fingerprint: null,
+      registeredProjectIds: [],
+      trustedProjectRoots: [],
+      partitions: [],
+      readyPartitions: [],
+      recoveryRequiredPartitions: [],
+    };
+  }
+  const previousByPartition = new Map(
+    input.previous.partitions.map((entry) => [entry.partition, entry]),
+  );
+  const partitions: ProjectPartitionPreparationEntry[] = [];
+  for (const project of projects) {
+    const partition = `project:${project.id}`;
+    let entry = input.entries.get(project.id);
+    if (!entry) {
+      entry = createProjectPartition(input.rootDir, partition, input.headPing);
+      entry.manager.prepare();
+      input.entries.set(project.id, entry);
+    }
+    const inspection = entry.manager.inspect();
+    partitions.push({
+      projectId: project.id,
+      partition,
+      status: inspection.status === "ready" ? "ready" : "recovery_required",
+      virtual: previousByPartition.get(partition)?.virtual ?? false,
+      fingerprint: inspection.fingerprint,
+      manager: entry.manager,
+    });
+  }
+  const registeredProjectIds = projects.map((project) => project.id);
+  const trustedProjectRoots = projects.map((project) => project.root);
+  return {
+    coverage: "complete",
+    fingerprint: preparationFingerprint(registeredProjectIds, trustedProjectRoots, partitions),
+    registeredProjectIds,
+    trustedProjectRoots,
+    partitions,
+    readyPartitions: partitions
+      .filter((entry) => entry.status === "ready")
+      .map((entry) => entry.partition),
+    recoveryRequiredPartitions: partitions
+      .filter((entry) => entry.status === "recovery_required")
+      .map((entry) => entry.partition),
+  };
+}
+
 export function activatePreparedProjectPartitions(input: {
   rootDir: string;
   projects: JournalProjectionSlot<ProjectStore>;

--- a/packages/daemon/src/project-partition-preparation.ts
+++ b/packages/daemon/src/project-partition-preparation.ts
@@ -241,7 +241,10 @@ export function activatePreparedProjectPartitions(input: {
     throw new Error("project partitions require recovery before activation");
   }
   try {
-    for (const entry of input.entries.values()) entry.manager.revalidatePreparation();
+    for (const entry of input.entries.values()) {
+      // Reopened-after-quarantine managers are live (C6); skip revalidation.
+      if (!entry.manager.ready()) entry.manager.revalidatePreparation();
+    }
     for (const entry of input.entries.values()) entry.manager.activatePrepared();
   } catch (error) {
     const recovery = recoveryFrom(error, "project partition activation failed");

--- a/packages/daemon/src/project-partitions.ts
+++ b/packages/daemon/src/project-partitions.ts
@@ -8,19 +8,17 @@ import type {
 } from "@claudexor/schema";
 import { isEphemeralRunScope } from "@claudexor/schema";
 import { hashJson, isClaudexorOwnedRuntimePath } from "@claudexor/util";
-import { commandProjection, type CommandStore } from "./command-store.js";
-import { JournalManager, type JournalProjectionSlot } from "./journal-manager.js";
-import { interactionProjection, type InteractionStore } from "./interactions.js";
+import type { CommandStore } from "./command-store.js";
+import type { JournalManager, JournalProjectionSlot } from "./journal-manager.js";
+import type { InteractionStore } from "./interactions.js";
 import {
-  operatorDecisionProjection,
   type OperatorDecisionRecord,
   type OperatorDecisionStore,
   type RecordedOperatorDecision,
 } from "./operator-decisions.js";
-import { runEventProjection, type RunEventStore } from "./run-events.js";
+import type { RunEventStore } from "./run-events.js";
 import type { ProjectStore } from "./projects.js";
 import {
-  threadProjection,
   type CreateThreadInput,
   type CreateTurnInput,
   type ThreadHeadPingSink,
@@ -33,18 +31,16 @@ import {
   completeDeliveryCommand,
   failDeliveryCommand,
 } from "./delivery-command.js";
+import {
+  prepareProjectPartitions,
+  ProjectPartitionCollection,
+  type ProjectPartitionsPreparation,
+} from "./project-partition-preparation.js";
 
-interface ProjectPartition {
-  manager: JournalManager;
-  commands: JournalProjectionSlot<CommandStore>;
-  interactions: JournalProjectionSlot<InteractionStore>;
-  decisions: JournalProjectionSlot<OperatorDecisionStore>;
-  runEvents: JournalProjectionSlot<RunEventStore>;
-  threads: JournalProjectionSlot<ThreadStore>;
-}
-
+export type { ProjectPartitionsPreparation } from "./project-partition-preparation.js";
 export class ProjectPartitions implements CommandAuthority {
-  private readonly partitions = new Map<string, ProjectPartition>();
+  private readonly partitions: ProjectPartitionCollection;
+  private preparationResult: ProjectPartitionsPreparation | null = null;
 
   constructor(
     private readonly rootDir: string,
@@ -57,27 +53,63 @@ export class ProjectPartitions implements CommandAuthority {
     /** Global-partition `thread.head.updated` sink, threaded into every project ThreadStore. */
     private readonly headPing?: ThreadHeadPingSink,
   ) {
-    this.sync();
+    this.partitions = new ProjectPartitionCollection(rootDir, projects, headPing);
+  }
+
+  prepare(): ProjectPartitionsPreparation {
+    if (this.preparationResult) return this.preparationResult;
+    const prepared = prepareProjectPartitions({
+      rootDir: this.rootDir,
+      projects: this.projects,
+      headPing: this.headPing,
+    });
+    this.partitions.clear();
+    for (const [id, entry] of prepared.entries) this.partitions.set(id, entry);
+    this.preparationResult = prepared.receipt;
+    return prepared.receipt;
+  }
+
+  revalidatePreparation(): void {
+    if (!this.preparationResult) throw new Error("project partitions are not prepared");
+    for (const entry of this.partitions.values()) entry.manager.revalidatePreparation();
+  }
+
+  activatePrepared(): void {
+    if (!this.preparationResult) throw new Error("project partitions are not prepared");
+    if (
+      this.preparationResult.coverage !== "complete" ||
+      this.preparationResult.recoveryRequiredPartitions.length > 0
+    ) {
+      throw new Error("project partitions require recovery before activation");
+    }
+    this.revalidatePreparation();
+    for (const entry of this.partitions.values()) entry.manager.activatePrepared();
+  }
+
+  recoverAfterStartup(): void {
+    for (const entry of this.partitions.values()) entry.manager.recoverAfterStartup();
   }
 
   all(): CommandStore[] {
     return [
       this.globalCommands.current(),
-      ...this.healthy().map((entry) => entry.commands.current()),
+      ...this.partitions.healthy().map((entry) => entry.commands.current()),
     ];
   }
 
   interactionStores(): InteractionStore[] {
     return [
       this.globalInteractions.current(),
-      ...this.healthy().map((entry) => entry.interactions.current()),
+      ...this.partitions.healthy().map((entry) => entry.interactions.current()),
     ];
   }
 
   interactionsForRequest(params: unknown): InteractionStore {
     const commandStore = this.forRequest(params);
     if (commandStore === this.globalCommands.current()) return this.globalInteractions.current();
-    const entry = this.healthy().find((candidate) => candidate.commands.current() === commandStore);
+    const entry = this.partitions
+      .healthy()
+      .find((candidate) => candidate.commands.current() === commandStore);
     if (!entry) throw new Error("command partition has no interaction authority");
     return entry.interactions.current();
   }
@@ -143,7 +175,7 @@ export class ProjectPartitions implements CommandAuthority {
 
   registerProject(input: Parameters<ProjectStore["register"]>[0]): Project {
     const project = this.projects.current().register(input);
-    this.ensure(project.id);
+    this.partitions.ensure(project.id);
     return project;
   }
 
@@ -169,13 +201,13 @@ export class ProjectPartitions implements CommandAuthority {
         reason: owned ? "root_inside_claudexor_runtime" : "root_permanently_missing",
       });
     }
-    if (retired.length > 0) this.sync();
+    if (retired.length > 0) this.partitions.sync();
     return retired;
   }
 
   relinkProject(id: string, root: string): Project {
     const project = this.projects.current().relink(id, root);
-    this.ensure(id).threads.current().relinkProjectRoot(project.root);
+    this.partitions.ensure(id).threads.current().relinkProjectRoot(project.root);
     return project;
   }
 
@@ -202,7 +234,7 @@ export class ProjectPartitions implements CommandAuthority {
         status: 404,
       });
     }
-    this.sync();
+    this.partitions.sync();
     const entry = this.partitions.get(id);
     if (entry) {
       if (!entry.manager.ready()) {
@@ -275,8 +307,13 @@ export class ProjectPartitions implements CommandAuthority {
   journal(partition: string): JournalManager {
     if (!partition.startsWith("project:")) throw unknownPartition(partition);
     const id = partition.slice("project:".length);
+    const prepared = this.partitions.get(id);
+    if (prepared) return prepared.manager;
+    if (this.preparationResult?.coverage === "global_registry_unavailable") {
+      throw unknownPartition(partition);
+    }
     if (!id || !this.projects.current().get(id)) throw unknownPartition(partition);
-    return this.ensure(id).manager;
+    return this.partitions.ensure(id).manager;
   }
 
   /** `ephemeral`: the caller declared this root ONE-SHOT (INV-035) — never registered, so the
@@ -304,7 +341,7 @@ export class ProjectPartitions implements CommandAuthority {
    * (dogfood: the fresh thread sank to the bottom). One global recency order.
    */
   listThreadsResilient(): { threads: Thread[]; problems: ControlProjectListingProblem[] } {
-    this.sync();
+    this.partitions.sync();
     const registry = this.projects.current();
     const threads: Thread[] = [...this.globalThreads.current().listThreads()];
     const problems: ControlProjectListingProblem[] = [];
@@ -371,7 +408,7 @@ export class ProjectPartitions implements CommandAuthority {
   }
 
   assertCredentialProfileInvalidationReady(): void {
-    this.sync();
+    this.partitions.sync();
     const unavailable = [...this.partitions.entries()]
       .filter(([, entry]) => !entry.manager.ready())
       .map(([id]) => id);
@@ -490,41 +527,6 @@ export class ProjectPartitions implements CommandAuthority {
     this.partitions.clear();
   }
 
-  private sync(): void {
-    const ids = new Set(
-      this.projects
-        .current()
-        .list()
-        .map((project) => project.id),
-    );
-    for (const id of ids) this.ensure(id);
-    for (const [id, entry] of this.partitions) {
-      if (ids.has(id)) continue;
-      entry.manager.close();
-      this.partitions.delete(id);
-    }
-  }
-
-  private ensure(projectId: string): ProjectPartition {
-    const existing = this.partitions.get(projectId);
-    if (existing) return existing;
-    const manager = new JournalManager(this.rootDir, { partition: `project:${projectId}` });
-    const commands = manager.registerProjection(commandProjection());
-    const interactions = manager.registerProjection(interactionProjection());
-    const decisions = manager.registerProjection(operatorDecisionProjection());
-    const runEvents = manager.registerProjection(runEventProjection());
-    const threads = manager.registerProjection(threadProjection(this.headPing));
-    manager.start();
-    const entry = { manager, commands, interactions, decisions, runEvents, threads };
-    this.partitions.set(projectId, entry);
-    return entry;
-  }
-
-  private healthy(): ProjectPartition[] {
-    this.sync();
-    return [...this.partitions.values()].filter((entry) => entry.manager.ready());
-  }
-
   /**
    * Canonical roots whose partition journal is READY — the set whose thread
    * lineage / job records are trustworthy. Retention (W3.6) fails CLOSED on a
@@ -533,18 +535,10 @@ export class ProjectPartitions implements CommandAuthority {
    * so its referenced runs would otherwise look unreferenced).
    */
   healthyProjectRoots(): string[] {
-    this.sync();
-    const registry = this.projects.current();
-    const roots: string[] = [];
-    for (const [id, entry] of this.partitions) {
-      if (!entry.manager.ready()) continue;
-      const root = registry.get(id)?.root;
-      if (root) roots.push(root);
-    }
-    return roots;
+    return this.partitions.healthyRoots();
   }
 
-  private partitionForRoot(root: string): ProjectPartition {
+  private partitionForRoot(root: string) {
     const project = this.projects.current().findByRoot(root);
     if (!project) {
       throw Object.assign(new Error(`project is not registered: ${root}`), {
@@ -552,13 +546,13 @@ export class ProjectPartitions implements CommandAuthority {
         status: 404,
       });
     }
-    return this.ensure(project.id);
+    return this.partitions.ensure(project.id);
   }
 
   private threadStores(): ThreadStore[] {
     return [
       this.globalThreads.current(),
-      ...this.healthy().map((entry) => entry.threads.current()),
+      ...this.partitions.healthy().map((entry) => entry.threads.current()),
     ];
   }
 
@@ -588,7 +582,9 @@ export class ProjectPartitions implements CommandAuthority {
 
   private commandStoreForThreadStore(store: ThreadStore): CommandStore {
     if (store === this.globalThreads.current()) return this.globalCommands.current();
-    const entry = this.healthy().find((candidate) => candidate.threads.current() === store);
+    const entry = this.partitions
+      .healthy()
+      .find((candidate) => candidate.threads.current() === store);
     if (!entry) throw new Error("thread partition has no command authority");
     return entry.commands.current();
   }
@@ -596,7 +592,9 @@ export class ProjectPartitions implements CommandAuthority {
   private decisionStoreForRequest(params: unknown): OperatorDecisionStore {
     const commands = this.forRequest(params);
     if (commands === this.globalCommands.current()) return this.globalDecisions.current();
-    const entry = this.healthy().find((candidate) => candidate.commands.current() === commands);
+    const entry = this.partitions
+      .healthy()
+      .find((candidate) => candidate.commands.current() === commands);
     if (!entry) throw new Error("command partition has no operator-decision authority");
     return entry.decisions.current();
   }
@@ -604,7 +602,9 @@ export class ProjectPartitions implements CommandAuthority {
   private runEventStoreForRequest(params: unknown): RunEventStore {
     const commands = this.forRequest(params);
     if (commands === this.globalCommands.current()) return this.globalRunEvents.current();
-    const entry = this.healthy().find((candidate) => candidate.commands.current() === commands);
+    const entry = this.partitions
+      .healthy()
+      .find((candidate) => candidate.commands.current() === commands);
     if (!entry) throw new Error("command partition has no run-event authority");
     return entry.runEvents.current();
   }

--- a/packages/daemon/src/project-partitions.ts
+++ b/packages/daemon/src/project-partitions.ts
@@ -34,6 +34,7 @@ import {
 import {
   activatePreparedProjectPartitions,
   prepareProjectPartitions,
+  refreshProjectPartitionsPreparation,
   ProjectPartitionCollection,
   type ProjectPartitionsPreparation,
 } from "./project-partition-preparation.js";
@@ -73,6 +74,22 @@ export class ProjectPartitions implements CommandAuthority {
   revalidatePreparation(): void {
     if (!this.preparationResult) throw new Error("project partitions are not prepared");
     for (const entry of this.partitions.values()) entry.manager.revalidatePreparation();
+  }
+
+  /** Live stage-2 re-verdict for the in-process reopen (C6): quarantined
+   * partitions reopened by their manager count ready, and a registry that
+   * became readable after a global reopen restores coverage. Refreshes the
+   * cached receipt the activation gate checks. */
+  refreshPreparation(): ProjectPartitionsPreparation {
+    if (!this.preparationResult) throw new Error("project partitions are not prepared");
+    this.preparationResult = refreshProjectPartitionsPreparation({
+      rootDir: this.rootDir,
+      projects: this.projects,
+      headPing: this.headPing,
+      previous: this.preparationResult,
+      entries: this.partitions,
+    });
+    return this.preparationResult;
   }
 
   activatePrepared(): void {

--- a/packages/daemon/src/project-partitions.ts
+++ b/packages/daemon/src/project-partitions.ts
@@ -32,6 +32,7 @@ import {
   failDeliveryCommand,
 } from "./delivery-command.js";
 import {
+  activatePreparedProjectPartitions,
   prepareProjectPartitions,
   ProjectPartitionCollection,
   type ProjectPartitionsPreparation,
@@ -76,16 +77,15 @@ export class ProjectPartitions implements CommandAuthority {
 
   activatePrepared(): void {
     if (!this.preparationResult) throw new Error("project partitions are not prepared");
-    if (
-      this.preparationResult.coverage !== "complete" ||
-      this.preparationResult.recoveryRequiredPartitions.length > 0
-    ) {
-      throw new Error("project partitions require recovery before activation");
-    }
-    this.revalidatePreparation();
-    for (const entry of this.partitions.values()) entry.manager.activatePrepared();
+    activatePreparedProjectPartitions({
+      rootDir: this.rootDir,
+      projects: this.projects,
+      headPing: this.headPing,
+      receipt: this.preparationResult,
+      entries: this.partitions,
+      resetReceipt: (receipt) => (this.preparationResult = receipt),
+    });
   }
-
   recoverAfterStartup(): void {
     for (const entry of this.partitions.values()) entry.manager.recoverAfterStartup();
   }

--- a/packages/daemon/src/project-partitions.ts
+++ b/packages/daemon/src/project-partitions.ts
@@ -38,6 +38,7 @@ import {
   ProjectPartitionCollection,
   type ProjectPartitionsPreparation,
 } from "./project-partition-preparation.js";
+import { listProjectThreadsResilient } from "./project-thread-listing.js";
 
 export type { ProjectPartitionsPreparation } from "./project-partition-preparation.js";
 export class ProjectPartitions implements CommandAuthority {
@@ -73,7 +74,12 @@ export class ProjectPartitions implements CommandAuthority {
 
   revalidatePreparation(): void {
     if (!this.preparationResult) throw new Error("project partitions are not prepared");
-    for (const entry of this.partitions.values()) entry.manager.revalidatePreparation();
+    for (const entry of this.partitions.values()) {
+      // A manager reopened by a recovery-route quarantine is live authority
+      // (C6): only still-prepared partitions revalidate.
+      if (entry.manager.ready()) continue;
+      entry.manager.revalidatePreparation();
+    }
   }
 
   /** Live stage-2 re-verdict for the in-process reopen (C6): quarantined
@@ -348,39 +354,14 @@ export class ProjectPartitions implements CommandAuthority {
     return this.listThreadsResilient().threads;
   }
 
-  /**
-   * Thread listing that is RESILIENT to a dead project (F2): a
-   * registered project whose filesystem root has vanished (e.g. a swept ghost
-   * envelope worktree) is SKIPPED with a disclosed per-project problem instead
-   * of failing the whole listing, while every other project's threads load.
-   * Each store sorts ITS threads by recency, but the stores concatenate —
-   * without a merge-sort a fresh project thread lands below every global one
-   * (dogfood: the fresh thread sank to the bottom). One global recency order.
-   */
+  /** Dead-project-resilient listing in one global recency order (F2);
+   * the mechanics live in project-thread-listing.ts. */
   listThreadsResilient(): { threads: Thread[]; problems: ControlProjectListingProblem[] } {
-    this.partitions.sync();
-    const registry = this.projects.current();
-    const threads: Thread[] = [...this.globalThreads.current().listThreads()];
-    const problems: ControlProjectListingProblem[] = [];
-    for (const [id, entry] of this.partitions) {
-      if (!entry.manager.ready()) continue;
-      const root = registry.get(id)?.root;
-      if (!root) continue;
-      if (!existsSync(root)) {
-        problems.push({
-          projectId: id,
-          root,
-          code: "project_root_missing",
-          message: `project root no longer exists: ${root}`,
-        });
-        continue;
-      }
-      for (const thread of entry.threads.current().listThreads()) threads.push(thread);
-    }
-    threads.sort((a, b) =>
-      a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0,
-    );
-    return { threads, problems };
+    return listProjectThreadsResilient({
+      partitions: this.partitions,
+      projects: this.projects,
+      globalThreads: this.globalThreads,
+    });
   }
 
   getThread(id: string): Thread | undefined {

--- a/packages/daemon/src/project-thread-listing.ts
+++ b/packages/daemon/src/project-thread-listing.ts
@@ -1,0 +1,43 @@
+/**
+ * Thread listing that is RESILIENT to a dead project (F2): a registered
+ * project whose filesystem root has vanished (e.g. a swept ghost envelope
+ * worktree) is SKIPPED with a disclosed per-project problem instead of
+ * failing the whole listing, while every other project's threads load. Each
+ * store sorts ITS threads by recency, but the stores concatenate — without a
+ * merge-sort a fresh project thread lands below every global one (dogfood:
+ * the fresh thread sank to the bottom). One global recency order.
+ */
+import { existsSync } from "node:fs";
+import type { ControlProjectListingProblem, Thread } from "@claudexor/schema";
+import type { JournalProjectionSlot } from "./journal-manager.js";
+import type { ProjectPartitionCollection } from "./project-partition-preparation.js";
+import type { ProjectStore } from "./projects.js";
+import type { ThreadStore } from "./threads.js";
+
+export function listProjectThreadsResilient(input: {
+  partitions: ProjectPartitionCollection;
+  projects: JournalProjectionSlot<ProjectStore>;
+  globalThreads: JournalProjectionSlot<ThreadStore>;
+}): { threads: Thread[]; problems: ControlProjectListingProblem[] } {
+  input.partitions.sync();
+  const registry = input.projects.current();
+  const threads: Thread[] = [...input.globalThreads.current().listThreads()];
+  const problems: ControlProjectListingProblem[] = [];
+  for (const [id, entry] of input.partitions) {
+    if (!entry.manager.ready()) continue;
+    const root = registry.get(id)?.root;
+    if (!root) continue;
+    if (!existsSync(root)) {
+      problems.push({
+        projectId: id,
+        root,
+        code: "project_root_missing",
+        message: `project root no longer exists: ${root}`,
+      });
+      continue;
+    }
+    for (const thread of entry.threads.current().listThreads()) threads.push(thread);
+  }
+  threads.sort((a, b) => (a.updated_at < b.updated_at ? 1 : a.updated_at > b.updated_at ? -1 : 0));
+  return { threads, problems };
+}

--- a/packages/daemon/src/quota-projection.ts
+++ b/packages/daemon/src/quota-projection.ts
@@ -1,0 +1,15 @@
+import type { DurableJournal } from "@claudexor/journal";
+import { QuotaRegistry, type QuotaRefresher, type QuotaSubjectUniverse } from "./quota-registry.js";
+
+export function quotaProjection(
+  refreshers: readonly QuotaRefresher[] = [],
+  subjects?: QuotaSubjectUniverse,
+  now: () => Date = () => new Date(),
+) {
+  return {
+    name: "quota",
+    create: (journal: DurableJournal) => new QuotaRegistry(journal, refreshers, now, subjects),
+    validate: (registry: QuotaRegistry) => registry.validateProjection(),
+    recover: (registry: QuotaRegistry) => registry.recoverAfterStartup(),
+  };
+}

--- a/packages/daemon/src/quota-registry.test.ts
+++ b/packages/daemon/src/quota-registry.test.ts
@@ -6,7 +6,8 @@ import { DurableJournal } from "@claudexor/journal";
 import { withQuotaAvailability } from "@claudexor/schema";
 import { hashJson } from "@claudexor/util";
 import { JournalManager } from "./journal-manager.js";
-import { QuotaRegistry, quotaProjection } from "./quota-registry.js";
+import { quotaProjection } from "./quota-projection.js";
+import { QuotaRegistry } from "./quota-registry.js";
 
 function quotaSnapshot(harness: string, subjectId: string | null, usedRatio: number) {
   return {
@@ -496,6 +497,8 @@ describe("QuotaRegistry", () => {
     const now = () => new Date("2026-07-28T00:00:01.000Z");
     const recovered = new QuotaRegistry(afterUpsert, [], now);
     expect(recovered.read().snapshots).toHaveLength(1);
+    expect(afterUpsert.records().map((record) => record.type)).toEqual(["quota.snapshot.upserted"]);
+    recovered.recoverAfterStartup();
     expect(afterUpsert.records().map((record) => record.type)).toEqual([
       "quota.snapshot.upserted",
       "quota.projection.updated",
@@ -510,6 +513,7 @@ describe("QuotaRegistry", () => {
     const afterRemove = new DurableJournal({ rootDir: root, partition: "global" });
     const recoveredRemoval = new QuotaRegistry(afterRemove, [], now);
     expect(recoveredRemoval.read().snapshots).toEqual([]);
+    recoveredRemoval.recoverAfterStartup();
     expect(afterRemove.records().at(-1)?.payload).toMatchObject({ reason: "recovery" });
     afterRemove.close();
     rmSync(root, { recursive: true, force: true });

--- a/packages/daemon/src/quota-registry.ts
+++ b/packages/daemon/src/quota-registry.ts
@@ -53,6 +53,7 @@ export class QuotaRegistry {
     Awaited<ReturnType<QuotaRegistry["performRefreshCycle"]>>
   >();
   private readonly pollPacer: QuotaPollPacer;
+  private recoveryMarkerPending = false;
 
   constructor(
     private readonly journal: DurableJournal,
@@ -126,9 +127,7 @@ export class QuotaRegistry {
     // projection marker. Replaying that state without a new marker would leave
     // already-subscribed clients permanently behind. Close the recovered
     // commit boundary synchronously before the projection becomes available.
-    if (rawMutationAfterMarker) {
-      this.appendProjectionMarker("recovery", this.now().toISOString());
-    }
+    this.recoveryMarkerPending = rawMutationAfterMarker;
     this.pollPacer = new QuotaPollPacer({
       now: this.now,
       publishClockTransition: () => this.publishClockTransitionIfNeeded(),
@@ -138,6 +137,13 @@ export class QuotaRegistry {
         await this.refreshCycle(false);
       },
     });
+  }
+
+  /** Publish the recovered projection boundary only after bootstrap activation. */
+  recoverAfterStartup(): void {
+    if (!this.recoveryMarkerPending) return;
+    this.appendProjectionMarker("recovery", this.now().toISOString());
+    this.recoveryMarkerPending = false;
   }
 
   read() {
@@ -515,18 +521,6 @@ export class QuotaRegistry {
     }
     return removed;
   }
-}
-
-export function quotaProjection(
-  refreshers: readonly QuotaRefresher[] = [],
-  subjects?: QuotaSubjectUniverse,
-  now: () => Date = () => new Date(),
-) {
-  return {
-    name: "quota",
-    create: (journal: DurableJournal) => new QuotaRegistry(journal, refreshers, now, subjects),
-    validate: (registry: QuotaRegistry) => registry.validateProjection(),
-  };
 }
 
 function snapshotKey(snapshot: QuotaSnapshot): string {

--- a/packages/daemon/src/recovery-only-admission.test.ts
+++ b/packages/daemon/src/recovery-only-admission.test.ts
@@ -1,0 +1,125 @@
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DurableJournal } from "@claudexor/journal";
+import { afterAll, describe, expect, it } from "vitest";
+import { DaemonClient } from "./client.js";
+import { CommandStore } from "./command-store.js";
+import { DaemonServer } from "./server.js";
+import { recoveryOnlyRefusal, servingModeOf, type DaemonServingMode } from "./serving-admission.js";
+
+const reapDirs: string[] = [];
+afterAll(() => {
+  for (const dir of reapDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function tempDir(name: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), `claudexor-${name}-`)));
+  reapDirs.push(dir);
+  return dir;
+}
+
+describe("serving admission snapshot", () => {
+  it("defaults to normal when the embedder wires no snapshot", () => {
+    expect(servingModeOf(undefined)).toBe("normal");
+    expect(servingModeOf(() => "recovery_only")).toBe("recovery_only");
+  });
+
+  it("shapes the typed recovery-only refusal", () => {
+    const refusal = recoveryOnlyRefusal("claudexor.enqueue");
+    expect(refusal).toMatchObject({
+      code: "daemon_recovery_only",
+      status: 503,
+      retryable: true,
+    });
+    expect(refusal.message).toContain("claudexor.enqueue");
+  });
+});
+
+describe("DaemonServer recovery-only admission (issue #165 D5)", () => {
+  it("starts without touching command projections, refuses product RPCs typed, keeps health + shutdown reachable, and opens admission live", async () => {
+    const dir = tempDir("recovery-admission");
+    const socketPath = join(dir, "daemon.sock");
+    let mode: DaemonServingMode = "recovery_only";
+    const journal = new DurableJournal({ rootDir: join(dir, "journal"), partition: "global" });
+    const store = new CommandStore(journal);
+    store.recoverAfterStartup();
+    let projectionTouchesWhileClosed = 0;
+    const server = new DaemonServer({
+      socketPath,
+      token: "token",
+      servingMode: () => mode,
+      commands: {
+        current: () => {
+          // The registry must stay untouched while product admission is
+          // closed: the journal projections are not activated yet (D5).
+          if (mode !== "normal") {
+            projectionTouchesWhileClosed += 1;
+            throw new Error("command projection touched during recovery-only admission");
+          }
+          return store;
+        },
+      },
+      runner: async () => ({ lifecycle: "succeeded" }),
+    });
+    await server.start();
+    try {
+      const client = new DaemonClient(socketPath, "token");
+      await expect(client.health()).resolves.toMatchObject({
+        ok: true,
+        servingMode: "recovery_only",
+        jobs: 0,
+      });
+      await expect(
+        client.enqueue({ value: 1 }, { idempotencyKey: "recovery-1", clientId: "test" }),
+      ).rejects.toMatchObject({
+        code: "daemon_recovery_only",
+        status: 503,
+        retryable: true,
+      });
+      await expect(client.list()).rejects.toMatchObject({ code: "daemon_recovery_only" });
+      expect(projectionTouchesWhileClosed).toBe(0);
+
+      mode = "normal";
+      await expect(client.health()).resolves.toMatchObject({ ok: true, servingMode: "normal" });
+      const accepted = await client.enqueue(
+        { value: 2 },
+        { idempotencyKey: "normal-1", clientId: "test" },
+      );
+      expect(accepted).toMatchObject({ id: expect.any(String) });
+    } finally {
+      await server.stop();
+      journal.close();
+    }
+  });
+
+  it("keeps the operator shutdown RPC reachable while admission is closed", async () => {
+    const dir = tempDir("recovery-shutdown");
+    const socketPath = join(dir, "daemon.sock");
+    const journal = new DurableJournal({ rootDir: join(dir, "journal"), partition: "global" });
+    const store = new CommandStore(journal);
+    store.recoverAfterStartup();
+    let shutdownRequested = 0;
+    const server = new DaemonServer({
+      socketPath,
+      token: "token",
+      servingMode: () => "recovery_only",
+      commands: { current: () => store },
+      onShutdownRequested: async () => {
+        shutdownRequested += 1;
+        await server.stop();
+      },
+      runner: async () => ({ lifecycle: "succeeded" }),
+    });
+    await server.start();
+    try {
+      const client = new DaemonClient(socketPath, "token");
+      await expect(client.shutdown()).resolves.toMatchObject({ ok: true });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(shutdownRequested).toBe(1);
+    } finally {
+      await server.stop();
+      journal.close();
+    }
+  });
+});

--- a/packages/daemon/src/root-authority.test.ts
+++ b/packages/daemon/src/root-authority.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -71,6 +71,32 @@ describe("root authority barrier installation", () => {
     expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
     expect(grant.lease.path).toBe(join(anchor, "active.writer"));
     expect(marker).toContain(anchor);
+    // C4: the stale owner record was preserved in place as evidence.
+    expect(
+      readdirSync(anchor).some(
+        (name) => name.startsWith("owner.stale-2147483646-") && name.endsWith(".json"),
+      ),
+    ).toBe(true);
+    grant.release();
+  });
+
+  it("completes a migration that crashed after preserving the stale owner (C4)", () => {
+    const { socketPath, anchor } = tempSocket();
+    // The only producer of {preservation file, no owner.json} is a crashed
+    // step-1 migration; the next candidate must finish the installation.
+    mkdirSync(anchor, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(anchor, `owner.stale-2147483646-${"a".repeat(64)}.json`),
+      '{"pid":2147483646,"token":"legacy"}\n',
+      { mode: 0o600 },
+    );
+    const grant = grantFor(socketPath, "3.4.0");
+    expect(readRootAuthority(anchor)).toMatchObject({
+      status: "valid",
+      record: { state: "vacant", epoch: ROOT_AUTHORITY_EPOCH },
+    });
+    expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+    expect(grant.lease.path).toBe(join(anchor, "active.writer"));
     grant.release();
   });
 

--- a/packages/daemon/src/root-authority.test.ts
+++ b/packages/daemon/src/root-authority.test.ts
@@ -1,4 +1,14 @@
-import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -259,6 +269,63 @@ describe("root authority floor advancement and persistence", () => {
     // A pre-fix-shaped flat acquisition attempt still fails closed: the anchor
     // directory exists and carries no parseable owner record.
     expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+  });
+});
+
+describe("root authority validation hardening (C9, sol SCOPE-07)", () => {
+  it("a released grant superseded by a newer generation cannot advance the floor", () => {
+    const { socketPath, anchor } = tempSocket();
+    const stale = grantFor(socketPath, "3.4.0");
+    stale.release();
+    // A newer generation owns the root now; the stale grant must be fenced.
+    const live = grantFor(socketPath, "3.5.0");
+    expect(() => stale.advanceFloor()).toThrow(
+      expect.objectContaining({ code: "root_authority_grant_stale" }),
+    );
+    // The live generation's authority is undisturbed by the stale attempt.
+    expect(readRootAuthority(anchor)).toMatchObject({ status: "valid" });
+    expect(live.advanceFloor().floor).toBe("3.5.0");
+    live.release();
+  });
+
+  it("refuses to overwrite a missing or corrupt marker at floor advancement", () => {
+    const { socketPath, marker } = tempSocket();
+    const grant = grantFor(socketPath, "3.4.0");
+    // The marker vanishes underneath the serving daemon: refusal, no rewrite.
+    rmSync(marker);
+    expect(() => grant.advanceFloor()).toThrow(
+      expect.objectContaining({ code: "root_authority_unreadable" }),
+    );
+    expect(existsSync(marker)).toBe(false);
+    // A corrupt marker is typed-refused and its bytes stay untouched.
+    writeFileSync(marker, "not json\n", { mode: 0o600 });
+    expect(() => grant.advanceFloor()).toThrow(
+      expect.objectContaining({ code: "root_authority_unreadable" }),
+    );
+    expect(readFileSync(marker, "utf8")).toBe("not json\n");
+    grant.release();
+  });
+
+  it("refuses a malformed candidate semantic version even on a fresh floor", () => {
+    const { socketPath, anchor } = tempSocket();
+    expect(() => grantFor(socketPath, "not-a-semver")).toThrow(
+      expect.objectContaining({ code: "root_authority_candidate_invalid" }),
+    );
+    // Nothing was installed by the refused candidate.
+    expect(readRootAuthority(anchor)).toMatchObject({ status: "absent" });
+  });
+
+  it("refuses a world-writable/foreign-mode marker (validated like startup diagnostics)", () => {
+    if (!process.getuid) return; // POSIX-only privacy semantics
+    const { socketPath, anchor, marker } = tempSocket();
+    writeMarker(anchor, { schemaVersion: 2, epoch: ROOT_AUTHORITY_EPOCH, state: "vacant" });
+    chmodSync(marker, 0o666);
+    expect(readRootAuthority(anchor)).toMatchObject({ status: "invalid" });
+    expect(() => grantFor(socketPath, "3.4.0")).toThrow(
+      expect.objectContaining({ code: "root_authority_unreadable" }),
+    );
+    // The foreign-mode bytes were not repaired or replaced.
+    expect(lstatSync(marker).mode & 0o777).toBe(0o666);
   });
 });
 

--- a/packages/daemon/src/root-authority.test.ts
+++ b/packages/daemon/src/root-authority.test.ts
@@ -52,9 +52,9 @@ describe("root authority barrier installation", () => {
     expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
     // The live claim moved to the nested slot behind the barrier.
     expect(grant.lease.path).toBe(join(anchor, "active.writer"));
-    expect(
-      JSON.parse(readFileSync(join(grant.lease.path, "owner.json"), "utf8")),
-    ).toMatchObject({ pid: process.pid });
+    expect(JSON.parse(readFileSync(join(grant.lease.path, "owner.json"), "utf8"))).toMatchObject({
+      pid: process.pid,
+    });
     grant.release();
   });
 

--- a/packages/daemon/src/root-authority.test.ts
+++ b/packages/daemon/src/root-authority.test.ts
@@ -1,0 +1,261 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireRootAuthority,
+  assertRootAuthorityAdmits,
+  readRootAuthority,
+  ROOT_AUTHORITY_EPOCH,
+  type RootAuthorityRecord,
+} from "./root-authority.js";
+import {
+  acquireDaemonWriterLease,
+  inspectDaemonWriterLease,
+  writerLeaseAnchorPath,
+  writerLeasePath,
+  ROOT_AUTHORITY_MARKER_FILE,
+} from "./writer-lease.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempSocket(): { socketPath: string; anchor: string; marker: string } {
+  const root = mkdtempSync(join(tmpdir(), "claudexor-root-authority-"));
+  roots.push(root);
+  const socketPath = join(root, "claudexord.sock");
+  const anchor = writerLeaseAnchorPath(socketPath);
+  return { socketPath, anchor, marker: join(anchor, ROOT_AUTHORITY_MARKER_FILE) };
+}
+
+function writeMarker(anchor: string, record: Record<string, unknown>): void {
+  mkdirSync(anchor, { recursive: true, mode: 0o700 });
+  writeFileSync(join(anchor, ROOT_AUTHORITY_MARKER_FILE), `${JSON.stringify(record)}\n`, {
+    mode: 0o600,
+  });
+}
+
+function grantFor(socketPath: string, version: string) {
+  return acquireRootAuthority({ socketPath, version, canonicalSocketPath: socketPath });
+}
+
+describe("root authority barrier installation", () => {
+  it("installs the permanent opaque barrier on a barrier-less root and claims the nested slot", () => {
+    const { socketPath, anchor, marker } = tempSocket();
+    const grant = grantFor(socketPath, "3.4.0");
+    const record = JSON.parse(readFileSync(marker, "utf8")) as RootAuthorityRecord;
+    expect(record).toEqual({ schemaVersion: 2, epoch: ROOT_AUTHORITY_EPOCH, state: "vacant" });
+    // The barrier carries NO top-level owner record a pre-fix parse could use.
+    expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+    // The live claim moved to the nested slot behind the barrier.
+    expect(grant.lease.path).toBe(join(anchor, "active.writer"));
+    expect(
+      JSON.parse(readFileSync(join(grant.lease.path, "owner.json"), "utf8")),
+    ).toMatchObject({ pid: process.pid });
+    grant.release();
+  });
+
+  it("converts an owned stale flat legacy lease in place (D3 first migration)", () => {
+    const { socketPath, anchor, marker } = tempSocket();
+    // A dead pre-fix owner: flat directory with a parseable owner.json whose
+    // pid can no longer exist.
+    mkdirSync(anchor, { recursive: true, mode: 0o700 });
+    writeFileSync(join(anchor, "owner.json"), '{"pid":2147483646,"token":"legacy"}\n', {
+      mode: 0o600,
+    });
+    const grant = grantFor(socketPath, "3.4.0");
+    expect(readRootAuthority(anchor).status).toBe("valid");
+    expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+    expect(grant.lease.path).toBe(join(anchor, "active.writer"));
+    expect(marker).toContain(anchor);
+    grant.release();
+  });
+
+  it("refuses while a live flat legacy owner holds the address", () => {
+    const { socketPath, anchor } = tempSocket();
+    mkdirSync(anchor, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      join(anchor, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, token: "live-legacy" })}\n`,
+      { mode: 0o600 },
+    );
+    expect(() => grantFor(socketPath, "3.4.0")).toThrow(
+      expect.objectContaining({ code: "daemon_writer_busy" }),
+    );
+    // The live owner's record was not disturbed.
+    expect(JSON.parse(readFileSync(join(anchor, "owner.json"), "utf8"))).toMatchObject({
+      pid: process.pid,
+      token: "live-legacy",
+    });
+  });
+
+  it("completes an interrupted migration whose owner record is the sentinel", () => {
+    const { socketPath, anchor } = tempSocket();
+    mkdirSync(anchor, { recursive: true, mode: 0o700 });
+    writeFileSync(join(anchor, "owner.json"), '{"rootAuthority":"migrating"}\n', { mode: 0o600 });
+    const grant = grantFor(socketPath, "3.4.0");
+    expect(readRootAuthority(anchor)).toMatchObject({
+      status: "valid",
+      record: { state: "vacant", epoch: ROOT_AUTHORITY_EPOCH },
+    });
+    expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+    grant.release();
+  });
+});
+
+describe("root authority epoch and floor admission", () => {
+  it("refuses a pre-fix (lower) writer epoch", () => {
+    const { socketPath, anchor } = tempSocket();
+    writeMarker(anchor, { schemaVersion: 2, epoch: 1, state: "vacant" });
+    expect(() => grantFor(socketPath, "3.4.0")).toThrow(
+      expect.objectContaining({ code: "root_authority_epoch_unsupported" }),
+    );
+  });
+
+  it("refuses a newer-than-supported writer epoch", () => {
+    const { socketPath, anchor } = tempSocket();
+    writeMarker(anchor, { schemaVersion: 2, epoch: ROOT_AUTHORITY_EPOCH + 1, state: "vacant" });
+    expect(() => grantFor(socketPath, "3.4.0")).toThrow(
+      expect.objectContaining({ code: "root_authority_epoch_unsupported" }),
+    );
+  });
+
+  it("refuses a candidate strictly below the proven serving floor", () => {
+    const { socketPath, anchor } = tempSocket();
+    writeMarker(anchor, {
+      schemaVersion: 2,
+      epoch: ROOT_AUTHORITY_EPOCH,
+      state: "served",
+      floor: "3.5.0",
+    });
+    expect(() => grantFor(socketPath, "3.4.9")).toThrow(
+      expect.objectContaining({ code: "root_authority_floor_regression" }),
+    );
+  });
+
+  it("admits an equal semantic version for normal contention (SHA is evidence, not ordering)", () => {
+    const { socketPath, anchor } = tempSocket();
+    writeMarker(anchor, {
+      schemaVersion: 2,
+      epoch: ROOT_AUTHORITY_EPOCH,
+      state: "served",
+      floor: "3.4.0",
+    });
+    const grant = grantFor(socketPath, "3.4.0");
+    expect(grant.record.floor).toBe("3.4.0");
+    grant.release();
+  });
+
+  it("admits a higher semantic version and keeps the floor until it re-proves serving", () => {
+    const { socketPath, anchor } = tempSocket();
+    writeMarker(anchor, {
+      schemaVersion: 2,
+      epoch: ROOT_AUTHORITY_EPOCH,
+      state: "served",
+      floor: "3.4.0",
+    });
+    const grant = grantFor(socketPath, "3.5.0");
+    expect(readRootAuthority(anchor)).toMatchObject({
+      status: "valid",
+      record: { floor: "3.4.0", state: "served" },
+    });
+    grant.release();
+  });
+
+  it("fails closed on a candidate version that cannot be ordered against a floor", () => {
+    expect(() =>
+      assertRootAuthorityAdmits(
+        { schemaVersion: 2, epoch: ROOT_AUTHORITY_EPOCH, state: "served", floor: "3.4.0" },
+        "not-a-semver",
+      ),
+    ).toThrow(expect.objectContaining({ code: "root_authority_floor_regression" }));
+  });
+
+  it("fails closed on a malformed or foreign-schema marker", () => {
+    const malformed = tempSocket();
+    writeMarker(malformed.anchor, { schemaVersion: 3, epoch: 9, state: "vacant" });
+    expect(() => grantFor(malformed.socketPath, "3.4.0")).toThrow(
+      expect.objectContaining({ code: "root_authority_unreadable" }),
+    );
+    const garbage = tempSocket();
+    mkdirSync(garbage.anchor, { recursive: true, mode: 0o700 });
+    writeFileSync(join(garbage.anchor, ROOT_AUTHORITY_MARKER_FILE), "not json\n", {
+      mode: 0o600,
+    });
+    expect(() => grantFor(garbage.socketPath, "3.4.0")).toThrow(
+      expect.objectContaining({ code: "root_authority_unreadable" }),
+    );
+  });
+});
+
+describe("root authority floor advancement and persistence", () => {
+  it("advances the floor only through advanceFloor and keeps it monotonic", () => {
+    const { socketPath, anchor } = tempSocket();
+    const grant = grantFor(socketPath, "3.4.0");
+    expect(grant.advanceFloor()).toEqual({
+      schemaVersion: 2,
+      epoch: ROOT_AUTHORITY_EPOCH,
+      state: "served",
+      floor: "3.4.0",
+    });
+    grant.release();
+
+    // A later, higher candidate raises the floor after its own proof…
+    const higher = grantFor(socketPath, "3.6.0");
+    expect(higher.advanceFloor().floor).toBe("3.6.0");
+    higher.release();
+
+    // …and an equal-floor candidate can never lower it.
+    const equal = grantFor(socketPath, "3.6.0");
+    expect(equal.advanceFloor().floor).toBe("3.6.0");
+    equal.release();
+    expect(readRootAuthority(anchor)).toMatchObject({
+      status: "valid",
+      record: { floor: "3.6.0", state: "served" },
+    });
+  });
+
+  it("keeps the barrier and its record across a clean release (never removed automatically)", () => {
+    const { socketPath, anchor, marker } = tempSocket();
+    const grant = grantFor(socketPath, "3.4.0");
+    grant.advanceFloor();
+    grant.release();
+    expect(readRootAuthority(anchor)).toMatchObject({
+      status: "valid",
+      record: { state: "served", floor: "3.4.0" },
+    });
+    // The nested claim is gone, the barrier is not.
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({ status: "absent" });
+    expect(readFileSync(marker, "utf8")).toContain('"state":"served"');
+    // A pre-fix-shaped flat acquisition attempt still fails closed: the anchor
+    // directory exists and carries no parseable owner record.
+    expect(() => readFileSync(join(anchor, "owner.json"))).toThrow();
+  });
+});
+
+describe("writer lease address redirect under a barrier", () => {
+  it("resolves the flat anchor without a barrier and the nested slot with one", () => {
+    const { socketPath, anchor } = tempSocket();
+    expect(writerLeasePath(socketPath)).toBe(anchor);
+    writeMarker(anchor, { schemaVersion: 2, epoch: ROOT_AUTHORITY_EPOCH, state: "vacant" });
+    expect(writerLeasePath(socketPath)).toBe(join(anchor, "active.writer"));
+  });
+
+  it("routes plain lease acquisition and inspection through the nested slot", () => {
+    const { socketPath, anchor } = tempSocket();
+    writeMarker(anchor, { schemaVersion: 2, epoch: ROOT_AUTHORITY_EPOCH, state: "vacant" });
+    const lease = acquireDaemonWriterLease(socketPath);
+    expect(lease.path).toBe(join(anchor, "active.writer"));
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({
+      status: "owned",
+      owner: { pid: process.pid },
+    });
+    lease.release();
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({ status: "absent" });
+    // Releasing the nested claim never releases the barrier.
+    expect(readRootAuthority(anchor).status).toBe("valid");
+  });
+});

--- a/packages/daemon/src/root-authority.ts
+++ b/packages/daemon/src/root-authority.ts
@@ -32,18 +32,22 @@
  * This module builds ON the writer-lease owner (single-writer acquisition,
  * owner classification, stale quarantine) and never re-implements liveness.
  */
-import { randomUUID } from "node:crypto";
-import { lstatSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { lstatSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ProcessIdentityReader } from "@claudexor/core";
 import { compareRuntimeSemver, isRuntimeSemver } from "@claudexor/util";
 import { canonicalDefaultSocketPath } from "./token.js";
 import {
   acquireDaemonWriterLease,
+  inspectDaemonWriterLease,
+  resolveWriterLeaseFilesystem,
   writerLeaseAnchorPath,
   ROOT_AUTHORITY_MARKER_FILE,
+  type DaemonLeaseOwner,
   type DaemonWriterLease,
   type DaemonWriterLeaseDependencies,
+  type DaemonWriterLeaseFilesystem,
 } from "./writer-lease.js";
 
 export const ROOT_AUTHORITY_SCHEMA_VERSION = 2;
@@ -222,6 +226,97 @@ function completeBarrierInstallation(anchorPath: string): void {
   rmSync(join(anchorPath, "owner.json"), { force: true });
 }
 
+/** In-place preservation name for a stale flat owner record (C4). The name
+ * never parses as the owner record, marks a migration as begun for crash
+ * completion, and keeps the dead owner's bytes as evidence (authority
+ * artifacts are never deleted). */
+function staleFlatOwnerPreservationName(owner: DaemonLeaseOwner): string {
+  const digest = createHash("sha256")
+    .update(String(owner.pid))
+    .update("\0")
+    .update(owner.token)
+    .digest("hex");
+  return `owner.stale-${owner.pid}-${digest}.json`;
+}
+
+function hasStaleFlatOwnerPreservation(anchorPath: string): boolean {
+  try {
+    return readdirSync(anchorPath).some(
+      (name) => name.startsWith("owner.stale-") && name.endsWith(".json"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/** Atomically install the migration sentinel as owner.json (temp + rename). */
+function installMigrationSentinel(anchorPath: string, fs: DaemonWriterLeaseFilesystem): void {
+  const temp = join(anchorPath, `.owner.json.${process.pid}-${randomUUID()}`);
+  fs.writeOwner(temp, `${JSON.stringify(MIGRATION_SENTINEL)}\n`);
+  fs.rename(temp, join(anchorPath, "owner.json"));
+}
+
+/**
+ * C4: convert a PROVEN-STALE flat legacy generation into the barrier IN
+ * PLACE, before any claim. The shared lease machinery's stale quarantine
+ * renames the WHOLE directory to the tombstone and recreates it — an absence
+ * window a newly arriving legacy claimant wins, beyond D3's accepted
+ * already-running limitation. On this migration path the directory is never
+ * absent and owner.json is never a parseable dead owner after our first
+ * mutation:
+ *   1. atomically rename owner.json to the in-dir stale-owner preservation
+ *      file (a legacy claimant fails closed on the missing owner record and
+ *      never writes one into an existing directory);
+ *   2. atomically install the migration sentinel as owner.json;
+ *   3. publish the marker and retire the sentinel.
+ * A crash between 1 and 2 leaves {preservation file, no owner.json} — a
+ * state only this module produces — and the next fixed candidate completes
+ * the installation deterministically; a crash between 2 and 3 is the
+ * existing sentinel-completion path. Nested-slot (#159) semantics are
+ * untouched: this runs only on the barrier-less flat address.
+ */
+function migrateStaleFlatGenerationInPlace(
+  anchorPath: string,
+  canonical: string,
+  deps: DaemonWriterLeaseDependencies,
+): void {
+  const status = inspectDaemonWriterLease(canonical, deps);
+  if (status.path !== anchorPath) return; // a barrier already resolved the nested slot
+  const fs = resolveWriterLeaseFilesystem(deps);
+  try {
+    if (status.status === "owned" && status.capability.status === "proven_stale") {
+      fs.rename(
+        join(anchorPath, "owner.json"),
+        join(anchorPath, staleFlatOwnerPreservationName(status.owner)),
+      );
+      installMigrationSentinel(anchorPath, fs);
+      completeBarrierInstallation(anchorPath);
+      return;
+    }
+    if (
+      status.status === "unknown" &&
+      status.reason === "owner_missing" &&
+      hasStaleFlatOwnerPreservation(anchorPath)
+    ) {
+      // A previous migration crashed after preserving the stale owner.
+      installMigrationSentinel(anchorPath, fs);
+      completeBarrierInstallation(anchorPath);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      // A concurrent fixed contender is migrating the same generation; the
+      // claim below arbitrates through the shared single-writer machinery.
+      return;
+    }
+    throw rootAuthorityRefusal(
+      "root_authority_unreadable",
+      `root authority barrier could not be installed over the stale flat generation at ${anchorPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+}
+
 /**
  * Stage-1 startup admission: validate/install the permanent barrier, apply
  * the epoch + floor refusals, and claim single-writer authority for this
@@ -253,6 +348,14 @@ export function acquireRootAuthority(input: AcquireRootAuthorityInput): RootAuth
     // publishing the marker. The address stayed opaque throughout; finish the
     // interrupted installation deterministically.
     completeBarrierInstallation(anchorPath);
+  } else {
+    // C4: a PROVEN-STALE flat generation migrates in place BEFORE any claim,
+    // so the shared quarantine's rename-away/recreate absence window never
+    // opens on the legacy-visible address.
+    migrateStaleFlatGenerationInPlace(anchorPath, canonical, {
+      identity: input.identity,
+      ...(input.deps ?? {}),
+    });
   }
 
   // Claim the canonical root address. With a barrier installed the lease

--- a/packages/daemon/src/root-authority.ts
+++ b/packages/daemon/src/root-authority.ts
@@ -1,0 +1,336 @@
+/**
+ * Persistent root-authority barrier for a shared data root (issue #165).
+ *
+ * D1: before ANY journal recovery or destructive startup work, the fixed
+ * daemon publishes a permanent, legacy-opaque barrier at the canonical writer
+ * address. The barrier is a lease DIRECTORY carrying `root-authority-v2.json`
+ * and NO top-level owner.json, so a pre-fix claimant's owner parse fails
+ * closed forever — it can neither adopt nor quarantine the address. The
+ * barrier is never removed, including on clean shutdown: a failed fixed
+ * candidate leaves a protected recovery/offline state instead of reopening
+ * the process-reaping race.
+ *
+ * D2: the barrier record persists two SEPARATE facts — the writer protocol
+ * epoch (pre-fix and newer-than-supported epochs are refused) and the
+ * semantic version floor of the last fixed runtime that PROVED it could
+ * serve (strictly lower fixed versions are refused; equal versions contend
+ * normally — build SHA/entry path are evidence, not ordering).
+ *
+ * D3: an already-running pre-fix contender that passed its dead-owner check
+ * before this barrier existed cannot be retroactively revoked — a LIVE flat
+ * owner refuses this candidate through the shared lease machinery. Migration
+ * of an owned flat generation is an in-place atomic owner replacement: the
+ * owner record is atomically swapped for an unparseable migration sentinel,
+ * so the address is never absent and never carries a dead parseable owner.
+ * This module makes no stronger claim.
+ *
+ * D4: authority follows the data root. The barrier anchors at the canonical
+ * DEFAULT socket address of the daemon root even when the serving socket
+ * spelling differs, so every fixed runtime sharing one
+ * CLAUDEXOR_CONFIG_DIR/daemon root contends on one root authority.
+ *
+ * This module builds ON the writer-lease owner (single-writer acquisition,
+ * owner classification, stale quarantine) and never re-implements liveness.
+ */
+import { randomUUID } from "node:crypto";
+import { lstatSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ProcessIdentityReader } from "@claudexor/core";
+import { compareRuntimeSemver, isRuntimeSemver } from "@claudexor/util";
+import { canonicalDefaultSocketPath } from "./token.js";
+import {
+  acquireDaemonWriterLease,
+  writerLeaseAnchorPath,
+  ROOT_AUTHORITY_MARKER_FILE,
+  type DaemonWriterLease,
+  type DaemonWriterLeaseDependencies,
+} from "./writer-lease.js";
+
+export const ROOT_AUTHORITY_SCHEMA_VERSION = 2;
+/** First fixed writer-protocol epoch. Pre-fix runtimes have no epoch at all;
+ * a record with a lower OR higher epoch than this build supports is refused. */
+export const ROOT_AUTHORITY_EPOCH = 2;
+
+export interface RootAuthorityRecord {
+  schemaVersion: typeof ROOT_AUTHORITY_SCHEMA_VERSION;
+  epoch: number;
+  /** `vacant` until some fixed runtime proved it could serve this root;
+   * `served` afterwards (with `floor` recording that runtime's version). */
+  state: "vacant" | "served";
+  /** Semantic version of the last fixed runtime that proved it could serve. */
+  floor?: string;
+}
+
+export type RootAuthorityRefusalCode =
+  | "root_authority_unreadable"
+  | "root_authority_epoch_unsupported"
+  | "root_authority_floor_regression";
+
+function rootAuthorityRefusal(
+  code: RootAuthorityRefusalCode,
+  message: string,
+): Error & { code: RootAuthorityRefusalCode; status: number } {
+  return Object.assign(new Error(message), { code, status: 409 });
+}
+
+export type RootAuthorityStatus =
+  | { status: "absent"; markerPath: string }
+  | { status: "valid"; markerPath: string; record: RootAuthorityRecord }
+  | { status: "invalid"; markerPath: string; reason: string };
+
+function parseRootAuthorityRecord(raw: string): RootAuthorityRecord | string {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return "marker is not valid JSON";
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return "marker is not a JSON object";
+  }
+  const record = value as Record<string, unknown>;
+  if (record.schemaVersion !== ROOT_AUTHORITY_SCHEMA_VERSION) {
+    return `marker schemaVersion is not ${ROOT_AUTHORITY_SCHEMA_VERSION}`;
+  }
+  if (!Number.isSafeInteger(record.epoch) || (record.epoch as number) <= 0) {
+    return "marker epoch is not a positive integer";
+  }
+  if (record.state !== "vacant" && record.state !== "served") {
+    return "marker state is not vacant/served";
+  }
+  if (record.floor !== undefined && !isRuntimeSemver(record.floor)) {
+    return "marker floor is not an x.y.z semver";
+  }
+  return {
+    schemaVersion: ROOT_AUTHORITY_SCHEMA_VERSION,
+    epoch: record.epoch as number,
+    state: record.state,
+    ...(record.floor !== undefined ? { floor: record.floor as string } : {}),
+  };
+}
+
+/** Fail-closed barrier read: only a physically missing marker is `absent`. */
+export function readRootAuthority(anchorPath: string): RootAuthorityStatus {
+  const markerPath = join(anchorPath, ROOT_AUTHORITY_MARKER_FILE);
+  let raw: string;
+  try {
+    const stat = lstatSync(markerPath);
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      return { status: "invalid", markerPath, reason: "marker is not a regular file" };
+    }
+    raw = readFileSync(markerPath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { status: "absent", markerPath };
+    }
+    return { status: "invalid", markerPath, reason: "marker is unreadable" };
+  }
+  const record = parseRootAuthorityRecord(raw);
+  if (typeof record === "string") return { status: "invalid", markerPath, reason: record };
+  return { status: "valid", markerPath, record };
+}
+
+/** D2 admission: refuse foreign epochs and strictly lower semantic versions. */
+export function assertRootAuthorityAdmits(record: RootAuthorityRecord, version: string): void {
+  if (record.epoch !== ROOT_AUTHORITY_EPOCH) {
+    throw rootAuthorityRefusal(
+      "root_authority_epoch_unsupported",
+      record.epoch < ROOT_AUTHORITY_EPOCH
+        ? `root authority epoch ${record.epoch} predates the supported writer epoch ${ROOT_AUTHORITY_EPOCH}`
+        : `root authority epoch ${record.epoch} is newer than the supported writer epoch ${ROOT_AUTHORITY_EPOCH}`,
+    );
+  }
+  if (record.floor === undefined) return;
+  if (!isRuntimeSemver(version)) {
+    // Fail closed: a candidate that cannot be ORDERED against the proven
+    // floor cannot prove it is not a regression.
+    throw rootAuthorityRefusal(
+      "root_authority_floor_regression",
+      `candidate version '${version}' cannot be ordered against the proven serving floor ${record.floor}`,
+    );
+  }
+  if (compareRuntimeSemver(version, record.floor) < 0) {
+    throw rootAuthorityRefusal(
+      "root_authority_floor_regression",
+      `candidate version ${version} is below the proven serving floor ${record.floor}`,
+    );
+  }
+}
+
+/** Atomic (tmp + rename), link-refusing marker write inside the barrier dir. */
+function writeRootAuthorityRecord(anchorPath: string, record: RootAuthorityRecord): void {
+  const markerPath = join(anchorPath, ROOT_AUTHORITY_MARKER_FILE);
+  const temp = join(anchorPath, `.${ROOT_AUTHORITY_MARKER_FILE}.${process.pid}-${randomUUID()}`);
+  writeFileSync(temp, `${JSON.stringify(record)}\n`, { mode: 0o600, flag: "wx" });
+  try {
+    renameSync(temp, markerPath);
+  } catch (error) {
+    rmSync(temp, { force: true });
+    throw error;
+  }
+}
+
+export interface RootAuthorityGrant {
+  /** The daemon's operational writer lease (socket-adjacent address). */
+  readonly lease: DaemonWriterLease;
+  /** The barrier record that admitted this candidate. */
+  readonly record: RootAuthorityRecord;
+  /** Barrier anchor directory (also the canonical lease anchor). */
+  readonly anchorPath: string;
+  /** D5 stage 4: persist that this exact runtime PROVED it could serve.
+   * Monotonic — never lowers an existing floor. Returns the stored record. */
+  advanceFloor(): RootAuthorityRecord;
+  /** Release the live writer claim(s). The barrier itself persists (D1). */
+  release(): void;
+}
+
+export interface AcquireRootAuthorityInput {
+  socketPath: string;
+  /** Candidate's semantic runtime version (engine build identity). */
+  version: string;
+  identity?: ProcessIdentityReader;
+  deps?: Omit<DaemonWriterLeaseDependencies, "identity">;
+  /** Test seam: canonical default endpoint of this data root. */
+  canonicalSocketPath?: string;
+}
+
+/** Migration sentinel that atomically replaces the owned flat owner record.
+ * It parses as NO lease owner anywhere (no pid/token), so from the instant it
+ * lands, pre-fix AND fixed claimants alike fail closed on the flat address;
+ * only this module recognizes it and completes the interrupted migration. */
+const MIGRATION_SENTINEL = { rootAuthority: "migrating" } as const;
+
+function isMigrationSentinel(anchorPath: string): boolean {
+  try {
+    const value = JSON.parse(readFileSync(join(anchorPath, "owner.json"), "utf8")) as {
+      rootAuthority?: unknown;
+    };
+    return value?.rootAuthority === MIGRATION_SENTINEL.rootAuthority;
+  } catch {
+    return false;
+  }
+}
+
+/** Publish the marker over an already-neutralized generation, then retire the
+ * sentinel. Every intermediate state keeps the address occupied and opaque. */
+function completeBarrierInstallation(anchorPath: string): void {
+  writeRootAuthorityRecord(anchorPath, {
+    schemaVersion: ROOT_AUTHORITY_SCHEMA_VERSION,
+    epoch: ROOT_AUTHORITY_EPOCH,
+    state: "vacant",
+  });
+  rmSync(join(anchorPath, "owner.json"), { force: true });
+}
+
+/**
+ * Stage-1 startup admission: validate/install the permanent barrier, apply
+ * the epoch + floor refusals, and claim single-writer authority for this
+ * root. On a barrier-less root the flat legacy address is claimed through
+ * the shared lease machinery first (live owners refuse, proven-stale owners
+ * are quarantined), then the owned generation becomes the barrier in place:
+ * owner record atomically swapped for the migration sentinel, marker
+ * published, sentinel retired, claim reacquired in the nested slot.
+ */
+export function acquireRootAuthority(input: AcquireRootAuthorityInput): RootAuthorityGrant {
+  const canonical = input.canonicalSocketPath ?? canonicalDefaultSocketPath();
+  const anchorPath = writerLeaseAnchorPath(canonical);
+  const acquireClaim = (socketPath: string): DaemonWriterLease =>
+    acquireDaemonWriterLease(socketPath, { identity: input.identity }, input.deps ?? {});
+
+  const before = readRootAuthority(anchorPath);
+  if (before.status === "invalid") {
+    throw rootAuthorityRefusal(
+      "root_authority_unreadable",
+      `root authority barrier at ${before.markerPath} is unusable (${before.reason}); refusing to serve this data root`,
+    );
+  }
+  let record: RootAuthorityRecord | null = null;
+  if (before.status === "valid") {
+    assertRootAuthorityAdmits(before.record, input.version);
+    record = before.record;
+  } else if (isMigrationSentinel(anchorPath)) {
+    // A previous fixed candidate crashed between neutralizing the owner and
+    // publishing the marker. The address stayed opaque throughout; finish the
+    // interrupted installation deterministically.
+    completeBarrierInstallation(anchorPath);
+  }
+
+  // Claim the canonical root address. With a barrier installed the lease
+  // machinery resolves the nested active slot; without one it wins (or
+  // refuses with the shared typed errors) the flat legacy address.
+  let rootClaim = acquireClaim(canonical);
+  if (rootClaim.path === anchorPath) {
+    // First migration (D1/D3): we own the FLAT generation with a live owner
+    // record. Convert it in place — the directory never disappears and its
+    // owner record is either this live pid or the unparseable sentinel, so a
+    // pre-fix claimant fails closed at every instant.
+    try {
+      const temp = join(anchorPath, `.owner.json.${process.pid}-${randomUUID()}`);
+      writeFileSync(temp, `${JSON.stringify(MIGRATION_SENTINEL)}\n`, { mode: 0o600, flag: "wx" });
+      renameSync(temp, join(anchorPath, "owner.json"));
+      completeBarrierInstallation(anchorPath);
+    } catch (error) {
+      throw rootAuthorityRefusal(
+        "root_authority_unreadable",
+        `root authority barrier could not be installed at ${anchorPath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    rootClaim = acquireClaim(canonical);
+  }
+  if (record === null) {
+    const installed = readRootAuthority(anchorPath);
+    if (installed.status !== "valid") {
+      rootClaim.release();
+      throw rootAuthorityRefusal(
+        "root_authority_unreadable",
+        `root authority barrier at ${anchorPath} did not settle after installation`,
+      );
+    }
+    try {
+      assertRootAuthorityAdmits(installed.record, input.version);
+    } catch (error) {
+      rootClaim.release();
+      throw error;
+    }
+    record = installed.record;
+  }
+
+  // D4: a custom socket spelling still serves under the canonical root
+  // authority; its own socket-adjacent lease is claimed in addition.
+  const socketLease = input.socketPath === canonical ? null : acquireClaim(input.socketPath);
+  const lease = socketLease ?? rootClaim;
+  let released = false;
+  return {
+    lease,
+    record,
+    anchorPath,
+    advanceFloor: () => {
+      const current = readRootAuthority(anchorPath);
+      const floor =
+        current.status === "valid" &&
+        current.record.floor !== undefined &&
+        (!isRuntimeSemver(input.version) ||
+          compareRuntimeSemver(current.record.floor, input.version) >= 0)
+          ? current.record.floor
+          : isRuntimeSemver(input.version)
+            ? input.version
+            : undefined;
+      const next: RootAuthorityRecord = {
+        schemaVersion: ROOT_AUTHORITY_SCHEMA_VERSION,
+        epoch: ROOT_AUTHORITY_EPOCH,
+        state: "served",
+        ...(floor !== undefined ? { floor } : {}),
+      };
+      writeRootAuthorityRecord(anchorPath, next);
+      return next;
+    },
+    release: () => {
+      if (released) return;
+      released = true;
+      socketLease?.release();
+      rootClaim.release();
+    },
+  };
+}

--- a/packages/daemon/src/root-authority.ts
+++ b/packages/daemon/src/root-authority.ts
@@ -68,7 +68,9 @@ export interface RootAuthorityRecord {
 export type RootAuthorityRefusalCode =
   | "root_authority_unreadable"
   | "root_authority_epoch_unsupported"
-  | "root_authority_floor_regression";
+  | "root_authority_floor_regression"
+  | "root_authority_candidate_invalid"
+  | "root_authority_grant_stale";
 
 function rootAuthorityRefusal(
   code: RootAuthorityRefusalCode,
@@ -113,7 +115,10 @@ function parseRootAuthorityRecord(raw: string): RootAuthorityRecord | string {
   };
 }
 
-/** Fail-closed barrier read: only a physically missing marker is `absent`. */
+/** Fail-closed barrier read: only a physically missing marker is `absent`.
+ * C9c: the marker is validated like the startup-diagnostics target — a
+ * symlink, a multi-linked file, a foreign uid, or group/other-accessible
+ * permissions cannot carry root authority. */
 export function readRootAuthority(anchorPath: string): RootAuthorityStatus {
   const markerPath = join(anchorPath, ROOT_AUTHORITY_MARKER_FILE);
   let raw: string;
@@ -121,6 +126,18 @@ export function readRootAuthority(anchorPath: string): RootAuthorityStatus {
     const stat = lstatSync(markerPath);
     if (stat.isSymbolicLink() || !stat.isFile()) {
       return { status: "invalid", markerPath, reason: "marker is not a regular file" };
+    }
+    if (stat.nlink !== 1) {
+      return { status: "invalid", markerPath, reason: "marker is not singly linked" };
+    }
+    if (process.platform !== "win32") {
+      const uid = process.getuid?.();
+      if (uid !== undefined && stat.uid !== uid) {
+        return { status: "invalid", markerPath, reason: "marker has a foreign uid" };
+      }
+      if ((stat.mode & 0o077) !== 0) {
+        return { status: "invalid", markerPath, reason: "marker permissions are not private" };
+      }
     }
     raw = readFileSync(markerPath, "utf8");
   } catch (error) {
@@ -327,8 +344,21 @@ function migrateStaleFlatGenerationInPlace(
  * published, sentinel retired, claim reacquired in the nested slot.
  */
 export function acquireRootAuthority(input: AcquireRootAuthorityInput): RootAuthorityGrant {
+  // C9b: a candidate that cannot be ORDERED against serving floors must not
+  // serve — even on a fresh floorless root, where it would otherwise be
+  // admitted and then leave the root floorless forever.
+  if (!isRuntimeSemver(input.version)) {
+    throw rootAuthorityRefusal(
+      "root_authority_candidate_invalid",
+      `candidate version '${input.version}' is not an x.y.z semantic version; refusing to serve this data root`,
+    );
+  }
   const canonical = input.canonicalSocketPath ?? canonicalDefaultSocketPath();
   const anchorPath = writerLeaseAnchorPath(canonical);
+  const effectiveDeps: DaemonWriterLeaseDependencies = {
+    identity: input.identity,
+    ...(input.deps ?? {}),
+  };
   const acquireClaim = (socketPath: string): DaemonWriterLease =>
     acquireDaemonWriterLease(socketPath, { identity: input.identity }, input.deps ?? {});
 
@@ -352,10 +382,7 @@ export function acquireRootAuthority(input: AcquireRootAuthorityInput): RootAuth
     // C4: a PROVEN-STALE flat generation migrates in place BEFORE any claim,
     // so the shared quarantine's rename-away/recreate absence window never
     // opens on the legacy-visible address.
-    migrateStaleFlatGenerationInPlace(anchorPath, canonical, {
-      identity: input.identity,
-      ...(input.deps ?? {}),
-    });
+    migrateStaleFlatGenerationInPlace(anchorPath, canonical, effectiveDeps);
   }
 
   // Claim the canonical root address. With a barrier installed the lease
@@ -410,21 +437,51 @@ export function acquireRootAuthority(input: AcquireRootAuthorityInput): RootAuth
     record,
     anchorPath,
     advanceFloor: () => {
+      // C9a generation fence: only the LIVE writer of the root address may
+      // promote the floor. A released grant, or one superseded by a newer
+      // generation, refuses instead of clobbering the successor's authority.
+      if (released) {
+        throw rootAuthorityRefusal(
+          "root_authority_grant_stale",
+          "root authority grant was released; refusing to advance the serving floor",
+        );
+      }
+      // C9a: missing/corrupt current state is a typed refusal, never a
+      // silent rewrite — the barrier record is authority evidence. Checked
+      // BEFORE the lease fence: a vanished marker also breaks the nested
+      // address resolution, and the honest cause is the marker itself.
       const current = readRootAuthority(anchorPath);
+      if (current.status !== "valid") {
+        throw rootAuthorityRefusal(
+          "root_authority_unreadable",
+          current.status === "absent"
+            ? `root authority marker at ${current.markerPath} disappeared; refusing to recreate it during floor advancement`
+            : `root authority marker at ${current.markerPath} is unusable (${current.reason}); refusing to overwrite it during floor advancement`,
+        );
+      }
+      const claim = inspectDaemonWriterLease(canonical, effectiveDeps);
+      if (
+        claim.status !== "owned" ||
+        claim.path !== rootClaim.path ||
+        claim.owner.pid !== rootClaim.owner.pid ||
+        claim.owner.token !== rootClaim.owner.token
+      ) {
+        throw rootAuthorityRefusal(
+          "root_authority_grant_stale",
+          `root authority grant is no longer the live writer of ${rootClaim.path}; refusing to advance the serving floor`,
+        );
+      }
+      // Monotonic floor: input.version is a proven semver (C9b admission).
       const floor =
-        current.status === "valid" &&
         current.record.floor !== undefined &&
-        (!isRuntimeSemver(input.version) ||
-          compareRuntimeSemver(current.record.floor, input.version) >= 0)
+        compareRuntimeSemver(current.record.floor, input.version) >= 0
           ? current.record.floor
-          : isRuntimeSemver(input.version)
-            ? input.version
-            : undefined;
+          : input.version;
       const next: RootAuthorityRecord = {
         schemaVersion: ROOT_AUTHORITY_SCHEMA_VERSION,
         epoch: ROOT_AUTHORITY_EPOCH,
         state: "served",
-        ...(floor !== undefined ? { floor } : {}),
+        floor,
       };
       writeRootAuthorityRecord(anchorPath, next);
       return next;

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -1,6 +1,4 @@
 import { type Server, type Socket, createServer } from "node:net";
-import { timingSafeEqual } from "node:crypto";
-import { chmodSync, lstatSync, unlinkSync } from "node:fs";
 import { RpcFollowers } from "./rpc-followers.js";
 import {
   assertNoInlineSecretValues,
@@ -22,6 +20,7 @@ import {
   publicAcceptedCommand,
 } from "./command-rpc.js";
 import { productCommandRecords, prunableCommandIds } from "./command-retention.js";
+import { clearStaleUnixSocketPath, listenOnDaemonEndpoint } from "./daemon-listen.js";
 import {
   admitDelegatedRequest,
   delegatedParentOf,
@@ -37,6 +36,12 @@ import {
   type JobRecord,
 } from "./job-record.js";
 import { settleJobError } from "./job-settlement.js";
+import {
+  daemonTokenMatches,
+  recoveryOnlyRefusal,
+  servingModeOf,
+  type DaemonServingModeSnapshot,
+} from "./serving-admission.js";
 import { socketAlive } from "./socket-probe.js";
 import { isWindowsPipePath } from "./token.js";
 import {
@@ -80,6 +85,8 @@ export interface DaemonOptions extends RuntimeReplacementAuthority {
   onTurnEnqueueFailed?: (turnId: string, problem: TurnEnqueueProblemValue) => void;
   onShutdownRequested?: () => Promise<void>;
   onRuntimeReplacementRequested?: () => Promise<void>;
+  /** Issue #165 D5 admission snapshot; absent embedders always serve normal. */
+  servingMode?: DaemonServingModeSnapshot;
   /** Test-only barriers around command authority acquisition. */
   startupBarrier?: (
     barrier: "before_registry_load" | "after_registry_load",
@@ -143,32 +150,16 @@ export class DaemonServer {
     }
     await this.opts.startupBarrier?.("before_registry_load");
     if (this.stopping) throw this.stoppingError("daemon startup was cancelled before listen");
-    commandStores(this.opts.commands);
+    // With product admission closed (issue #165 D5 stage 3) the command
+    // projections are not activated yet; the registry materializes lazily
+    // once normal admission opens.
+    if (servingModeOf(this.opts.servingMode) === "normal") commandStores(this.opts.commands);
     await this.opts.startupBarrier?.("after_registry_load");
     if (this.stopping) throw this.stoppingError("daemon startup was cancelled after registry load");
-    if (!pipeEndpoint && pathExists(this.opts.socketPath)) {
-      const stale = lstatSync(this.opts.socketPath);
-      if (!stale.isSocket() || (process.getuid && stale.uid !== process.getuid())) {
-        throw Object.assign(new Error(`refusing to replace non-owned Unix socket path`), {
-          code: "unsafe_daemon_socket_path",
-        });
-      }
-      unlinkSync(this.opts.socketPath);
-    }
+    if (!pipeEndpoint) clearStaleUnixSocketPath(this.opts.socketPath);
     if (this.stopping) throw this.stoppingError("daemon startup was cancelled before listen");
-    await new Promise<void>((resolve, reject) => {
-      this.server = createServer((sock) => this.onConnection(sock));
-      this.server.once("error", reject);
-      this.server.listen(this.opts.socketPath, () => {
-        if (pipeEndpoint) return resolve();
-        try {
-          chmodSync(this.opts.socketPath, 0o600);
-        } catch {
-          /* best-effort on exotic filesystems */
-        }
-        resolve();
-      });
-    });
+    this.server = createServer((sock) => this.onConnection(sock));
+    await listenOnDaemonEndpoint(this.server, this.opts.socketPath, pipeEndpoint);
   }
 
   stop(): Promise<void> {
@@ -258,7 +249,7 @@ export class DaemonServer {
       return;
     }
     const { id, method, params, token } = msg;
-    if (!tokenMatches(typeof token === "string" ? token : "", this.opts.token)) {
+    if (!daemonTokenMatches(typeof token === "string" ? token : "", this.opts.token)) {
       this.send(sock, { id, error: { message: "unauthorized" } });
       return;
     }
@@ -274,7 +265,13 @@ export class DaemonServer {
           ...(err && typeof err === "object" && "status" in err
             ? { status: Number((err as { status: unknown }).status) }
             : {}),
-          ...(replacementRefusal(err) ? { retryable: true } : {}),
+          ...(err &&
+          typeof err === "object" &&
+          typeof (err as { retryable?: unknown }).retryable === "boolean"
+            ? { retryable: (err as { retryable: boolean }).retryable }
+            : replacementRefusal(err)
+              ? { retryable: true }
+              : {}),
         },
       });
     }
@@ -292,17 +289,24 @@ export class DaemonServer {
       this.opts.runtimeLeaseOwner,
     );
     if (shutdown) return shutdown;
+    const servingMode = servingModeOf(this.opts.servingMode);
+    if (method === "claudexor.health") {
+      return {
+        ok: true,
+        uptime_ms: Date.now() - this.startedAt,
+        queue: this.queue.length,
+        running: this.active > 0,
+        active: this.active,
+        // Command projections are not activated while admission is closed.
+        jobs: servingMode === "normal" ? this.allRecords().length : 0,
+        stopping: this.stopping,
+        servingMode,
+      };
+    }
+    // Issue #165 D5: with product admission closed, every product RPC gets
+    // one typed refusal; health above and the shutdown RPCs stay reachable.
+    if (servingMode !== "normal") throw recoveryOnlyRefusal(method);
     switch (method) {
-      case "claudexor.health":
-        return {
-          ok: true,
-          uptime_ms: Date.now() - this.startedAt,
-          queue: this.queue.length,
-          running: this.active > 0,
-          active: this.active,
-          jobs: this.allRecords().length,
-          stopping: this.stopping,
-        };
       case "claudexor.enqueue": {
         if (this.stopping) {
           throw Object.assign(new Error("daemon is stopping; retry after reconnect"), {
@@ -608,12 +612,4 @@ export class DaemonServer {
       if (!this.stopping) this.drain();
     }
   }
-}
-
-/** Constant-time token comparison (parity with the HTTP control facade). */
-function tokenMatches(candidate: string, expected: string): boolean {
-  const a = Buffer.from(candidate);
-  const b = Buffer.from(expected);
-  if (a.length !== b.length) return false;
-  return timingSafeEqual(a, b);
 }

--- a/packages/daemon/src/serving-admission.ts
+++ b/packages/daemon/src/serving-admission.ts
@@ -1,0 +1,38 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Product admission of the serving daemon (issue #165 D5). One canonical
+ * coordinator snapshot drives the socket RPC gate, the control-API route
+ * gate, and the handshake's `servingMode` disclosure — transport/protocol
+ * success stays separate from product readiness. `recovery_only` keeps the
+ * recovery plane (health, handshake, recovery routes, operator stop) online
+ * while every normal product surface refuses with one typed error.
+ */
+export type DaemonServingMode = "normal" | "recovery_only";
+
+/** Snapshot reader wired into servers; absent means an always-normal embedder. */
+export type DaemonServingModeSnapshot = () => DaemonServingMode;
+
+export function servingModeOf(snapshot: DaemonServingModeSnapshot | undefined): DaemonServingMode {
+  return snapshot?.() ?? "normal";
+}
+
+/** The single typed refusal every closed product surface returns. */
+export function recoveryOnlyRefusal(
+  surface: string,
+): Error & { code: "daemon_recovery_only"; status: 503; retryable: true } {
+  return Object.assign(
+    new Error(
+      `daemon is serving recovery only; '${surface}' is closed until journal recovery completes`,
+    ),
+    { code: "daemon_recovery_only" as const, status: 503 as const, retryable: true as const },
+  );
+}
+
+/** Constant-time token comparison shared by the socket and HTTP planes. */
+export function daemonTokenMatches(candidate: string, expected: string): boolean {
+  const a = Buffer.from(candidate);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/packages/daemon/src/terminate.test.ts
+++ b/packages/daemon/src/terminate.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +10,7 @@ import {
 } from "./terminate.js";
 import {
   processIsAlive,
+  writerLeasePath,
   type DaemonLeaseOwner,
   type DaemonLeaseOwnerCapability,
   type DaemonWriterLeaseStatus,
@@ -174,6 +175,14 @@ function physicallyAbsentSocketPath(): string {
   return join(root, "daemon.sock");
 }
 
+function physicalLeaseFor(owner: DaemonLeaseOwner): string {
+  const socketPath = physicallyAbsentSocketPath();
+  const leasePath = writerLeasePath(socketPath);
+  mkdirSync(leasePath);
+  writeFileSync(join(leasePath, "owner.json"), `${JSON.stringify(owner)}\n`);
+  return socketPath;
+}
+
 describe("awaitDaemonTermination", () => {
   it("uses strict production inspection for physical absence", async () => {
     await expect(awaitDaemonTermination(physicallyAbsentSocketPath())).resolves.toMatchObject({
@@ -183,6 +192,111 @@ describe("awaitDaemonTermination", () => {
 
   it("preserves processIsAlive as the raw signal-zero compatibility helper", () => {
     expect(processIsAlive(process.pid)).toBe(true);
+  });
+
+  it("preserves the supplied legacy isAlive runtime seam without a fourth authority", async () => {
+    const socketPath = physicalLeaseFor({ pid: process.pid, token: "legacy-is-alive" });
+    let getterReads = 0;
+    let calls = 0;
+    const deps: DaemonTerminationDeps = {
+      get isAlive() {
+        getterReads += 1;
+        return () => {
+          calls += 1;
+          return false;
+        };
+      },
+    };
+
+    const result = await awaitDaemonTermination(socketPath, {}, deps);
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain(String(process.pid));
+    expect({ getterReads, calls }).toEqual({ getterReads: 1, calls: 1 });
+  });
+
+  it("preserves the supplied legacy identity runtime seam without a fourth authority", async () => {
+    const recordedIdentity: KnownProcessIdentity = {
+      ...IDENTITY,
+      pid: process.pid,
+      processGroupId: process.pid,
+    };
+    const socketPath = physicalLeaseFor({
+      pid: process.pid,
+      token: "legacy-identity",
+      identity: recordedIdentity,
+    });
+    let getterReads = 0;
+    let reads = 0;
+    const deps: DaemonTerminationDeps = {
+      get identity() {
+        getterReads += 1;
+        return {
+          read: (pid: number): ProcessIdentity => {
+            reads += 1;
+            return { status: "missing", pid, platform: process.platform };
+          },
+          self: () => recordedIdentity,
+        };
+      },
+    };
+
+    const result = await awaitDaemonTermination(socketPath, {}, deps);
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain(String(process.pid));
+    expect({ getterReads, reads }).toEqual({ getterReads: 1, reads: 1 });
+  });
+
+  it("keeps strict malformed-lease handling when a legacy process seam is supplied", async () => {
+    const socketPath = physicallyAbsentSocketPath();
+    const leasePath = writerLeasePath(socketPath);
+    mkdirSync(leasePath);
+    writeFileSync(join(leasePath, "owner.json"), "{not-json\n");
+    let calls = 0;
+
+    const result = await awaitDaemonTermination(
+      socketPath,
+      {},
+      {
+        isAlive: () => {
+          calls += 1;
+          return false;
+        },
+      },
+    );
+    expect(result).toMatchObject({ outcome: "still_alive" });
+    expect(result.detail).toContain("activity is unknown");
+    expect(calls).toBe(0);
+  });
+
+  it("does not inspect legacy policy getters when a fourth authority is explicit", async () => {
+    let identityGetterReads = 0;
+    let isAliveGetterReads = 0;
+    const deps: DaemonTerminationDeps = {
+      get identity() {
+        identityGetterReads += 1;
+        return {
+          read: () => {
+            throw new Error("explicit authority must own classification");
+          },
+          self: () => IDENTITY,
+        };
+      },
+      get isAlive() {
+        isAliveGetterReads += 1;
+        return () => {
+          throw new Error("explicit authority must own classification");
+        };
+      },
+    };
+    const fixture = sequenceAuthority([absent()]);
+
+    await expect(
+      awaitDaemonTermination(SOCKET_PATH, {}, deps, fixture.authority),
+    ).resolves.toMatchObject({ outcome: "exited" });
+    expect({ identityGetterReads, isAliveGetterReads }).toEqual({
+      identityGetterReads: 0,
+      isAliveGetterReads: 0,
+    });
   });
 
   it("fails closed when the initial lease authority is unknown", async () => {

--- a/packages/daemon/src/terminate.test.ts
+++ b/packages/daemon/src/terminate.test.ts
@@ -184,6 +184,10 @@ function physicalLeaseFor(owner: DaemonLeaseOwner): string {
 }
 
 describe("awaitDaemonTermination", () => {
+  it("preserves its public runtime arity", () => {
+    expect(awaitDaemonTermination.length).toBe(1);
+  });
+
   it("uses strict production inspection for physical absence", async () => {
     await expect(awaitDaemonTermination(physicallyAbsentSocketPath())).resolves.toMatchObject({
       outcome: "exited",
@@ -195,14 +199,35 @@ describe("awaitDaemonTermination", () => {
   });
 
   it("preserves the supplied legacy isAlive runtime seam without a fourth authority", async () => {
-    const socketPath = physicalLeaseFor({ pid: process.pid, token: "legacy-is-alive" });
-    let getterReads = 0;
-    let calls = 0;
+    const recordedIdentity: KnownProcessIdentity = {
+      ...IDENTITY,
+      pid: process.pid,
+      processGroupId: process.pid,
+    };
+    const socketPath = physicalLeaseFor({
+      pid: process.pid,
+      token: "legacy-is-alive",
+      identity: recordedIdentity,
+    });
+    let identityGetterReads = 0;
+    let identityReads = 0;
+    let isAliveGetterReads = 0;
+    let isAliveCalls = 0;
     const deps: DaemonTerminationDeps = {
+      get identity() {
+        identityGetterReads += 1;
+        return {
+          read: () => {
+            identityReads += 1;
+            return recordedIdentity;
+          },
+          self: () => recordedIdentity,
+        };
+      },
       get isAlive() {
-        getterReads += 1;
+        isAliveGetterReads += 1;
         return () => {
-          calls += 1;
+          isAliveCalls += 1;
           return false;
         };
       },
@@ -211,7 +236,12 @@ describe("awaitDaemonTermination", () => {
     const result = await awaitDaemonTermination(socketPath, {}, deps);
     expect(result).toMatchObject({ outcome: "exited" });
     expect(result.detail).toContain(String(process.pid));
-    expect({ getterReads, calls }).toEqual({ getterReads: 1, calls: 1 });
+    expect({ identityGetterReads, identityReads, isAliveGetterReads, isAliveCalls }).toEqual({
+      identityGetterReads: 1,
+      identityReads: 0,
+      isAliveGetterReads: 1,
+      isAliveCalls: 1,
+    });
   });
 
   it("preserves the supplied legacy identity runtime seam without a fourth authority", async () => {
@@ -299,6 +329,159 @@ describe("awaitDaemonTermination", () => {
     });
   });
 
+  it("reclassifies the pinned owner after time advances and before SIGKILL", async () => {
+    let recycled = false;
+    let nowCalls = 0;
+    const classified: DaemonLeaseOwner[] = [];
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const authority: DaemonTerminationLeaseAuthority = {
+      inspect: () => owned(OWNER, identityMatch()),
+      classify: (owner) => {
+        classified.push(owner);
+        return recycled ? stale("identity_mismatch", owner) : identityMatch(owner);
+      },
+    };
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 500,
+        killAfterMs: 0,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      {
+        kill: (pid, signal) => kills.push([pid, signal]),
+        sleep: async () => undefined,
+        now: () => {
+          nowCalls += 1;
+          if (nowCalls === 2) recycled = true;
+          return nowCalls === 1 ? 0 : 100;
+        },
+      },
+      authority,
+    );
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain("recycled");
+    expect({ nowCalls, classified, kills }).toEqual({
+      nowCalls: 2,
+      classified: [OWNER, OWNER],
+      kills: [],
+    });
+  });
+
+  it("preserves legacy match-to-mismatch pre-signal call counts", async () => {
+    const socketPath = physicalLeaseFor(OWNER);
+    const recycledIdentity: KnownProcessIdentity = {
+      ...IDENTITY,
+      startToken: "linux:999888",
+    };
+    let identityGetterReads = 0;
+    let identityReads = 0;
+    let isAliveGetterReads = 0;
+    let isAliveCalls = 0;
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      socketPath,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 500,
+        killAfterMs: 0,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      {
+        get identity() {
+          identityGetterReads += 1;
+          return {
+            read: () => {
+              identityReads += 1;
+              return identityReads === 1 ? IDENTITY : recycledIdentity;
+            },
+            self: () => IDENTITY,
+          };
+        },
+        get isAlive() {
+          isAliveGetterReads += 1;
+          return () => {
+            isAliveCalls += 1;
+            return true;
+          };
+        },
+        kill: (pid, signal) => kills.push([pid, signal]),
+        sleep: async () => undefined,
+        now: () => 0,
+      },
+    );
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain("recycled");
+    expect({ identityGetterReads, identityReads, isAliveGetterReads, isAliveCalls, kills }).toEqual(
+      {
+        identityGetterReads: 1,
+        identityReads: 2,
+        isAliveGetterReads: 1,
+        isAliveCalls: 1,
+        kills: [],
+      },
+    );
+  });
+
+  it("preserves legacy unknown-to-match pre-signal authority", async () => {
+    const socketPath = physicalLeaseFor(OWNER);
+    let identityGetterReads = 0;
+    let identityReads = 0;
+    let isAliveGetterReads = 0;
+    let isAliveCalls = 0;
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      socketPath,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 500,
+        killAfterMs: 0,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      {
+        get identity() {
+          identityGetterReads += 1;
+          return {
+            read: (pid: number): ProcessIdentity => {
+              identityReads += 1;
+              return identityReads === 1
+                ? { status: "unknown", pid, platform: "linux", reason: "permission_denied" }
+                : IDENTITY;
+            },
+            self: () => IDENTITY,
+          };
+        },
+        get isAlive() {
+          isAliveGetterReads += 1;
+          return () => {
+            isAliveCalls += 1;
+            return true;
+          };
+        },
+        kill: (pid, signal) => {
+          kills.push([pid, signal]);
+          rmSync(writerLeasePath(socketPath), { recursive: true, force: true });
+        },
+        sleep: async () => undefined,
+        now: () => 0,
+      },
+    );
+    expect(result).toMatchObject({ outcome: "killed" });
+    expect({ identityGetterReads, identityReads, isAliveGetterReads, isAliveCalls, kills }).toEqual(
+      {
+        identityGetterReads: 1,
+        identityReads: 2,
+        isAliveGetterReads: 1,
+        isAliveCalls: 1,
+        kills: [[OWNER.pid, "SIGKILL"]],
+      },
+    );
+  });
+
   it("fails closed when the initial lease authority is unknown", async () => {
     const fixture = sequenceAuthority([unknownLease("owner_unreadable")]);
     const result = await awaitDaemonTermination(
@@ -357,17 +540,21 @@ describe("awaitDaemonTermination", () => {
 
   it("escalates only an explicit same-generation identity match", async () => {
     let signalled = false;
+    const classified: DaemonLeaseOwner[] = [];
     const kills: Array<[number, NodeJS.Signals]> = [];
     const authority: DaemonTerminationLeaseAuthority = {
       inspect: () => (signalled ? absent() : owned(OWNER, identityMatch())),
-      classify: () => identityMatch(),
+      classify: (owner) => {
+        classified.push(owner);
+        return identityMatch(owner);
+      },
     };
     const result = await awaitDaemonTermination(
       SOCKET_PATH,
       {
         expectedOwner: OWNER,
         deadlineMs: 500,
-        killAfterMs: 100,
+        killAfterMs: 0,
         pollMs: 100,
         allowSigkill: true,
       },
@@ -378,6 +565,7 @@ describe("awaitDaemonTermination", () => {
       authority,
     );
     expect(kills).toEqual([[OWNER.pid, "SIGKILL"]]);
+    expect(classified).toEqual([OWNER, OWNER]);
     expect(result).toMatchObject({ outcome: "killed" });
   });
 
@@ -574,10 +762,14 @@ describe("awaitDaemonTermination", () => {
 
   it("signals only the pinned old target when a successor already owns the lease", async () => {
     let oldKilled = false;
+    const classified: DaemonLeaseOwner[] = [];
     const kills: Array<[number, NodeJS.Signals]> = [];
     const authority: DaemonTerminationLeaseAuthority = {
       inspect: () => owned(SUCCESSOR, identityMatch(SUCCESSOR)),
-      classify: (owner) => (oldKilled ? stale("process_missing", owner) : identityMatch(owner)),
+      classify: (owner) => {
+        classified.push(owner);
+        return oldKilled ? stale("process_missing", owner) : identityMatch(owner);
+      },
     };
     const result = await awaitDaemonTermination(
       SOCKET_PATH,
@@ -596,6 +788,7 @@ describe("awaitDaemonTermination", () => {
     );
     expect(kills).toEqual([[OWNER.pid, "SIGKILL"]]);
     expect(kills.some(([pid]) => pid === SUCCESSOR.pid)).toBe(false);
+    expect(classified.every((owner) => owner === OWNER)).toBe(true);
     expect(result).toMatchObject({ outcome: "killed" });
   });
 

--- a/packages/daemon/src/terminate.test.ts
+++ b/packages/daemon/src/terminate.test.ts
@@ -370,6 +370,129 @@ describe("awaitDaemonTermination", () => {
     });
   });
 
+  it.each([
+    {
+      name: "capable successor",
+      freshLease: owned(SUCCESSOR, identityMatch(SUCCESSOR)),
+      outcome: "still_alive",
+      detail: "successor pid 5151",
+    },
+    {
+      name: "unknown-capability successor",
+      freshLease: owned(SUCCESSOR, unknownCapability(SUCCESSOR)),
+      outcome: "still_alive",
+      detail: "successor pid 5151",
+    },
+    {
+      name: "unknown lease",
+      freshLease: unknownLease("owner_unreadable"),
+      outcome: "still_alive",
+      detail: "writer-lease activity is unknown (owner_unreadable)",
+    },
+    {
+      name: "proven-stale successor",
+      freshLease: owned(SUCCESSOR, stale("linux_zombie", SUCCESSOR)),
+      outcome: "exited",
+      detail: "stale pid 5151",
+    },
+  ] as const)(
+    "rechecks a $name after the pre-signal target becomes stale",
+    async ({ freshLease, outcome, detail }) => {
+      let transitioned = false;
+      let nowCalls = 0;
+      let sleepCalls = 0;
+      let requireNoSuccessorReads = 0;
+      const kills: Array<[number, NodeJS.Signals]> = [];
+      const fixture = sequenceAuthority([owned(OWNER, identityMatch()), freshLease], (owner) =>
+        transitioned ? stale("identity_mismatch", owner) : identityMatch(owner),
+      );
+
+      const result = await awaitDaemonTermination(
+        SOCKET_PATH,
+        {
+          expectedOwner: OWNER,
+          deadlineMs: 500,
+          killAfterMs: 0,
+          pollMs: 100,
+          allowSigkill: true,
+          get requireNoSuccessor() {
+            requireNoSuccessorReads += 1;
+            return requireNoSuccessorReads === 1;
+          },
+        },
+        {
+          kill: (pid, signal) => kills.push([pid, signal]),
+          sleep: async () => {
+            sleepCalls += 1;
+          },
+          now: () => {
+            nowCalls += 1;
+            if (nowCalls === 2) transitioned = true;
+            return nowCalls === 1 ? 0 : 100;
+          },
+        },
+        fixture.authority,
+      );
+
+      expect(result).toMatchObject({ outcome });
+      expect(result.detail).toContain(detail);
+      expect({
+        nowCalls,
+        sleepCalls,
+        requireNoSuccessorReads,
+        inspectCalls: fixture.inspectCalls(),
+        kills,
+      }).toEqual({
+        nowCalls: 2,
+        sleepCalls: 0,
+        requireNoSuccessorReads: 1,
+        inspectCalls: 2,
+        kills: [],
+      });
+      expect(fixture.classified).toEqual([OWNER, OWNER]);
+    },
+  );
+
+  it("does not add a successor inspection when the caller permits takeover", async () => {
+    let transitioned = false;
+    let nowCalls = 0;
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const fixture = sequenceAuthority(
+      [owned(OWNER, identityMatch()), owned(SUCCESSOR, identityMatch(SUCCESSOR))],
+      (owner) => (transitioned ? stale("identity_mismatch", owner) : identityMatch(owner)),
+    );
+
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 500,
+        killAfterMs: 0,
+        pollMs: 100,
+        allowSigkill: true,
+        requireNoSuccessor: false,
+      },
+      {
+        kill: (pid, signal) => kills.push([pid, signal]),
+        sleep: async () => undefined,
+        now: () => {
+          nowCalls += 1;
+          if (nowCalls === 2) transitioned = true;
+          return nowCalls === 1 ? 0 : 100;
+        },
+      },
+      fixture.authority,
+    );
+
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect({ nowCalls, inspectCalls: fixture.inspectCalls(), kills }).toEqual({
+      nowCalls: 2,
+      inspectCalls: 1,
+      kills: [],
+    });
+    expect(fixture.classified).toEqual([OWNER, OWNER]);
+  });
+
   it("preserves legacy match-to-mismatch pre-signal call counts", async () => {
     const socketPath = physicalLeaseFor(OWNER);
     const recycledIdentity: KnownProcessIdentity = {
@@ -389,6 +512,7 @@ describe("awaitDaemonTermination", () => {
         killAfterMs: 0,
         pollMs: 100,
         allowSigkill: true,
+        requireNoSuccessor: true,
       },
       {
         get identity() {

--- a/packages/daemon/src/terminate.test.ts
+++ b/packages/daemon/src/terminate.test.ts
@@ -1,14 +1,26 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { KnownProcessIdentity, ProcessIdentity } from "@claudexor/core";
-import { awaitDaemonTermination } from "./terminate.js";
+import {
+  awaitDaemonTermination,
+  type DaemonTerminationDeps,
+  type DaemonTerminationLeaseAuthority,
+} from "./terminate.js";
+import type {
+  DaemonLeaseOwner,
+  DaemonLeaseOwnerCapability,
+  DaemonWriterLeaseStatus,
+} from "./writer-lease.js";
 
 const roots: string[] = [];
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
+
+const SOCKET_PATH = "/tmp/claudexor-termination-test.sock";
+const LEASE_PATH = `${SOCKET_PATH}.writer`;
 
 const IDENTITY: KnownProcessIdentity = {
   status: "known",
@@ -19,201 +31,446 @@ const IDENTITY: KnownProcessIdentity = {
   processGroupId: 4242,
 };
 
-function leaseFor(owner: Record<string, unknown> | null): string {
-  const root = mkdtempSync(join(tmpdir(), "claudexor-terminate-"));
-  roots.push(root);
-  const socketPath = join(root, "daemon.sock");
-  if (owner) {
-    mkdirSync(`${socketPath}.writer`);
-    writeFileSync(`${socketPath}.writer/owner.json`, `${JSON.stringify(owner)}\n`);
+const OWNER: DaemonLeaseOwner = { pid: 4242, token: "old", identity: IDENTITY };
+const LEGACY_OWNER: DaemonLeaseOwner = { pid: 4242, token: "legacy" };
+const SUCCESSOR_IDENTITY: KnownProcessIdentity = {
+  ...IDENTITY,
+  pid: 5151,
+  startToken: "linux:555555",
+  processGroupId: 5151,
+};
+const SUCCESSOR: DaemonLeaseOwner = {
+  pid: 5151,
+  token: "new",
+  identity: SUCCESSOR_IDENTITY,
+};
+
+const absent = (): DaemonWriterLeaseStatus => ({ status: "absent", path: LEASE_PATH });
+const unknownLease = (
+  reason: "owner_malformed" | "owner_unreadable" = "owner_malformed",
+): DaemonWriterLeaseStatus => ({ status: "unknown", path: LEASE_PATH, reason });
+
+function identityMatch(owner: DaemonLeaseOwner = OWNER): DaemonLeaseOwnerCapability {
+  return {
+    status: "capable",
+    reason: "identity_match",
+    observation: {
+      identity: owner.identity ?? IDENTITY,
+      linuxState: "S",
+    },
+  };
+}
+
+function legacyCapable(owner: DaemonLeaseOwner = LEGACY_OWNER): DaemonLeaseOwnerCapability {
+  return {
+    status: "capable",
+    reason: "legacy_process_present",
+    observation: {
+      identity: { ...IDENTITY, pid: owner.pid },
+      linuxState: "S",
+    },
+  };
+}
+
+function stale(
+  reason: "process_missing" | "identity_mismatch" | "linux_zombie",
+  owner: DaemonLeaseOwner = OWNER,
+): DaemonLeaseOwnerCapability {
+  let identity: ProcessIdentity;
+  let linuxState: "Z" | null = null;
+  if (reason === "process_missing") {
+    identity = { status: "missing", pid: owner.pid, platform: "linux" };
+  } else if (reason === "identity_mismatch") {
+    identity = {
+      ...(owner.identity ?? IDENTITY),
+      pid: owner.pid,
+      startToken: "linux:recycled",
+    };
+  } else {
+    identity = owner.identity ?? { ...IDENTITY, pid: owner.pid };
+    linuxState = "Z";
   }
-  return socketPath;
+  return { status: "proven_stale", reason, observation: { identity, linuxState } };
+}
+
+function unknownCapability(owner: DaemonLeaseOwner = OWNER): DaemonLeaseOwnerCapability {
+  return {
+    status: "unknown",
+    reason: "identity_unavailable",
+    observation: {
+      identity: {
+        status: "unknown",
+        pid: owner.pid,
+        platform: "linux",
+        reason: "permission_denied",
+      },
+      linuxState: null,
+    },
+  };
+}
+
+function owned(
+  owner: DaemonLeaseOwner,
+  capability: DaemonLeaseOwnerCapability,
+): DaemonWriterLeaseStatus {
+  return { status: "owned", path: LEASE_PATH, owner, capability };
+}
+
+function sequenceAuthority(
+  inspections: DaemonWriterLeaseStatus[],
+  classify: (owner: DaemonLeaseOwner, call: number) => DaemonLeaseOwnerCapability = (owner) =>
+    identityMatch(owner),
+): {
+  authority: DaemonTerminationLeaseAuthority;
+  classified: DaemonLeaseOwner[];
+  inspectCalls: () => number;
+} {
+  let inspection = 0;
+  const classified: DaemonLeaseOwner[] = [];
+  return {
+    authority: {
+      inspect: () => inspections[Math.min(inspection++, inspections.length - 1)]!,
+      classify: (owner) => {
+        classified.push(owner);
+        return classify(owner, classified.length - 1);
+      },
+    },
+    classified,
+    inspectCalls: () => inspection,
+  };
 }
 
 /** Deterministic clock: every sleep advances the injected time by pollMs. */
-function deps(overrides: {
-  isAlive?: (pid: number) => boolean;
-  read?: (pid: number) => ProcessIdentity;
-  kill?: (pid: number, signal: NodeJS.Signals) => void;
-}) {
+function deterministicDeps(
+  kill: (pid: number, signal: NodeJS.Signals) => void = () => {
+    throw new Error("kill must not be called");
+  },
+): DaemonTerminationDeps {
   let clock = 0;
   return {
-    isAlive: overrides.isAlive ?? (() => true),
+    // These legacy fields remain source-compatible, but the strict lease
+    // authority is the sole owner of process capability policy.
     identity: {
-      read: overrides.read ?? ((): ProcessIdentity => IDENTITY),
-      self: (): ProcessIdentity => IDENTITY,
+      read: () => {
+        throw new Error("legacy identity dependency must not classify termination");
+      },
+      self: () => IDENTITY,
     },
-    kill:
-      overrides.kill ??
-      (() => {
-        throw new Error("kill must not be called");
-      }),
-    sleep: async (ms: number) => {
+    isAlive: () => {
+      throw new Error("legacy isAlive dependency must not classify termination");
+    },
+    kill,
+    sleep: async (ms) => {
       clock += ms;
     },
     now: () => clock,
   };
 }
 
+function physicallyAbsentSocketPath(): string {
+  const root = mkdtempSync(join(tmpdir(), "claudexor-terminate-"));
+  roots.push(root);
+  return join(root, "daemon.sock");
+}
+
 describe("awaitDaemonTermination", () => {
-  it("confirms death when the lease was released", async () => {
-    const socketPath = leaseFor(null);
-    const result = await awaitDaemonTermination(socketPath, {}, deps({}));
-    expect(result).toMatchObject({ outcome: "exited" });
+  it("uses strict production inspection for physical absence", async () => {
+    await expect(awaitDaemonTermination(physicallyAbsentSocketPath())).resolves.toMatchObject({
+      outcome: "exited",
+    });
   });
 
-  it("confirms death when the recorded pid is gone (stale lease)", async () => {
-    const socketPath = leaseFor({ pid: 4242, token: "t", identity: IDENTITY });
-    const result = await awaitDaemonTermination(socketPath, {}, deps({ isAlive: () => false }));
-    expect(result).toMatchObject({ outcome: "exited" });
-    expect(result.detail).toContain("4242");
+  it("fails closed when the initial lease authority is unknown", async () => {
+    const fixture = sequenceAuthority([unknownLease("owner_unreadable")]);
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {},
+      deterministicDeps(),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "still_alive" });
+    expect(result.detail).toContain("activity is unknown");
+    expect(fixture.inspectCalls()).toBe(1);
+    expect(fixture.classified).toEqual([]);
   });
 
-  it("treats a RECYCLED pid as dead and never signals it (sol #5)", async () => {
-    const socketPath = leaseFor({ pid: 4242, token: "t", identity: IDENTITY });
-    const recycled: ProcessIdentity = { ...IDENTITY, startToken: "linux:999888" };
-    const result = await awaitDaemonTermination(socketPath, {}, deps({ read: () => recycled }));
+  it("treats a matching Linux zombie as exited without signalling it", async () => {
+    const fixture = sequenceAuthority([owned(OWNER, stale("linux_zombie"))]);
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      { allowSigkill: true },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
+    );
     expect(result).toMatchObject({ outcome: "exited" });
-    expect(result.detail).toContain("recycled");
+    expect(result.detail).toContain("Linux zombie");
+    expect(kills).toEqual([]);
   });
 
-  it("never waits on — or kills — a REPLACEMENT daemon that took the lease", async () => {
-    // The pinned daemon exits and the app auto-starts a new one, which takes
-    // the lease inside the confirmation window. Re-reading the lease each poll
-    // would follow the newcomer and SIGKILL it at the escalation deadline.
-    const root = mkdtempSync(join(tmpdir(), "claudexor-terminate-"));
-    roots.push(root);
-    const socketPath = join(root, "daemon.sock");
-    const ownerPath = `${socketPath}.writer/owner.json`;
-    mkdirSync(`${socketPath}.writer`);
-    const write = (owner: Record<string, unknown>) =>
-      writeFileSync(ownerPath, `${JSON.stringify(owner)}\n`);
-    write({ pid: 4242, token: "old", identity: IDENTITY });
+  it("waits through a transient unknown lease and accepts later physical absence", async () => {
+    const fixture = sequenceAuthority([unknownLease(), absent()], () => unknownCapability());
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      { expectedOwner: OWNER, deadlineMs: 500, killAfterMs: 0, pollMs: 100, allowSigkill: true },
+      deterministicDeps(),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain("released its lease");
+    expect(fixture.inspectCalls()).toBe(2);
+  });
 
-    const replacement: KnownProcessIdentity = {
-      ...IDENTITY,
-      pid: 5151,
-      startToken: "linux:555555",
-      processGroupId: 5151,
+  it.each([
+    ["process_missing", "is gone"],
+    ["identity_mismatch", "recycled"],
+  ] as const)("treats a %s pinned owner as exited", async (reason, detail) => {
+    const fixture = sequenceAuthority([owned(OWNER, stale(reason))]);
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      { expectedOwner: OWNER, allowSigkill: true },
+      deterministicDeps(),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain(detail);
+  });
+
+  it("escalates only an explicit same-generation identity match", async () => {
+    let signalled = false;
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const authority: DaemonTerminationLeaseAuthority = {
+      inspect: () => (signalled ? absent() : owned(OWNER, identityMatch())),
+      classify: () => identityMatch(),
     };
-    // Release-wave hardening: a takeover proves OWNERSHIP moved, not that the
-    // old daemon died. The loop keeps escalating against the OLD pid only —
-    // never the replacement — and reports exit only once the old pid is gone.
-    const kills: Array<[number, string]> = [];
-    let oldAlive = true;
     const result = await awaitDaemonTermination(
-      socketPath,
-      { deadlineMs: 2_000, killAfterMs: 500, pollMs: 100, allowSigkill: true },
-      deps({
-        isAlive: (pid) => {
-          write({ pid: 5151, token: "new", identity: replacement });
-          return pid === 4242 ? oldAlive : true;
-        },
-        read: (pid) => (pid === 5151 ? replacement : IDENTITY),
-        kill: (pid, signal) => {
-          if (pid === 5151) throw new Error("must not signal the replacement");
-          kills.push([pid, signal]);
-          if (signal === "SIGKILL") oldAlive = false;
-        },
-      }),
-    );
-    expect(kills.every(([pid]) => pid === 4242)).toBe(true);
-    expect(result).toMatchObject({ outcome: "killed" });
-    expect(result.detail).toContain("5151"); // discloses who holds it now
-  });
-
-  it("refuses a live successor for runtime replacement after the pinned owner exits", async () => {
-    const root = mkdtempSync(join(tmpdir(), "claudexor-terminate-successor-"));
-    roots.push(root);
-    const socketPath = join(root, "daemon.sock");
-    const ownerPath = `${socketPath}.writer/owner.json`;
-    mkdirSync(`${socketPath}.writer`);
-    const expected = { pid: 4242, token: "old", identity: IDENTITY };
-    writeFileSync(
-      ownerPath,
-      `${JSON.stringify({
-        pid: 5151,
-        token: "new",
-        identity: { ...IDENTITY, pid: 5151, startToken: "linux:555555" },
-      })}\n`,
-    );
-
-    const kills: Array<[number, string]> = [];
-    const result = await awaitDaemonTermination(
-      socketPath,
+      SOCKET_PATH,
       {
-        expectedOwner: expected,
-        requireNoSuccessor: true,
+        expectedOwner: OWNER,
+        deadlineMs: 500,
+        killAfterMs: 100,
+        pollMs: 100,
         allowSigkill: true,
       },
-      deps({
-        isAlive: (pid) => pid === 5151,
-        kill: (pid, signal) => kills.push([pid, signal]),
+      deterministicDeps((pid, signal) => {
+        kills.push([pid, signal]);
+        signalled = true;
       }),
+      authority,
     );
-
-    expect(result).toMatchObject({ outcome: "still_alive" });
-    expect(result.detail).toContain("successor pid 5151");
-    expect(kills).toEqual([]);
-  });
-
-  it("escalates an identity-VERIFIED SIGKILL past the graceful window", async () => {
-    const socketPath = leaseFor({ pid: 4242, token: "t", identity: IDENTITY });
-    const kills: Array<[number, string]> = [];
-    let alive = true;
-    const result = await awaitDaemonTermination(
-      socketPath,
-      { deadlineMs: 2_000, killAfterMs: 500, pollMs: 100, allowSigkill: true },
-      deps({
-        isAlive: () => alive,
-        kill: (pid, signal) => {
-          kills.push([pid, signal]);
-          alive = false;
-        },
-      }),
-    );
-    expect(kills).toEqual([[4242, "SIGKILL"]]);
+    expect(kills).toEqual([[OWNER.pid, "SIGKILL"]]);
     expect(result).toMatchObject({ outcome: "killed" });
   });
 
-  it("withholds SIGKILL when the caller has no signal authority", async () => {
-    const socketPath = leaseFor({ pid: 4242, token: "t", identity: IDENTITY });
-    const kills: Array<[number, string]> = [];
+  it("withholds SIGKILL without an explicit expected owner even when allowSigkill is true", async () => {
+    const fixture = sequenceAuthority([owned(OWNER, identityMatch())]);
+    const kills: Array<[number, NodeJS.Signals]> = [];
     const result = await awaitDaemonTermination(
-      socketPath,
-      { deadlineMs: 1_000, killAfterMs: 300, pollMs: 100, allowSigkill: false },
-      deps({ kill: (pid, signal) => kills.push([pid, signal]) }),
+      SOCKET_PATH,
+      { deadlineMs: 300, killAfterMs: 100, pollMs: 100, allowSigkill: true },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
     );
-    expect(kills).toEqual([]);
     expect(result).toMatchObject({ outcome: "still_alive" });
-    expect(result.detail).toContain("caller has no signal authority");
+    expect(result.detail).toContain("no explicit expected owner");
+    expect(kills).toEqual([]);
   });
 
-  it("fails closed to an honest still_alive when no birth identity was recorded", async () => {
-    const socketPath = leaseFor({ pid: 4242, token: "t" }); // legacy lease shape
+  it("withholds SIGKILL when the explicit caller has no signal authority", async () => {
+    const fixture = sequenceAuthority([owned(OWNER, identityMatch())]);
+    const kills: Array<[number, NodeJS.Signals]> = [];
     const result = await awaitDaemonTermination(
-      socketPath,
-      { deadlineMs: 1_000, killAfterMs: 300, pollMs: 100, allowSigkill: true },
-      deps({}),
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 300,
+        killAfterMs: 100,
+        pollMs: 100,
+        allowSigkill: false,
+      },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "still_alive" });
+    expect(result.detail).toContain("caller has no signal authority");
+    expect(kills).toEqual([]);
+  });
+
+  it("never signals a capable legacy owner without birth identity", async () => {
+    const fixture = sequenceAuthority([owned(LEGACY_OWNER, legacyCapable())]);
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: LEGACY_OWNER,
+        deadlineMs: 300,
+        killAfterMs: 100,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
     );
     expect(result).toMatchObject({ outcome: "still_alive" });
     expect(result.detail).toContain("no recorded birth identity");
+    expect(kills).toEqual([]);
   });
 
-  it("withholds the SIGKILL when the live identity is unverifiable", async () => {
-    const socketPath = leaseFor({ pid: 4242, token: "t", identity: IDENTITY });
-    const unknown: ProcessIdentity = {
-      status: "unknown",
-      pid: 4242,
-      platform: "linux",
-      reason: "permission_denied",
-    };
+  it("does not borrow signal authority from a same-generation record changed after pinning", async () => {
+    const rewrittenOwner: DaemonLeaseOwner = { ...LEGACY_OWNER, identity: IDENTITY };
+    const fixture = sequenceAuthority([owned(rewrittenOwner, identityMatch(rewrittenOwner))]);
+    const kills: Array<[number, NodeJS.Signals]> = [];
     const result = await awaitDaemonTermination(
-      socketPath,
-      { deadlineMs: 1_000, killAfterMs: 300, pollMs: 100, allowSigkill: true },
-      deps({ read: () => unknown }),
+      SOCKET_PATH,
+      {
+        expectedOwner: LEGACY_OWNER,
+        deadlineMs: 300,
+        killAfterMs: 100,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "still_alive" });
+    expect(result.detail).toContain("no recorded birth identity");
+    expect(kills).toEqual([]);
+  });
+
+  it("never signals an owner whose current identity is unknown", async () => {
+    const fixture = sequenceAuthority([owned(OWNER, unknownCapability())]);
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 300,
+        killAfterMs: 100,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
     );
     expect(result).toMatchObject({ outcome: "still_alive" });
     expect(result.detail).toContain("identity unverifiable");
+    expect(kills).toEqual([]);
+  });
+
+  it("refuses a capable or unknown successor after the pinned owner exits", async () => {
+    for (const capability of [identityMatch(SUCCESSOR), unknownCapability(SUCCESSOR)]) {
+      const fixture = sequenceAuthority([owned(SUCCESSOR, capability)], () =>
+        stale("process_missing", OWNER),
+      );
+      const result = await awaitDaemonTermination(
+        SOCKET_PATH,
+        { expectedOwner: OWNER, requireNoSuccessor: true, allowSigkill: true },
+        deterministicDeps(),
+        fixture.authority,
+      );
+      expect(result).toMatchObject({ outcome: "still_alive" });
+      expect(result.detail).toContain("successor pid 5151");
+    }
+  });
+
+  it("does not promote a stale successor record into a live successor", async () => {
+    const fixture = sequenceAuthority([owned(SUCCESSOR, stale("linux_zombie", SUCCESSOR))], () =>
+      stale("process_missing", OWNER),
+    );
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      { expectedOwner: OWNER, requireNoSuccessor: true, allowSigkill: true },
+      deterministicDeps(),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain("stale pid 5151");
+  });
+
+  it("fails closed on an unknown successor authority even after the old target exits", async () => {
+    const fixture = sequenceAuthority([unknownLease()], () => stale("process_missing", OWNER));
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      { expectedOwner: OWNER, requireNoSuccessor: true, allowSigkill: true },
+      deterministicDeps(),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "still_alive" });
+    expect(result.detail).toContain("writer-lease activity is unknown");
+  });
+
+  it("signals only the pinned old target when a successor already owns the lease", async () => {
+    let oldKilled = false;
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const authority: DaemonTerminationLeaseAuthority = {
+      inspect: () => owned(SUCCESSOR, identityMatch(SUCCESSOR)),
+      classify: (owner) => (oldKilled ? stale("process_missing", owner) : identityMatch(owner)),
+    };
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 500,
+        killAfterMs: 100,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      deterministicDeps((pid, signal) => {
+        kills.push([pid, signal]);
+        oldKilled = true;
+      }),
+      authority,
+    );
+    expect(kills).toEqual([[OWNER.pid, "SIGKILL"]]);
+    expect(kills.some(([pid]) => pid === SUCCESSOR.pid)).toBe(false);
+    expect(result).toMatchObject({ outcome: "killed" });
+  });
+
+  it("keeps legacy dependency objects source-compatible with inspect/classify collisions", async () => {
+    let inspectCollisionCalls = 0;
+    let classifyCollisionCalls = 0;
+
+    class InspectCollision {
+      private readonly inspect = () => {
+        inspectCollisionCalls += 1;
+      };
+
+      now(): number {
+        return 0;
+      }
+
+      constructor() {
+        void this.inspect;
+      }
+    }
+
+    class ClassifyCollision {
+      private readonly classify = () => {
+        classifyCollisionCalls += 1;
+      };
+
+      now(): number {
+        return 0;
+      }
+
+      constructor() {
+        void this.classify;
+      }
+    }
+
+    const inspectDeps: DaemonTerminationDeps = new InspectCollision();
+    const classifyDeps: DaemonTerminationDeps = new ClassifyCollision();
+    const fixture = sequenceAuthority([absent()]);
+
+    await expect(
+      awaitDaemonTermination(SOCKET_PATH, {}, inspectDeps, fixture.authority),
+    ).resolves.toMatchObject({ outcome: "exited" });
+    await expect(
+      awaitDaemonTermination(SOCKET_PATH, {}, classifyDeps, fixture.authority),
+    ).resolves.toMatchObject({ outcome: "exited" });
+    expect({ inspectCollisionCalls, classifyCollisionCalls }).toEqual({
+      inspectCollisionCalls: 0,
+      classifyCollisionCalls: 0,
+    });
   });
 });

--- a/packages/daemon/src/terminate.test.ts
+++ b/packages/daemon/src/terminate.test.ts
@@ -8,10 +8,11 @@ import {
   type DaemonTerminationDeps,
   type DaemonTerminationLeaseAuthority,
 } from "./terminate.js";
-import type {
-  DaemonLeaseOwner,
-  DaemonLeaseOwnerCapability,
-  DaemonWriterLeaseStatus,
+import {
+  processIsAlive,
+  type DaemonLeaseOwner,
+  type DaemonLeaseOwnerCapability,
+  type DaemonWriterLeaseStatus,
 } from "./writer-lease.js";
 
 const roots: string[] = [];
@@ -180,6 +181,10 @@ describe("awaitDaemonTermination", () => {
     });
   });
 
+  it("preserves processIsAlive as the raw signal-zero compatibility helper", () => {
+    expect(processIsAlive(process.pid)).toBe(true);
+  });
+
   it("fails closed when the initial lease authority is unknown", async () => {
     const fixture = sequenceAuthority([unknownLease("owner_unreadable")]);
     const result = await awaitDaemonTermination(
@@ -225,7 +230,7 @@ describe("awaitDaemonTermination", () => {
     ["process_missing", "is gone"],
     ["identity_mismatch", "recycled"],
   ] as const)("treats a %s pinned owner as exited", async (reason, detail) => {
-    const fixture = sequenceAuthority([owned(OWNER, stale(reason))]);
+    const fixture = sequenceAuthority([owned(OWNER, stale(reason))], () => stale(reason));
     const result = await awaitDaemonTermination(
       SOCKET_PATH,
       { expectedOwner: OWNER, allowSigkill: true },
@@ -297,7 +302,9 @@ describe("awaitDaemonTermination", () => {
   });
 
   it("never signals a capable legacy owner without birth identity", async () => {
-    const fixture = sequenceAuthority([owned(LEGACY_OWNER, legacyCapable())]);
+    const fixture = sequenceAuthority([owned(LEGACY_OWNER, legacyCapable())], () =>
+      legacyCapable(),
+    );
     const kills: Array<[number, NodeJS.Signals]> = [];
     const result = await awaitDaemonTermination(
       SOCKET_PATH,
@@ -318,7 +325,9 @@ describe("awaitDaemonTermination", () => {
 
   it("does not borrow signal authority from a same-generation record changed after pinning", async () => {
     const rewrittenOwner: DaemonLeaseOwner = { ...LEGACY_OWNER, identity: IDENTITY };
-    const fixture = sequenceAuthority([owned(rewrittenOwner, identityMatch(rewrittenOwner))]);
+    const fixture = sequenceAuthority([owned(rewrittenOwner, identityMatch(rewrittenOwner))], () =>
+      legacyCapable(),
+    );
     const kills: Array<[number, NodeJS.Signals]> = [];
     const result = await awaitDaemonTermination(
       SOCKET_PATH,
@@ -337,8 +346,38 @@ describe("awaitDaemonTermination", () => {
     expect(kills).toEqual([]);
   });
 
+  it("classifies the pinned birth identity instead of a same pid/token record's identity", async () => {
+    const recycledIdentity: KnownProcessIdentity = {
+      ...IDENTITY,
+      startToken: "linux:999888",
+    };
+    const rewrittenOwner: DaemonLeaseOwner = { ...OWNER, identity: recycledIdentity };
+    const fixture = sequenceAuthority([owned(rewrittenOwner, identityMatch(rewrittenOwner))], () =>
+      stale("identity_mismatch", OWNER),
+    );
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 300,
+        killAfterMs: 0,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "exited" });
+    expect(result.detail).toContain("recycled");
+    expect(fixture.classified).toEqual([OWNER]);
+    expect(kills).toEqual([]);
+  });
+
   it("never signals an owner whose current identity is unknown", async () => {
-    const fixture = sequenceAuthority([owned(OWNER, unknownCapability())]);
+    const fixture = sequenceAuthority([owned(OWNER, unknownCapability())], () =>
+      unknownCapability(),
+    );
     const kills: Array<[number, NodeJS.Signals]> = [];
     const result = await awaitDaemonTermination(
       SOCKET_PATH,
@@ -354,6 +393,26 @@ describe("awaitDaemonTermination", () => {
     );
     expect(result).toMatchObject({ outcome: "still_alive" });
     expect(result.detail).toContain("identity unverifiable");
+    expect(kills).toEqual([]);
+  });
+
+  it("withholds signal authority while the physical lease is unknown", async () => {
+    const fixture = sequenceAuthority([unknownLease()], () => identityMatch());
+    const kills: Array<[number, NodeJS.Signals]> = [];
+    const result = await awaitDaemonTermination(
+      SOCKET_PATH,
+      {
+        expectedOwner: OWNER,
+        deadlineMs: 300,
+        killAfterMs: 0,
+        pollMs: 100,
+        allowSigkill: true,
+      },
+      deterministicDeps((pid, signal) => kills.push([pid, signal])),
+      fixture.authority,
+    );
+    expect(result).toMatchObject({ outcome: "still_alive" });
+    expect(result.detail).toContain("writer-lease authority unknown");
     expect(kills).toEqual([]);
   });
 

--- a/packages/daemon/src/terminate.ts
+++ b/packages/daemon/src/terminate.ts
@@ -144,10 +144,11 @@ export async function awaitDaemonTermination(
 
     const successor =
       current.status === "owned" && !sameOwner(current.owner, owner) ? current : null;
-    const targetCapability =
-      current.status === "owned" && sameOwner(current.owner, owner)
-        ? current.capability
-        : leaseAuthority.classify(owner);
+    // The current lease record may have the same pid/token but different
+    // identity bytes. Classify the immutable pinned target itself every time;
+    // a current record's capability may describe only a successor/current
+    // generation and can never lend signal authority to the target.
+    const targetCapability = leaseAuthority.classify(owner);
 
     if (targetCapability.status === "proven_stale") {
       if (options.requireNoSuccessor) {
@@ -189,6 +190,8 @@ export async function awaitDaemonTermination(
         noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (caller has no signal authority)`;
       } else if (!explicitOwner) {
         noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (no explicit expected owner)`;
+      } else if (current.status === "unknown") {
+        noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (writer-lease authority unknown)`;
       } else if (
         owner.identity &&
         targetCapability.status === "capable" &&

--- a/packages/daemon/src/terminate.ts
+++ b/packages/daemon/src/terminate.ts
@@ -1,9 +1,11 @@
+import type { ProcessIdentityReader } from "@claudexor/core";
 import {
-  compareProcessIdentity,
-  defaultProcessIdentityService,
-  type ProcessIdentityReader,
-} from "@claudexor/core";
-import { daemonLeaseOwner, processIsAlive, type DaemonLeaseOwner } from "./writer-lease.js";
+  classifyDaemonLeaseOwner,
+  inspectDaemonWriterLease,
+  type DaemonLeaseOwner,
+  type DaemonLeaseOwnerCapability,
+  type DaemonWriterLeaseStatus,
+} from "./writer-lease.js";
 
 export type DaemonTerminationOutcome =
   /** The daemon released its lease or its pid is gone — confirmed dead. */
@@ -44,6 +46,38 @@ export interface DaemonTerminationDeps {
 }
 
 /**
+ * Strict writer-lease authority used by termination. This is deliberately a
+ * separate argument rather than new optional members on DaemonTerminationDeps:
+ * downstream dependency objects may already use these names for unrelated
+ * private or runtime state.
+ */
+export interface DaemonTerminationLeaseAuthority {
+  inspect(socketPath: string): DaemonWriterLeaseStatus;
+  classify(owner: DaemonLeaseOwner): DaemonLeaseOwnerCapability;
+}
+
+const DEFAULT_LEASE_AUTHORITY: DaemonTerminationLeaseAuthority = {
+  inspect: (socketPath) => inspectDaemonWriterLease(socketPath),
+  classify: (owner) => classifyDaemonLeaseOwner(owner),
+};
+
+function sameOwner(left: DaemonLeaseOwner, right: DaemonLeaseOwner): boolean {
+  return left.pid === right.pid && left.token === right.token;
+}
+
+function staleOwnerDetail(owner: DaemonLeaseOwner, capability: DaemonLeaseOwnerCapability): string {
+  if (capability.status !== "proven_stale") return `daemon pid ${owner.pid} exited`;
+  switch (capability.reason) {
+    case "process_missing":
+      return `daemon pid ${owner.pid} is gone`;
+    case "identity_mismatch":
+      return `pid ${owner.pid} was recycled by another process (never signalled)`;
+    case "linux_zombie":
+      return `daemon pid ${owner.pid} is a Linux zombie (never signalled)`;
+  }
+}
+
+/**
  * Await the CONFIRMED death of the daemon owning `socketPath`'s writer lease
  * (W3.5): "stop requested" is not "stopped" — a disposer that removes state
  * under a still-live daemon manufactures orphans.
@@ -55,83 +89,90 @@ export interface DaemonTerminationDeps {
  * window (the app auto-starts one) could be waited on — and SIGKILLed — in
  * place of the process we were asked to stop.
  *
- * Confirmed death = the pinned owner's lease is gone or taken over by a
- * different token/pid, or its pid is gone/recycled. Past the graceful window a
- * SIGKILL is sent ONLY when the pinned birth identity still matches the live
- * process (a recycled pid is never signalled, sol #5); without a verifiable
- * identity this fails closed to an honest `still_alive`.
+ * Confirmed death = the pinned owner released its lease, or the canonical
+ * classifier proves its pid missing, recycled, or a Linux zombie. A takeover
+ * alone does not prove that the old owner exited. Past the graceful window a
+ * SIGKILL is sent ONLY when an explicitly supplied pinned birth identity still
+ * matches the process in that same iteration; without that proof this fails
+ * closed to an honest `still_alive`.
  */
 export async function awaitDaemonTermination(
   socketPath: string,
   options: AwaitDaemonTerminationOptions = {},
   deps: DaemonTerminationDeps = {},
+  leaseAuthority: DaemonTerminationLeaseAuthority = DEFAULT_LEASE_AUTHORITY,
 ): Promise<DaemonTerminationOutcome> {
   const deadlineMs = options.deadlineMs ?? 20_000;
   const killAfterMs = options.killAfterMs ?? 17_000;
   const allowSigkill = options.allowSigkill ?? false;
   const pollMs = options.pollMs ?? 150;
-  const identity = deps.identity ?? defaultProcessIdentityService;
   const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
-  const isAlive = deps.isAlive ?? processIsAlive;
   const sleep = deps.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const now = deps.now ?? Date.now;
 
   const start = now();
   let killed = false;
   let noKillReason: string | null = null;
+  let current = leaseAuthority.inspect(socketPath);
   // The ONE owner this call is about. Everything below judges the world
   // against this snapshot — never against whoever holds the lease later.
-  const owner = options.expectedOwner ?? daemonLeaseOwner(socketPath);
-  if (!owner) return { outcome: "exited", detail: "no daemon owns the writer lease" };
+  let owner = options.expectedOwner;
+  if (!owner) {
+    if (current.status === "absent") {
+      return { outcome: "exited", detail: "no daemon owns the writer lease" };
+    }
+    if (current.status === "unknown") {
+      return {
+        outcome: "still_alive",
+        detail: `daemon activity is unknown (${current.reason})`,
+      };
+    }
+    if (current.capability.status === "proven_stale") {
+      return { outcome: "exited", detail: staleOwnerDetail(current.owner, current.capability) };
+    }
+    owner = current.owner;
+  }
+
+  const explicitOwner = options.expectedOwner !== undefined;
   for (;;) {
-    const current = daemonLeaseOwner(socketPath);
-    if (!current) {
+    if (current.status === "absent") {
       return {
         outcome: killed ? "killed" : "exited",
         detail: killed ? "daemon exited after SIGKILL escalation" : "daemon released its lease",
       };
     }
-    // A different token/pid holds the lease: the pinned daemon released it and
-    // a REPLACEMENT took over. The one we were asked to stop is gone — confirm
-    // that, and never touch the newcomer.
-    if (current.token !== owner.token || current.pid !== owner.pid) {
-      // Takeover proves OWNERSHIP changed, not that the old daemon died
-      // (release wave tier1 #2): confirm the pinned pid is actually gone
-      // before reporting exit; a still-alive old process keeps this loop
-      // (and its escalation) on the case.
-      if (!isAlive(owner.pid)) {
-        if (options.requireNoSuccessor) {
+
+    const successor =
+      current.status === "owned" && !sameOwner(current.owner, owner) ? current : null;
+    const targetCapability =
+      current.status === "owned" && sameOwner(current.owner, owner)
+        ? current.capability
+        : leaseAuthority.classify(owner);
+
+    if (targetCapability.status === "proven_stale") {
+      if (options.requireNoSuccessor) {
+        if (current.status === "unknown") {
           return {
             outcome: "still_alive",
-            detail: `daemon pid ${owner.pid} exited but successor pid ${current.pid} owns the writer lease`,
+            detail: `daemon pid ${owner.pid} exited but writer-lease activity is unknown (${current.reason})`,
           };
         }
-        return {
-          outcome: killed ? "killed" : "exited",
-          detail: `daemon pid ${owner.pid} released its lease (now held by pid ${current.pid})`,
-        };
+        if (successor && successor.capability.status !== "proven_stale") {
+          return {
+            outcome: "still_alive",
+            detail: `daemon pid ${owner.pid} exited but successor pid ${successor.owner.pid} owns the writer lease`,
+          };
+        }
       }
-    } else if (!isAlive(owner.pid)) {
+      const successorDetail = successor
+        ? ` (writer lease now records stale pid ${successor.owner.pid})`
+        : "";
       return {
         outcome: killed ? "killed" : "exited",
-        detail: `daemon pid ${owner.pid} is gone (stale lease left behind)`,
+        detail: `${staleOwnerDetail(owner, targetCapability)}${successorDetail}`,
       };
     }
-    if (owner.identity) {
-      const observed = identity.read(owner.pid);
-      if (observed.status === "missing") {
-        return { outcome: killed ? "killed" : "exited", detail: `daemon pid ${owner.pid} is gone` };
-      }
-      if (
-        observed.status === "known" &&
-        compareProcessIdentity(owner.identity, observed) === "different"
-      ) {
-        return {
-          outcome: "exited",
-          detail: `pid ${owner.pid} was recycled by another process (never signalled)`,
-        };
-      }
-    }
+
     const elapsed = now() - start;
     if (elapsed >= deadlineMs) {
       return {
@@ -146,16 +187,15 @@ export async function awaitDaemonTermination(
     if (!killed && elapsed >= killAfterMs) {
       if (!allowSigkill) {
         noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (caller has no signal authority)`;
-        await sleep(pollMs);
-        continue;
-      }
-      // Escalate ONLY under a verified identity match observed THIS iteration.
-      const observed = owner.identity ? identity.read(owner.pid) : null;
-      if (
+      } else if (!explicitOwner) {
+        noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (no explicit expected owner)`;
+      } else if (
         owner.identity &&
-        observed?.status === "known" &&
-        compareProcessIdentity(owner.identity, observed) === "same"
+        targetCapability.status === "capable" &&
+        targetCapability.reason === "identity_match"
       ) {
+        // Escalate only with caller admission and a fresh canonical identity
+        // match for the pinned target from this exact iteration.
         try {
           kill(owner.pid, "SIGKILL");
           killed = true;
@@ -169,5 +209,6 @@ export async function awaitDaemonTermination(
       }
     }
     await sleep(pollMs);
+    current = leaseAuthority.inspect(socketPath);
   }
 }

--- a/packages/daemon/src/terminate.ts
+++ b/packages/daemon/src/terminate.ts
@@ -333,11 +333,18 @@ export async function awaitDaemonTermination(
         // immediately before delivery can authorize a signal.
         const signalCapability = classifySignalTarget(owner);
         if (signalCapability.status === "proven_stale") {
+          // Runtime replacement must also refuse a successor that appeared
+          // during the pre-signal identity recheck. The loop's `current`
+          // snapshot predates `now()` and this second classification, so it
+          // cannot prove the no-successor condition at this return boundary.
+          // Other callers preserve their existing inspection/call counts.
+          const requireNoSuccessor = options.requireNoSuccessor;
+          const exitCurrent = requireNoSuccessor ? authority.inspect(socketPath) : current;
           return staleOwnerOutcome(
             owner,
             signalCapability,
-            current,
-            options.requireNoSuccessor,
+            exitCurrent,
+            requireNoSuccessor,
             killed,
           );
         }

--- a/packages/daemon/src/terminate.ts
+++ b/packages/daemon/src/terminate.ts
@@ -1,7 +1,14 @@
-import type { ProcessIdentityReader } from "@claudexor/core";
+import {
+  compareProcessIdentity,
+  defaultProcessIdentityService,
+  type ProcessIdentity,
+  type ProcessIdentityReader,
+  type ProcessObservation,
+} from "@claudexor/core";
 import {
   classifyDaemonLeaseOwner,
   inspectDaemonWriterLease,
+  processIsAlive,
   type DaemonLeaseOwner,
   type DaemonLeaseOwnerCapability,
   type DaemonWriterLeaseStatus,
@@ -61,6 +68,85 @@ const DEFAULT_LEASE_AUTHORITY: DaemonTerminationLeaseAuthority = {
   classify: (owner) => classifyDaemonLeaseOwner(owner),
 };
 
+function compatibilityObservation(identity: ProcessIdentity): ProcessObservation {
+  return { identity, linuxState: null };
+}
+
+function compatibilityUnknownObservation(owner: DaemonLeaseOwner): ProcessObservation {
+  return compatibilityObservation({
+    status: "unknown",
+    pid: owner.pid,
+    platform: process.platform,
+    reason: "unsupported_platform",
+  });
+}
+
+/**
+ * Patch-compatible dependency adapter for callers that supplied the old
+ * identity/isAlive test seams. It is unreachable from normal production and
+ * from the explicit strict fourth-argument authority. Filesystem inspection
+ * remains strict; only a valid owner's injected process capability follows the
+ * old isAlive-before-identity order. The shared termination loop still owns
+ * target pinning, successor refusal, and explicit-owner-only signal authority.
+ */
+function createCompatibilityLeaseAuthority(
+  identity: ProcessIdentityReader,
+  isAlive: (pid: number) => boolean,
+): DaemonTerminationLeaseAuthority {
+  const classify = (owner: DaemonLeaseOwner): DaemonLeaseOwnerCapability => {
+    if (!isAlive(owner.pid)) {
+      return {
+        status: "proven_stale",
+        reason: "process_missing",
+        observation: compatibilityObservation({
+          status: "missing",
+          pid: owner.pid,
+          platform: process.platform,
+        }),
+      };
+    }
+    if (!owner.identity) {
+      return {
+        status: "capable",
+        reason: "legacy_process_present",
+        observation: compatibilityUnknownObservation(owner),
+      };
+    }
+
+    const observed = identity.read(owner.pid);
+    const observation = compatibilityObservation(observed);
+    if (observed.status === "missing") {
+      return { status: "proven_stale", reason: "process_missing", observation };
+    }
+    if (observed.status === "known") {
+      return compareProcessIdentity(owner.identity, observed) === "same"
+        ? { status: "capable", reason: "identity_match", observation }
+        : { status: "proven_stale", reason: "identity_mismatch", observation };
+    }
+    return { status: "unknown", reason: "identity_unavailable", observation };
+  };
+
+  return {
+    inspect: (socketPath) => {
+      const current = inspectDaemonWriterLease(socketPath);
+      return current.status === "owned"
+        ? {
+            ...current,
+            // Inspection proves only that a valid record is present. The
+            // shared loop classifies the pinned target exactly once; this
+            // placeholder also preserves old successor refusal semantics.
+            capability: {
+              status: "capable",
+              reason: "legacy_process_present",
+              observation: compatibilityUnknownObservation(current.owner),
+            },
+          }
+        : current;
+    },
+    classify,
+  };
+}
+
 function sameOwner(left: DaemonLeaseOwner, right: DaemonLeaseOwner): boolean {
   return left.pid === right.pid && left.token === right.token;
 }
@@ -100,20 +186,40 @@ export async function awaitDaemonTermination(
   socketPath: string,
   options: AwaitDaemonTerminationOptions = {},
   deps: DaemonTerminationDeps = {},
-  leaseAuthority: DaemonTerminationLeaseAuthority = DEFAULT_LEASE_AUTHORITY,
+  leaseAuthority?: DaemonTerminationLeaseAuthority,
 ): Promise<DaemonTerminationOutcome> {
   const deadlineMs = options.deadlineMs ?? 20_000;
   const killAfterMs = options.killAfterMs ?? 17_000;
   const allowSigkill = options.allowSigkill ?? false;
   const pollMs = options.pollMs ?? 150;
-  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
-  const sleep = deps.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  const now = deps.now ?? Date.now;
+  // Legacy execution dependencies retain their one-read accessor behavior.
+  const configuredKill = deps.kill;
+  const configuredSleep = deps.sleep;
+  const configuredNow = deps.now;
+  const kill = configuredKill ?? ((pid, signal) => process.kill(pid, signal));
+  const sleep =
+    configuredSleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const now = configuredNow ?? Date.now;
+  let authority = leaseAuthority;
+  if (!authority) {
+    // Do not even inspect the old policy getters when an explicit fourth
+    // authority is present. Without one, capture each exactly once and enable
+    // compatibility only when the caller actually supplied that seam.
+    const configuredIdentity = deps.identity;
+    const configuredIsAlive = deps.isAlive;
+    authority =
+      configuredIdentity !== undefined || configuredIsAlive !== undefined
+        ? createCompatibilityLeaseAuthority(
+            configuredIdentity ?? defaultProcessIdentityService,
+            configuredIsAlive ?? processIsAlive,
+          )
+        : DEFAULT_LEASE_AUTHORITY;
+  }
 
   const start = now();
   let killed = false;
   let noKillReason: string | null = null;
-  let current = leaseAuthority.inspect(socketPath);
+  let current = authority.inspect(socketPath);
   // The ONE owner this call is about. Everything below judges the world
   // against this snapshot — never against whoever holds the lease later.
   let owner = options.expectedOwner;
@@ -148,7 +254,7 @@ export async function awaitDaemonTermination(
     // identity bytes. Classify the immutable pinned target itself every time;
     // a current record's capability may describe only a successor/current
     // generation and can never lend signal authority to the target.
-    const targetCapability = leaseAuthority.classify(owner);
+    const targetCapability = authority.classify(owner);
 
     if (targetCapability.status === "proven_stale") {
       if (options.requireNoSuccessor) {
@@ -212,6 +318,6 @@ export async function awaitDaemonTermination(
       }
     }
     await sleep(pollMs);
-    current = leaseAuthority.inspect(socketPath);
+    current = authority.inspect(socketPath);
   }
 }

--- a/packages/daemon/src/terminate.ts
+++ b/packages/daemon/src/terminate.ts
@@ -81,6 +81,31 @@ function compatibilityUnknownObservation(owner: DaemonLeaseOwner): ProcessObserv
   });
 }
 
+function classifyCompatibilityIdentity(
+  owner: DaemonLeaseOwner,
+  identity: ProcessIdentityReader,
+): DaemonLeaseOwnerCapability {
+  if (!owner.identity) {
+    return {
+      status: "capable",
+      reason: "legacy_process_present",
+      observation: compatibilityUnknownObservation(owner),
+    };
+  }
+
+  const observed = identity.read(owner.pid);
+  const observation = compatibilityObservation(observed);
+  if (observed.status === "missing") {
+    return { status: "proven_stale", reason: "process_missing", observation };
+  }
+  if (observed.status === "known") {
+    return compareProcessIdentity(owner.identity, observed) === "same"
+      ? { status: "capable", reason: "identity_match", observation }
+      : { status: "proven_stale", reason: "identity_mismatch", observation };
+  }
+  return { status: "unknown", reason: "identity_unavailable", observation };
+}
+
 /**
  * Patch-compatible dependency adapter for callers that supplied the old
  * identity/isAlive test seams. It is unreachable from normal production and
@@ -105,25 +130,7 @@ function createCompatibilityLeaseAuthority(
         }),
       };
     }
-    if (!owner.identity) {
-      return {
-        status: "capable",
-        reason: "legacy_process_present",
-        observation: compatibilityUnknownObservation(owner),
-      };
-    }
-
-    const observed = identity.read(owner.pid);
-    const observation = compatibilityObservation(observed);
-    if (observed.status === "missing") {
-      return { status: "proven_stale", reason: "process_missing", observation };
-    }
-    if (observed.status === "known") {
-      return compareProcessIdentity(owner.identity, observed) === "same"
-        ? { status: "capable", reason: "identity_match", observation }
-        : { status: "proven_stale", reason: "identity_mismatch", observation };
-    }
-    return { status: "unknown", reason: "identity_unavailable", observation };
+    return classifyCompatibilityIdentity(owner, identity);
   };
 
   return {
@@ -163,6 +170,37 @@ function staleOwnerDetail(owner: DaemonLeaseOwner, capability: DaemonLeaseOwnerC
   }
 }
 
+function staleOwnerOutcome(
+  owner: DaemonLeaseOwner,
+  capability: DaemonLeaseOwnerCapability,
+  current: DaemonWriterLeaseStatus,
+  requireNoSuccessor: boolean | undefined,
+  killed: boolean,
+): DaemonTerminationOutcome {
+  const successor = current.status === "owned" && !sameOwner(current.owner, owner) ? current : null;
+  if (requireNoSuccessor) {
+    if (current.status === "unknown") {
+      return {
+        outcome: "still_alive",
+        detail: `daemon pid ${owner.pid} exited but writer-lease activity is unknown (${current.reason})`,
+      };
+    }
+    if (successor && successor.capability.status !== "proven_stale") {
+      return {
+        outcome: "still_alive",
+        detail: `daemon pid ${owner.pid} exited but successor pid ${successor.owner.pid} owns the writer lease`,
+      };
+    }
+  }
+  const successorDetail = successor
+    ? ` (writer lease now records stale pid ${successor.owner.pid})`
+    : "";
+  return {
+    outcome: killed ? "killed" : "exited",
+    detail: `${staleOwnerDetail(owner, capability)}${successorDetail}`,
+  };
+}
+
 /**
  * Await the CONFIRMED death of the daemon owning `socketPath`'s writer lease
  * (W3.5): "stop requested" is not "stopped" — a disposer that removes state
@@ -200,20 +238,25 @@ export async function awaitDaemonTermination(
   const sleep =
     configuredSleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const now = configuredNow ?? Date.now;
-  let authority = leaseAuthority;
-  if (!authority) {
+  let authority: DaemonTerminationLeaseAuthority;
+  let classifySignalTarget: (owner: DaemonLeaseOwner) => DaemonLeaseOwnerCapability;
+  if (leaseAuthority) {
+    authority = leaseAuthority;
+    classifySignalTarget = (owner) => leaseAuthority.classify(owner);
+  } else {
     // Do not even inspect the old policy getters when an explicit fourth
     // authority is present. Without one, capture each exactly once and enable
     // compatibility only when the caller actually supplied that seam.
     const configuredIdentity = deps.identity;
     const configuredIsAlive = deps.isAlive;
-    authority =
-      configuredIdentity !== undefined || configuredIsAlive !== undefined
-        ? createCompatibilityLeaseAuthority(
-            configuredIdentity ?? defaultProcessIdentityService,
-            configuredIsAlive ?? processIsAlive,
-          )
-        : DEFAULT_LEASE_AUTHORITY;
+    if (configuredIdentity !== undefined || configuredIsAlive !== undefined) {
+      const identity = configuredIdentity ?? defaultProcessIdentityService;
+      authority = createCompatibilityLeaseAuthority(identity, configuredIsAlive ?? processIsAlive);
+      classifySignalTarget = (owner) => classifyCompatibilityIdentity(owner, identity);
+    } else {
+      authority = DEFAULT_LEASE_AUTHORITY;
+      classifySignalTarget = (owner) => DEFAULT_LEASE_AUTHORITY.classify(owner);
+    }
   }
 
   const start = now();
@@ -248,8 +291,6 @@ export async function awaitDaemonTermination(
       };
     }
 
-    const successor =
-      current.status === "owned" && !sameOwner(current.owner, owner) ? current : null;
     // The current lease record may have the same pid/token but different
     // identity bytes. Classify the immutable pinned target itself every time;
     // a current record's capability may describe only a successor/current
@@ -257,27 +298,13 @@ export async function awaitDaemonTermination(
     const targetCapability = authority.classify(owner);
 
     if (targetCapability.status === "proven_stale") {
-      if (options.requireNoSuccessor) {
-        if (current.status === "unknown") {
-          return {
-            outcome: "still_alive",
-            detail: `daemon pid ${owner.pid} exited but writer-lease activity is unknown (${current.reason})`,
-          };
-        }
-        if (successor && successor.capability.status !== "proven_stale") {
-          return {
-            outcome: "still_alive",
-            detail: `daemon pid ${owner.pid} exited but successor pid ${successor.owner.pid} owns the writer lease`,
-          };
-        }
-      }
-      const successorDetail = successor
-        ? ` (writer lease now records stale pid ${successor.owner.pid})`
-        : "";
-      return {
-        outcome: killed ? "killed" : "exited",
-        detail: `${staleOwnerDetail(owner, targetCapability)}${successorDetail}`,
-      };
+      return staleOwnerOutcome(
+        owner,
+        targetCapability,
+        current,
+        options.requireNoSuccessor,
+        killed,
+      );
     }
 
     const elapsed = now() - start;
@@ -298,23 +325,32 @@ export async function awaitDaemonTermination(
         noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (no explicit expected owner)`;
       } else if (current.status === "unknown") {
         noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (writer-lease authority unknown)`;
-      } else if (
-        owner.identity &&
-        targetCapability.status === "capable" &&
-        targetCapability.reason === "identity_match"
-      ) {
-        // Escalate only with caller admission and a fresh canonical identity
-        // match for the pinned target from this exact iteration.
-        try {
-          kill(owner.pid, "SIGKILL");
-          killed = true;
-        } catch {
-          /* delivery raced its exit; the next poll observes the truth */
-        }
+      } else if (!owner.identity) {
+        noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (no recorded birth identity)`;
       } else {
-        noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (${
-          owner.identity ? "identity unverifiable" : "no recorded birth identity"
-        })`;
+        // Time and injected dependencies may advance between the loop's exit
+        // classification and this escalation point. Only a second proof made
+        // immediately before delivery can authorize a signal.
+        const signalCapability = classifySignalTarget(owner);
+        if (signalCapability.status === "proven_stale") {
+          return staleOwnerOutcome(
+            owner,
+            signalCapability,
+            current,
+            options.requireNoSuccessor,
+            killed,
+          );
+        }
+        if (signalCapability.status === "capable" && signalCapability.reason === "identity_match") {
+          try {
+            kill(owner.pid, "SIGKILL");
+            killed = true;
+          } catch {
+            /* delivery raced its exit; the next poll observes the truth */
+          }
+        } else {
+          noKillReason = `daemon pid ${owner.pid} is still alive; SIGKILL withheld (identity unverifiable)`;
+        }
       }
     }
     await sleep(pollMs);

--- a/packages/daemon/src/token.ts
+++ b/packages/daemon/src/token.ts
@@ -61,9 +61,7 @@ export function defaultSocketPath(platform: NodeJS.Platform = process.platform):
  * follows the data root, so runtimes with custom socket spellings still share
  * one root authority, and the legacy barrier stays at the address pre-fix
  * runtimes contend on. */
-export function canonicalDefaultSocketPath(
-  platform: NodeJS.Platform = process.platform,
-): string {
+export function canonicalDefaultSocketPath(platform: NodeJS.Platform = process.platform): string {
   if (platform === "win32") {
     const digest = sha256(resolve(daemonDir()))
       .replace(/^sha256:/, "")

--- a/packages/daemon/src/token.ts
+++ b/packages/daemon/src/token.ts
@@ -53,6 +53,17 @@ export function ensureDaemonRuntimeRoot(): string {
 export function defaultSocketPath(platform: NodeJS.Platform = process.platform): string {
   const override = process.env.CLAUDEXOR_DAEMON_SOCK;
   if (override) return override;
+  return canonicalDefaultSocketPath(platform);
+}
+
+/** The data root's canonical default endpoint, ignoring any socket-spelling
+ * override. The issue #165 root-authority barrier anchors HERE (D4): authority
+ * follows the data root, so runtimes with custom socket spellings still share
+ * one root authority, and the legacy barrier stays at the address pre-fix
+ * runtimes contend on. */
+export function canonicalDefaultSocketPath(
+  platform: NodeJS.Platform = process.platform,
+): string {
   if (platform === "win32") {
     const digest = sha256(resolve(daemonDir()))
       .replace(/^sha256:/, "")

--- a/packages/daemon/src/writer-lease.test.ts
+++ b/packages/daemon/src/writer-lease.test.ts
@@ -104,6 +104,10 @@ function seedOwner(owner: unknown, path = leasePath): string {
   return raw;
 }
 
+function replaceOwner(owner: unknown, path = leasePath): void {
+  writeFileSync(join(path, "owner.json"), `${JSON.stringify(owner)}\n`, { mode: 0o600 });
+}
+
 function depsFor(
   observed: ProcessObservation | ((pid: number) => ProcessObservation),
   extra: Omit<DaemonWriterLeaseDependencies, "identity" | "observation"> = {},
@@ -200,6 +204,74 @@ describe("strict writer-lease inspection", () => {
         },
       }),
     ).toMatchObject({ status: "unknown", reason: "owner_unreadable" });
+  });
+
+  it("retries when classification observes a superseded owner generation", () => {
+    const original: DaemonLeaseOwner = {
+      pid: 44,
+      token: "original",
+      identity: known(44, "linux:1"),
+    };
+    const successor: DaemonLeaseOwner = {
+      pid: 55,
+      token: "successor",
+      identity: known(55, "linux:2"),
+    };
+    seedOwner(original);
+    let swapped = false;
+    const observed: number[] = [];
+
+    expect(
+      inspectDaemonWriterLease(
+        socketPath,
+        depsFor(
+          (pid) => {
+            observed.push(pid);
+            if (pid === original.pid && !swapped) {
+              swapped = true;
+              replaceOwner(successor);
+              return observation({ status: "missing", pid, platform: "linux" });
+            }
+            return observation(successor.identity!, "S");
+          },
+          { probeProcess: () => expect.fail("known observations must not probe or signal") },
+        ),
+      ),
+    ).toMatchObject({
+      status: "owned",
+      owner: successor,
+      capability: { status: "capable", reason: "identity_match" },
+    });
+    expect(observed).toEqual([original.pid, successor.pid]);
+    expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(successor);
+  });
+
+  it("fails closed when the owner generation changes on both inspection attempts", () => {
+    const owners: DaemonLeaseOwner[] = [
+      { pid: 44, token: "first", identity: known(44, "linux:1") },
+      { pid: 55, token: "second", identity: known(55, "linux:2") },
+      { pid: 66, token: "third", identity: known(66, "linux:3") },
+    ];
+    seedOwner(owners[0]);
+    let generation = 0;
+    const observed: number[] = [];
+
+    expect(
+      inspectDaemonWriterLease(
+        socketPath,
+        depsFor(
+          (pid) => {
+            observed.push(pid);
+            generation += 1;
+            replaceOwner(owners[generation]);
+            return observation({ status: "missing", pid, platform: "linux" });
+          },
+          { probeProcess: () => expect.fail("missing observations must not probe or signal") },
+        ),
+      ),
+    ).toEqual({ status: "unknown", path: leasePath, reason: "lease_unstable" });
+    expect(observed).toEqual([owners[0]!.pid, owners[1]!.pid]);
+    expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(owners[2]);
   });
 
   it("keeps the nullable compatibility projection deliberately lossy", () => {

--- a/packages/daemon/src/writer-lease.test.ts
+++ b/packages/daemon/src/writer-lease.test.ts
@@ -115,6 +115,21 @@ function depsFor(
   return { ...extra, ...observationDependencies(observed) };
 }
 
+function acquireWithDependencies(
+  path: string,
+  deps: DaemonWriterLeaseDependencies,
+): ReturnType<typeof acquireDaemonWriterLease> {
+  return acquireDaemonWriterLease(
+    path,
+    { identity: deps.identity },
+    {
+      observation: deps.observation,
+      probeProcess: deps.probeProcess,
+      filesystem: deps.filesystem,
+    },
+  );
+}
+
 describe("strict writer-lease inspection", () => {
   it("distinguishes physical absence, the owner-write boot window, and invalid paths", () => {
     expect(inspectDaemonWriterLease(socketPath)).toEqual({ status: "absent", path: leasePath });
@@ -282,6 +297,128 @@ describe("strict writer-lease inspection", () => {
     expect(daemonLeaseOwner(socketPath)).toBeNull();
     writeFileSync(join(leasePath, "owner.json"), '{"pid":7,"token":"legacy"}\n');
     expect(daemonLeaseOwner(socketPath)).toEqual({ pid: 7, token: "legacy" });
+
+    replaceOwner({ pid: 7, token: "" });
+    expect(daemonLeaseOwner(socketPath)).toEqual({ pid: 7, token: "" });
+
+    replaceOwner({ pid: 7, token: "null-identity", identity: null });
+    expect(daemonLeaseOwner(socketPath)).toEqual({ pid: 7, token: "null-identity" });
+
+    replaceOwner({ pid: 7, token: "invalid-identity", identity: { status: "known" } });
+    expect(daemonLeaseOwner(socketPath)).toEqual({ pid: 7, token: "invalid-identity" });
+
+    const mismatchedIdentity = known(8, "linux:8");
+    replaceOwner({ pid: 7, token: "mismatched-identity", identity: mismatchedIdentity });
+    expect(daemonLeaseOwner(socketPath)).toEqual({
+      pid: 7,
+      token: "mismatched-identity",
+      identity: mismatchedIdentity,
+    });
+
+    rmSync(join(leasePath, "owner.json"));
+    writeFileSync(join(root, "legacy-owner-target"), '{"pid":7,"token":"symlink"}\n');
+    symlinkSync(join(root, "legacy-owner-target"), join(leasePath, "owner.json"));
+    expect(daemonLeaseOwner(socketPath)).toEqual({ pid: 7, token: "symlink" });
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({
+      status: "unknown",
+      reason: "owner_malformed",
+    });
+  });
+});
+
+describe("legacy acquisition dependency compatibility", () => {
+  it("ignores unrelated members that collide with new dependency names", () => {
+    const stalePid = 999_999_999;
+    const identity: ProcessIdentityReader = {
+      read: (pid) => ({
+        status: "unknown",
+        pid,
+        platform: process.platform,
+        reason: "permission_denied",
+      }),
+      self: () => known(process.pid, "linux:999"),
+    };
+    let observationCalls = 0;
+    let probeCalls = 0;
+    let filesystemCalls = 0;
+
+    class ObservationCollision {
+      readonly identity = identity;
+      private readonly observation = () => {
+        observationCalls += 1;
+      };
+
+      constructor() {
+        void this.observation;
+      }
+    }
+
+    class ProbeCollision {
+      readonly identity = identity;
+      private readonly probeProcess = () => {
+        probeCalls += 1;
+      };
+
+      constructor() {
+        void this.probeProcess;
+      }
+    }
+
+    class FilesystemCollision {
+      readonly identity = identity;
+      private readonly filesystem = {
+        createLeaseDirectory: () => {
+          filesystemCalls += 1;
+          throw new Error("unrelated filesystem member was invoked");
+        },
+      };
+
+      constructor() {
+        void this.filesystem;
+      }
+    }
+
+    const observationSocket = join(root, "observation.sock");
+    const probeSocket = join(root, "probe.sock");
+    const filesystemSocket = join(root, "filesystem.sock");
+    seedOwner({ pid: stalePid, token: "observation" }, writerLeasePath(observationSocket));
+    seedOwner({ pid: stalePid, token: "probe" }, writerLeasePath(probeSocket));
+    seedOwner({ pid: stalePid, token: "filesystem" }, writerLeasePath(filesystemSocket));
+
+    const observationLease = acquireDaemonWriterLease(
+      observationSocket,
+      new ObservationCollision(),
+    );
+    const probeLease = acquireDaemonWriterLease(probeSocket, new ProbeCollision());
+    const filesystemLease = acquireDaemonWriterLease(filesystemSocket, new FilesystemCollision());
+
+    expect({ observationCalls, probeCalls, filesystemCalls }).toEqual({
+      observationCalls: 0,
+      probeCalls: 0,
+      filesystemCalls: 0,
+    });
+    observationLease.release();
+    probeLease.release();
+    filesystemLease.release();
+  });
+
+  it("reads the legacy identity dependency exactly once", () => {
+    const identity: ProcessIdentityReader = {
+      read: (pid) => ({ status: "missing", pid, platform: process.platform }),
+      self: () => known(process.pid, "linux:999"),
+    };
+    let reads = 0;
+    const deps = {
+      get identity(): ProcessIdentityReader {
+        reads += 1;
+        if (reads > 1) throw new Error("identity getter read twice");
+        return identity;
+      },
+    };
+
+    const lease = acquireDaemonWriterLease(join(root, "identity-getter.sock"), deps);
+    expect(reads).toBe(1);
+    lease.release();
   });
 });
 
@@ -461,7 +598,7 @@ describe("generation-bound writer-lease recovery", () => {
 
   it("recovers a matching zombie and preserves its exact nonempty tombstone", () => {
     const original = seedOwner(staleOwner);
-    const lease = acquireDaemonWriterLease(socketPath, recoveryDeps());
+    const lease = acquireWithDependencies(socketPath, recoveryDeps());
     const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
 
     expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toMatchObject({
@@ -486,7 +623,7 @@ describe("generation-bound writer-lease recovery", () => {
         rename: (from, to) => {
           if (!interleaved) {
             interleaved = true;
-            successor = acquireDaemonWriterLease(socketPath, recoveryDeps());
+            successor = acquireWithDependencies(socketPath, recoveryDeps());
             successorBytes = readFileSync(join(leasePath, "owner.json"), "utf8");
           }
           renameSync(from, to);
@@ -494,7 +631,7 @@ describe("generation-bound writer-lease recovery", () => {
       },
     };
 
-    expect(() => acquireDaemonWriterLease(socketPath, delayedDeps)).toThrowError(
+    expect(() => acquireWithDependencies(socketPath, delayedDeps)).toThrowError(
       expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
     );
     expect(successor).toBeDefined();
@@ -526,7 +663,7 @@ describe("generation-bound writer-lease recovery", () => {
       }),
     };
 
-    expect(() => acquireDaemonWriterLease(socketPath, deps)).toThrowError(
+    expect(() => acquireWithDependencies(socketPath, deps)).toThrowError(
       expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
     );
     expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(successor);
@@ -540,7 +677,7 @@ describe("generation-bound writer-lease recovery", () => {
     const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
     seedOwner(staleOwner, tombstone);
 
-    expect(() => acquireDaemonWriterLease(socketPath, recoveryDeps())).toThrow(
+    expect(() => acquireWithDependencies(socketPath, recoveryDeps())).toThrow(
       `could not replace stale daemon writer lease ${leasePath}`,
     );
     expect(readFileSync(join(leasePath, "owner.json"), "utf8")).toBe(original);
@@ -580,7 +717,7 @@ describe("generation-bound writer-lease recovery", () => {
       },
     };
 
-    expect(() => acquireDaemonWriterLease(socketPath, deps)).toThrowError(
+    expect(() => acquireWithDependencies(socketPath, deps)).toThrowError(
       expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
     );
     expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(successor);
@@ -599,14 +736,14 @@ describe("generation-bound writer-lease recovery", () => {
       },
     };
 
-    expect(() => acquireDaemonWriterLease(socketPath, epermDeps)).toThrow(
+    expect(() => acquireWithDependencies(socketPath, epermDeps)).toThrow(
       `could not replace stale daemon writer lease ${leasePath}`,
     );
 
     rmSync(tombstone, { recursive: true });
     const foreignOwner: DaemonLeaseOwner = { pid: 5555, token: "foreign" };
     seedOwner(foreignOwner, tombstone);
-    expect(() => acquireDaemonWriterLease(socketPath, epermDeps)).toThrowError(
+    expect(() => acquireWithDependencies(socketPath, epermDeps)).toThrowError(
       expect.objectContaining({ code: "EPERM" }),
     );
     expect(JSON.parse(readFileSync(join(tombstone, "owner.json"), "utf8"))).toEqual(foreignOwner);
@@ -616,7 +753,7 @@ describe("generation-bound writer-lease recovery", () => {
     const raw = seedOwner(staleOwner);
     const liveDeps = depsFor(observation(staleOwner.identity!, "S"));
     try {
-      acquireDaemonWriterLease(socketPath, liveDeps);
+      acquireWithDependencies(socketPath, liveDeps);
       throw new Error("expected busy lease");
     } catch (error) {
       expect(error).toMatchObject({ code: "daemon_writer_busy", status: 409 });
@@ -625,13 +762,13 @@ describe("generation-bound writer-lease recovery", () => {
 
     rmSync(leasePath, { recursive: true });
     mkdirSync(leasePath);
-    expect(() => acquireDaemonWriterLease(socketPath, recoveryDeps())).toThrowError(
+    expect(() => acquireWithDependencies(socketPath, recoveryDeps())).toThrowError(
       expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
     );
   });
 
   it("fences release to the exact main owner and never removes a successor", () => {
-    const lease = acquireDaemonWriterLease(
+    const lease = acquireWithDependencies(
       socketPath,
       depsFor(observation(known(process.pid, "linux:999"), "S")),
     );

--- a/packages/daemon/src/writer-lease.test.ts
+++ b/packages/daemon/src/writer-lease.test.ts
@@ -1,0 +1,457 @@
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  type KnownProcessIdentity,
+  type LinuxProcessState,
+  type ProcessIdentity,
+  type ProcessObservation,
+  type ProcessObservationSource,
+} from "@claudexor/core";
+import {
+  acquireDaemonWriterLease,
+  classifyDaemonLeaseOwner,
+  daemonLeaseOwner,
+  inspectDaemonWriterLease,
+  quarantineDaemonWriterLeaseGeneration,
+  writerLeasePath,
+  writerLeaseTombstonePath,
+  type DaemonLeaseOwner,
+  type DaemonWriterLeaseDependencies,
+} from "./writer-lease.js";
+
+function known(pid: number, start = `linux:${pid}`): KnownProcessIdentity {
+  return {
+    status: "known",
+    pid,
+    platform: "linux",
+    source: "procfs_stat",
+    startToken: start,
+    processGroupId: pid,
+  };
+}
+
+function observation(
+  identity: ProcessIdentity,
+  linuxState: LinuxProcessState | null = null,
+): ProcessObservation {
+  return { identity, linuxState };
+}
+
+function sourceFor(
+  observed: ProcessObservation | ((pid: number) => ProcessObservation),
+  selfIdentity: ProcessIdentity = known(process.pid, "linux:999"),
+): ProcessObservationSource {
+  const observe = typeof observed === "function" ? observed : () => observed;
+  return {
+    read: (pid) => observe(pid).identity,
+    observe,
+    self: () => selfIdentity,
+  };
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), { code });
+}
+
+let root: string;
+let socketPath: string;
+let leasePath: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "claudexor-writer-lease-"));
+  socketPath = join(root, "claudexord.sock");
+  leasePath = writerLeasePath(socketPath);
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function seedOwner(owner: unknown, path = leasePath): string {
+  mkdirSync(path, { mode: 0o700 });
+  const raw = `${JSON.stringify(owner)}\n`;
+  writeFileSync(join(path, "owner.json"), raw, { mode: 0o600 });
+  return raw;
+}
+
+function depsFor(
+  observed: ProcessObservation | ((pid: number) => ProcessObservation),
+  extra: Omit<DaemonWriterLeaseDependencies, "identity"> = {},
+): DaemonWriterLeaseDependencies {
+  return { ...extra, identity: sourceFor(observed) };
+}
+
+describe("strict writer-lease inspection", () => {
+  it("distinguishes physical absence, the owner-write boot window, and invalid paths", () => {
+    expect(inspectDaemonWriterLease(socketPath)).toEqual({ status: "absent", path: leasePath });
+
+    mkdirSync(leasePath);
+    expect(inspectDaemonWriterLease(socketPath)).toEqual({
+      status: "unknown",
+      path: leasePath,
+      reason: "owner_missing",
+    });
+
+    rmSync(leasePath, { recursive: true });
+    writeFileSync(leasePath, "not a directory");
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({
+      status: "unknown",
+      reason: "invalid_lease_path",
+    });
+
+    rmSync(leasePath);
+    mkdirSync(join(root, "target"));
+    symlinkSync(join(root, "target"), leasePath);
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({
+      status: "unknown",
+      reason: "invalid_lease_path",
+    });
+  });
+
+  it("accepts only strict current and legacy owner records", () => {
+    const current = known(process.pid, "linux:999");
+    seedOwner({ pid: process.pid, token: "legacy", future: true });
+    expect(inspectDaemonWriterLease(socketPath, depsFor(observation(current, "S")))).toMatchObject({
+      status: "owned",
+      owner: { pid: process.pid, token: "legacy" },
+      capability: { status: "capable", reason: "legacy_process_present" },
+    });
+
+    rmSync(leasePath, { recursive: true });
+    seedOwner({ pid: process.pid, token: "current", identity: current, future: true });
+    expect(inspectDaemonWriterLease(socketPath, depsFor(observation(current, "S")))).toMatchObject({
+      status: "owned",
+      owner: { identity: current },
+      capability: { status: "capable", reason: "identity_match" },
+    });
+
+    for (const invalid of [
+      { pid: 0, token: "x" },
+      { pid: process.pid, token: "" },
+      { pid: process.pid, token: "x", identity: null },
+      { pid: process.pid, token: "x", identity: known(process.pid + 1) },
+    ]) {
+      rmSync(leasePath, { recursive: true });
+      seedOwner(invalid);
+      expect(inspectDaemonWriterLease(socketPath)).toMatchObject({
+        status: "unknown",
+        reason: "owner_malformed",
+      });
+    }
+  });
+
+  it("rejects a symlinked owner and preserves filesystem errors as unknown", () => {
+    mkdirSync(leasePath);
+    writeFileSync(join(root, "owner-target"), JSON.stringify({ pid: 1, token: "x" }));
+    symlinkSync(join(root, "owner-target"), join(leasePath, "owner.json"));
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({
+      status: "unknown",
+      reason: "owner_malformed",
+    });
+
+    rmSync(leasePath, { recursive: true });
+    expect(
+      inspectDaemonWriterLease(socketPath, {
+        filesystem: {
+          lstat: () => {
+            throw errno("EACCES");
+          },
+        },
+      }),
+    ).toMatchObject({ status: "unknown", reason: "lease_unreadable" });
+
+    seedOwner({ pid: process.pid, token: "x" });
+    expect(
+      inspectDaemonWriterLease(socketPath, {
+        filesystem: {
+          readText: () => {
+            throw errno("EIO");
+          },
+        },
+      }),
+    ).toMatchObject({ status: "unknown", reason: "owner_unreadable" });
+  });
+
+  it("keeps the nullable compatibility projection deliberately lossy", () => {
+    expect(daemonLeaseOwner(socketPath)).toBeNull();
+    mkdirSync(leasePath);
+    expect(daemonLeaseOwner(socketPath)).toBeNull();
+    writeFileSync(join(leasePath, "owner.json"), "not-json");
+    expect(daemonLeaseOwner(socketPath)).toBeNull();
+    writeFileSync(join(leasePath, "owner.json"), '{"pid":7,"token":"legacy"}\n');
+    expect(daemonLeaseOwner(socketPath)).toEqual({ pid: 7, token: "legacy" });
+  });
+});
+
+describe("daemon lease-owner capability", () => {
+  const owner: DaemonLeaseOwner = { pid: 44, token: "owner", identity: known(44, "linux:1") };
+
+  it("proves only missing, recycled, or exact Linux Z owners stale", () => {
+    expect(
+      classifyDaemonLeaseOwner(
+        owner,
+        depsFor(observation({ status: "missing", pid: 44, platform: "linux" })),
+      ),
+    ).toMatchObject({ status: "proven_stale", reason: "process_missing" });
+    expect(
+      classifyDaemonLeaseOwner(owner, depsFor(observation(known(44, "linux:2"), "S"))),
+    ).toMatchObject({ status: "proven_stale", reason: "identity_mismatch" });
+    expect(
+      classifyDaemonLeaseOwner(owner, depsFor(observation(known(44, "linux:1"), "Z"))),
+    ).toMatchObject({ status: "proven_stale", reason: "linux_zombie" });
+
+    for (const state of ["R", "S", "D", "T", "t", "X", "x"] as const) {
+      expect(
+        classifyDaemonLeaseOwner(owner, depsFor(observation(known(44, "linux:1"), state))),
+      ).toMatchObject({ status: "capable", reason: "identity_match" });
+    }
+  });
+
+  it("handles legacy owners without granting them signal identity", () => {
+    const legacy = { pid: 44, token: "legacy" };
+    expect(
+      classifyDaemonLeaseOwner(legacy, depsFor(observation(known(44, "linux:1"), "Z"))),
+    ).toMatchObject({ status: "proven_stale", reason: "linux_zombie" });
+    expect(
+      classifyDaemonLeaseOwner(legacy, depsFor(observation(known(44, "linux:1"), "S"))),
+    ).toMatchObject({ status: "capable", reason: "legacy_process_present" });
+
+    const unsupported = observation({
+      status: "unknown",
+      pid: 44,
+      platform: "win32",
+      reason: "unsupported_platform",
+    });
+    expect(
+      classifyDaemonLeaseOwner(legacy, depsFor(unsupported, { probeProcess: () => undefined })),
+    ).toMatchObject({ status: "capable", reason: "legacy_process_present" });
+    expect(
+      classifyDaemonLeaseOwner(
+        legacy,
+        depsFor(unsupported, {
+          probeProcess: () => {
+            throw errno("EPERM");
+          },
+        }),
+      ),
+    ).toMatchObject({ status: "capable", reason: "legacy_process_present" });
+  });
+
+  it("fails closed when an identity-bearing owner cannot be observed", () => {
+    const unavailable = observation({
+      status: "unknown",
+      pid: 44,
+      platform: "linux",
+      reason: "permission_denied",
+    });
+    for (const probeProcess of [
+      () => undefined,
+      () => {
+        throw errno("EPERM");
+      },
+    ]) {
+      expect(classifyDaemonLeaseOwner(owner, depsFor(unavailable, { probeProcess }))).toMatchObject(
+        {
+          status: "unknown",
+          reason: "identity_unavailable",
+        },
+      );
+    }
+    expect(
+      classifyDaemonLeaseOwner(
+        owner,
+        depsFor(unavailable, {
+          probeProcess: () => {
+            throw errno("ESRCH");
+          },
+        }),
+      ),
+    ).toMatchObject({ status: "proven_stale", reason: "process_missing" });
+    expect(
+      classifyDaemonLeaseOwner(
+        owner,
+        depsFor(unavailable, {
+          probeProcess: () => {
+            throw errno("EIO");
+          },
+        }),
+      ),
+    ).toMatchObject({ status: "unknown", reason: "presence_unknown" });
+  });
+});
+
+describe("generation-bound writer-lease recovery", () => {
+  const staleOwner: DaemonLeaseOwner = {
+    pid: 4444,
+    token: "raw-secret-token",
+    identity: known(4444, "linux:1"),
+  };
+
+  function recoveryDeps(): DaemonWriterLeaseDependencies {
+    return {
+      identity: sourceFor((pid) =>
+        pid === staleOwner.pid
+          ? observation(staleOwner.identity!, "Z")
+          : observation(known(pid, "linux:999"), "S"),
+      ),
+      probeProcess: () => {
+        throw new Error("known observations must not need signal-zero fallback");
+      },
+    };
+  }
+
+  it("derives one opaque tombstone per exact owner generation", () => {
+    const first = writerLeaseTombstonePath(leasePath, staleOwner);
+    expect(writerLeaseTombstonePath(leasePath, staleOwner)).toBe(first);
+    expect(writerLeaseTombstonePath(leasePath, { ...staleOwner, token: "other" })).not.toBe(first);
+    expect(first).toMatch(new RegExp(`\\.stale-${staleOwner.pid}-[0-9a-f]{64}$`));
+    expect(first).not.toContain(staleOwner.token);
+  });
+
+  it("recovers a matching zombie and preserves its exact nonempty tombstone", () => {
+    const original = seedOwner(staleOwner);
+    const lease = acquireDaemonWriterLease(socketPath, recoveryDeps());
+    const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
+
+    expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toMatchObject({
+      pid: process.pid,
+      token: lease.owner.token,
+    });
+    expect(readFileSync(join(tombstone, "owner.json"), "utf8")).toBe(original);
+    lease.release();
+    expect(inspectDaemonWriterLease(socketPath)).toMatchObject({ status: "absent" });
+    expect(readFileSync(join(tombstone, "owner.json"), "utf8")).toBe(original);
+  });
+
+  it("prevents a delayed contender from moving a fresh successor", () => {
+    const original = seedOwner(staleOwner);
+    const cached = inspectDaemonWriterLease(socketPath, recoveryDeps());
+    expect(cached.status).toBe("owned");
+    if (cached.status !== "owned") throw new Error("expected owned lease");
+
+    const first = quarantineDaemonWriterLeaseGeneration(cached, recoveryDeps());
+    expect(first.status).toBe("quarantined");
+    const successor = acquireDaemonWriterLease(socketPath, recoveryDeps());
+    const successorBytes = readFileSync(join(leasePath, "owner.json"), "utf8");
+
+    const delayed = quarantineDaemonWriterLeaseGeneration(cached, recoveryDeps());
+    expect(delayed.status).toBe("contended");
+    expect(readFileSync(join(leasePath, "owner.json"), "utf8")).toBe(successorBytes);
+    expect(readFileSync(join(first.path, "owner.json"), "utf8")).toBe(original);
+    successor.release();
+  });
+
+  it("rechecks after classification so an orderly release cannot expose its successor", () => {
+    seedOwner(staleOwner);
+    const successor: DaemonLeaseOwner = {
+      pid: 5555,
+      token: "clean-successor",
+      identity: known(5555, "linux:2"),
+    };
+    let transitioned = false;
+    const deps: DaemonWriterLeaseDependencies = {
+      identity: sourceFor((pid) => {
+        if (pid === staleOwner.pid) {
+          if (!transitioned) {
+            transitioned = true;
+            rmSync(leasePath, { recursive: true });
+            seedOwner(successor);
+          }
+          return observation({ status: "missing", pid, platform: "linux" });
+        }
+        return observation(successor.identity!, "S");
+      }),
+    };
+
+    expect(() => acquireDaemonWriterLease(socketPath, deps)).toThrowError(
+      expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
+    );
+    expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(successor);
+    expect(() => lstatSync(writerLeaseTombstonePath(leasePath, staleOwner))).toThrowError(
+      expect.objectContaining({ code: "ENOENT" }),
+    );
+  });
+
+  it("fails boundedly when the tombstone exists but the stale main generation is unchanged", () => {
+    const original = seedOwner(staleOwner);
+    const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
+    seedOwner(staleOwner, tombstone);
+
+    expect(() => acquireDaemonWriterLease(socketPath, recoveryDeps())).toThrow(
+      `could not replace stale daemon writer lease ${leasePath}`,
+    );
+    expect(readFileSync(join(leasePath, "owner.json"), "utf8")).toBe(original);
+    expect(readFileSync(join(tombstone, "owner.json"), "utf8")).toBe(original);
+  });
+
+  it("normalizes only a proven occupied Windows-style EPERM destination", () => {
+    seedOwner(staleOwner);
+    const cached = inspectDaemonWriterLease(socketPath, recoveryDeps());
+    if (cached.status !== "owned") throw new Error("expected owned lease");
+    const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
+    seedOwner(staleOwner, tombstone);
+
+    expect(
+      quarantineDaemonWriterLeaseGeneration(cached, {
+        filesystem: {
+          rename: () => {
+            throw errno("EPERM");
+          },
+        },
+      }),
+    ).toMatchObject({ status: "contended", path: tombstone });
+
+    rmSync(tombstone, { recursive: true });
+    expect(() =>
+      quarantineDaemonWriterLeaseGeneration(cached, {
+        filesystem: {
+          rename: () => {
+            throw errno("EPERM");
+          },
+        },
+      }),
+    ).toThrowError(expect.objectContaining({ code: "EPERM" }));
+  });
+
+  it("blocks live, unknown, and malformed owners without mutating them", () => {
+    const raw = seedOwner(staleOwner);
+    const liveDeps = depsFor(observation(staleOwner.identity!, "S"));
+    try {
+      acquireDaemonWriterLease(socketPath, liveDeps);
+      throw new Error("expected busy lease");
+    } catch (error) {
+      expect(error).toMatchObject({ code: "daemon_writer_busy", status: 409 });
+    }
+    expect(readFileSync(join(leasePath, "owner.json"), "utf8")).toBe(raw);
+
+    rmSync(leasePath, { recursive: true });
+    mkdirSync(leasePath);
+    expect(() => acquireDaemonWriterLease(socketPath, recoveryDeps())).toThrowError(
+      expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
+    );
+  });
+
+  it("fences release to the exact main owner and never removes a successor", () => {
+    const lease = acquireDaemonWriterLease(
+      socketPath,
+      depsFor(observation(known(process.pid, "linux:999"), "S")),
+    );
+    rmSync(leasePath, { recursive: true });
+    const successor = { pid: process.pid + 1, token: "successor" };
+    seedOwner(successor);
+
+    lease.release();
+    expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(successor);
+    expect(lstatSync(leasePath).isDirectory()).toBe(true);
+  });
+});

--- a/packages/daemon/src/writer-lease.test.ts
+++ b/packages/daemon/src/writer-lease.test.ts
@@ -3,6 +3,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -22,7 +23,6 @@ import {
   classifyDaemonLeaseOwner,
   daemonLeaseOwner,
   inspectDaemonWriterLease,
-  quarantineDaemonWriterLeaseGeneration,
   writerLeasePath,
   writerLeaseTombstonePath,
   type DaemonLeaseOwner,
@@ -35,6 +35,17 @@ function known(pid: number, start = `linux:${pid}`): KnownProcessIdentity {
     pid,
     platform: "linux",
     source: "procfs_stat",
+    startToken: start,
+    processGroupId: pid,
+  };
+}
+
+function knownDarwin(pid: number, start = `darwin:${pid}:1`): KnownProcessIdentity {
+  return {
+    status: "known",
+    pid,
+    platform: "darwin",
+    source: "proc_pidinfo",
     startToken: start,
     processGroupId: pid,
   };
@@ -247,6 +258,19 @@ describe("daemon lease-owner capability", () => {
     ).toMatchObject({ status: "capable", reason: "legacy_process_present" });
   });
 
+  it("requires a same-pid Linux procfs observation before treating Z as a zombie", () => {
+    const darwin = knownDarwin(44);
+    const injectedState = depsFor(observation(darwin, "Z"));
+
+    expect(
+      classifyDaemonLeaseOwner({ pid: 44, token: "current", identity: darwin }, injectedState),
+    ).toMatchObject({ status: "capable", reason: "identity_match" });
+    expect(classifyDaemonLeaseOwner({ pid: 44, token: "legacy" }, injectedState)).toMatchObject({
+      status: "capable",
+      reason: "legacy_process_present",
+    });
+  });
+
   it("fails closed when an identity-bearing owner cannot be observed", () => {
     const unavailable = observation({
       status: "unknown",
@@ -335,19 +359,31 @@ describe("generation-bound writer-lease recovery", () => {
 
   it("prevents a delayed contender from moving a fresh successor", () => {
     const original = seedOwner(staleOwner);
-    const cached = inspectDaemonWriterLease(socketPath, recoveryDeps());
-    expect(cached.status).toBe("owned");
-    if (cached.status !== "owned") throw new Error("expected owned lease");
+    const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
+    let successor: ReturnType<typeof acquireDaemonWriterLease> | undefined;
+    let successorBytes = "";
+    let interleaved = false;
+    const delayedDeps: DaemonWriterLeaseDependencies = {
+      ...recoveryDeps(),
+      filesystem: {
+        rename: (from, to) => {
+          if (!interleaved) {
+            interleaved = true;
+            successor = acquireDaemonWriterLease(socketPath, recoveryDeps());
+            successorBytes = readFileSync(join(leasePath, "owner.json"), "utf8");
+          }
+          renameSync(from, to);
+        },
+      },
+    };
 
-    const first = quarantineDaemonWriterLeaseGeneration(cached, recoveryDeps());
-    expect(first.status).toBe("quarantined");
-    const successor = acquireDaemonWriterLease(socketPath, recoveryDeps());
-    const successorBytes = readFileSync(join(leasePath, "owner.json"), "utf8");
-
-    const delayed = quarantineDaemonWriterLeaseGeneration(cached, recoveryDeps());
-    expect(delayed.status).toBe("contended");
+    expect(() => acquireDaemonWriterLease(socketPath, delayedDeps)).toThrowError(
+      expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
+    );
+    expect(successor).toBeDefined();
     expect(readFileSync(join(leasePath, "owner.json"), "utf8")).toBe(successorBytes);
-    expect(readFileSync(join(first.path, "owner.json"), "utf8")).toBe(original);
+    expect(readFileSync(join(tombstone, "owner.json"), "utf8")).toBe(original);
+    if (!successor) throw new Error("expected interleaved successor");
     successor.release();
   });
 
@@ -394,33 +430,69 @@ describe("generation-bound writer-lease recovery", () => {
     expect(readFileSync(join(tombstone, "owner.json"), "utf8")).toBe(original);
   });
 
+  it("returns typed busy when the main owner changes during the final attempt", () => {
+    const successor: DaemonLeaseOwner = {
+      pid: 5555,
+      token: "final-attempt-successor",
+      identity: known(5555, "linux:2"),
+    };
+    let createAttempts = 0;
+    let transitioned = false;
+    const deps: DaemonWriterLeaseDependencies = {
+      identity: sourceFor((pid) => {
+        if (pid === staleOwner.pid) {
+          if (!transitioned) {
+            transitioned = true;
+            rmSync(leasePath, { recursive: true });
+            seedOwner(successor);
+          }
+          return observation({ status: "missing", pid, platform: "linux" });
+        }
+        return observation(successor.identity!, "S");
+      }),
+      filesystem: {
+        createLeaseDirectory: (path) => {
+          createAttempts += 1;
+          if (createAttempts === 1) throw errno("EEXIST");
+          if (createAttempts === 2) {
+            seedOwner(staleOwner, path);
+            throw errno("EEXIST");
+          }
+          mkdirSync(path, { mode: 0o700 });
+        },
+      },
+    };
+
+    expect(() => acquireDaemonWriterLease(socketPath, deps)).toThrowError(
+      expect.objectContaining({ code: "daemon_writer_busy", status: 409 }),
+    );
+    expect(JSON.parse(readFileSync(join(leasePath, "owner.json"), "utf8"))).toEqual(successor);
+  });
+
   it("normalizes only a proven occupied Windows-style EPERM destination", () => {
     seedOwner(staleOwner);
-    const cached = inspectDaemonWriterLease(socketPath, recoveryDeps());
-    if (cached.status !== "owned") throw new Error("expected owned lease");
     const tombstone = writerLeaseTombstonePath(leasePath, staleOwner);
     seedOwner(staleOwner, tombstone);
-
-    expect(
-      quarantineDaemonWriterLeaseGeneration(cached, {
-        filesystem: {
-          rename: () => {
-            throw errno("EPERM");
-          },
+    const epermDeps: DaemonWriterLeaseDependencies = {
+      ...recoveryDeps(),
+      filesystem: {
+        rename: () => {
+          throw errno("EPERM");
         },
-      }),
-    ).toMatchObject({ status: "contended", path: tombstone });
+      },
+    };
+
+    expect(() => acquireDaemonWriterLease(socketPath, epermDeps)).toThrow(
+      `could not replace stale daemon writer lease ${leasePath}`,
+    );
 
     rmSync(tombstone, { recursive: true });
-    expect(() =>
-      quarantineDaemonWriterLeaseGeneration(cached, {
-        filesystem: {
-          rename: () => {
-            throw errno("EPERM");
-          },
-        },
-      }),
-    ).toThrowError(expect.objectContaining({ code: "EPERM" }));
+    const foreignOwner: DaemonLeaseOwner = { pid: 5555, token: "foreign" };
+    seedOwner(foreignOwner, tombstone);
+    expect(() => acquireDaemonWriterLease(socketPath, epermDeps)).toThrowError(
+      expect.objectContaining({ code: "EPERM" }),
+    );
+    expect(JSON.parse(readFileSync(join(tombstone, "owner.json"), "utf8"))).toEqual(foreignOwner);
   });
 
   it("blocks live, unknown, and malformed owners without mutating them", () => {

--- a/packages/daemon/src/writer-lease.test.ts
+++ b/packages/daemon/src/writer-lease.test.ts
@@ -15,8 +15,9 @@ import {
   type KnownProcessIdentity,
   type LinuxProcessState,
   type ProcessIdentity,
+  type ProcessIdentityReader,
   type ProcessObservation,
-  type ProcessObservationSource,
+  type ProcessObservationReader,
 } from "@claudexor/core";
 import {
   acquireDaemonWriterLease,
@@ -61,13 +62,21 @@ function observation(
 function sourceFor(
   observed: ProcessObservation | ((pid: number) => ProcessObservation),
   selfIdentity: ProcessIdentity = known(process.pid, "linux:999"),
-): ProcessObservationSource {
+): ProcessIdentityReader & ProcessObservationReader {
   const observe = typeof observed === "function" ? observed : () => observed;
   return {
     read: (pid) => observe(pid).identity,
     observe,
     self: () => selfIdentity,
   };
+}
+
+function observationDependencies(
+  observed: ProcessObservation | ((pid: number) => ProcessObservation),
+  selfIdentity?: ProcessIdentity,
+): Pick<DaemonWriterLeaseDependencies, "identity" | "observation"> {
+  const source = sourceFor(observed, selfIdentity);
+  return { identity: source, observation: source };
 }
 
 function errno(code: string): NodeJS.ErrnoException {
@@ -97,9 +106,9 @@ function seedOwner(owner: unknown, path = leasePath): string {
 
 function depsFor(
   observed: ProcessObservation | ((pid: number) => ProcessObservation),
-  extra: Omit<DaemonWriterLeaseDependencies, "identity"> = {},
+  extra: Omit<DaemonWriterLeaseDependencies, "identity" | "observation"> = {},
 ): DaemonWriterLeaseDependencies {
-  return { ...extra, identity: sourceFor(observed) };
+  return { ...extra, ...observationDependencies(observed) };
 }
 
 describe("strict writer-lease inspection", () => {
@@ -312,6 +321,42 @@ describe("daemon lease-owner capability", () => {
       ),
     ).toMatchObject({ status: "unknown", reason: "presence_unknown" });
   });
+
+  it("keeps legacy identity readers with unrelated observe members source-compatible", () => {
+    let reads = 0;
+    let collidingObserveCalls = 0;
+    class LegacyReaderWithUnrelatedObserve implements ProcessIdentityReader {
+      constructor() {
+        void this.observe;
+      }
+
+      private observe(_pid: number): void {
+        collidingObserveCalls += 1;
+      }
+
+      read(pid: number): ProcessIdentity {
+        reads += 1;
+        return { status: "missing", pid, platform: "linux" };
+      }
+
+      self(): ProcessIdentity {
+        return known(process.pid, "linux:999");
+      }
+    }
+
+    const reader = new LegacyReaderWithUnrelatedObserve();
+    const dependencies: NonNullable<Parameters<typeof acquireDaemonWriterLease>[1]> = {
+      identity: reader,
+    };
+    expect(
+      classifyDaemonLeaseOwner(
+        { pid: 44, token: "legacy-reader", identity: known(44) },
+        dependencies,
+      ),
+    ).toMatchObject({ status: "proven_stale", reason: "process_missing" });
+    expect(reads).toBe(1);
+    expect(collidingObserveCalls).toBe(0);
+  });
 });
 
 describe("generation-bound writer-lease recovery", () => {
@@ -323,7 +368,7 @@ describe("generation-bound writer-lease recovery", () => {
 
   function recoveryDeps(): DaemonWriterLeaseDependencies {
     return {
-      identity: sourceFor((pid) =>
+      ...observationDependencies((pid) =>
         pid === staleOwner.pid
           ? observation(staleOwner.identity!, "Z")
           : observation(known(pid, "linux:999"), "S"),
@@ -396,7 +441,7 @@ describe("generation-bound writer-lease recovery", () => {
     };
     let transitioned = false;
     const deps: DaemonWriterLeaseDependencies = {
-      identity: sourceFor((pid) => {
+      ...observationDependencies((pid) => {
         if (pid === staleOwner.pid) {
           if (!transitioned) {
             transitioned = true;
@@ -439,7 +484,7 @@ describe("generation-bound writer-lease recovery", () => {
     let createAttempts = 0;
     let transitioned = false;
     const deps: DaemonWriterLeaseDependencies = {
-      identity: sourceFor((pid) => {
+      ...observationDependencies((pid) => {
         if (pid === staleOwner.pid) {
           if (!transitioned) {
             transitioned = true;

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import {
   compareProcessIdentity,
   defaultProcessIdentityService,
+  defaultProcessObservationReader,
   isKnownProcessIdentity,
   observeProcess,
   type KnownProcessIdentity,
@@ -247,7 +248,7 @@ export function classifyDaemonLeaseOwner(
   const identity = deps.identity ?? defaultProcessIdentityService;
   const observationReader =
     deps.observation ??
-    (identity === defaultProcessIdentityService ? defaultProcessIdentityService : undefined);
+    (identity === defaultProcessIdentityService ? defaultProcessObservationReader : undefined);
   const observation = observeProcess(identity, owner.pid, observationReader);
   const probe = deps.probeProcess ?? ((pid: number) => process.kill(pid, 0));
 

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -138,6 +138,16 @@ function sameOwner(left: DaemonLeaseOwner, right: DaemonLeaseOwner): boolean {
   return left.pid === right.pid && left.token === right.token;
 }
 
+function isLinuxZombieObservation(observation: ProcessObservation, pid: number): boolean {
+  return (
+    observation.linuxState === "Z" &&
+    observation.identity.status === "known" &&
+    observation.identity.pid === pid &&
+    observation.identity.platform === "linux" &&
+    observation.identity.source === "procfs_stat"
+  );
+}
+
 function parseLeaseOwner(raw: string): DaemonLeaseOwner | null {
   let value: unknown;
   try {
@@ -243,14 +253,14 @@ export function classifyDaemonLeaseOwner(
     if (compareProcessIdentity(owner.identity, observation.identity) !== "same") {
       return { status: "proven_stale", reason: "identity_mismatch", observation };
     }
-    if (observation.linuxState === "Z") {
+    if (isLinuxZombieObservation(observation, owner.pid)) {
       return { status: "proven_stale", reason: "linux_zombie", observation };
     }
     return { status: "capable", reason: "identity_match", observation };
   }
 
   if (!owner.identity && observation.identity.status === "known") {
-    if (observation.linuxState === "Z") {
+    if (isLinuxZombieObservation(observation, owner.pid)) {
       return { status: "proven_stale", reason: "linux_zombie", observation };
     }
     return { status: "capable", reason: "legacy_process_present", observation };
@@ -291,11 +301,11 @@ export function writerLeaseTombstonePath(leasePath: string, owner: DaemonLeaseOw
   return `${leasePath}.stale-${owner.pid}-${digest}`;
 }
 
-export type DaemonWriterLeaseQuarantineResult =
+type DaemonWriterLeaseQuarantineResult =
   { status: "quarantined"; path: string } | { status: "contended"; path: string };
 
 /** Move exactly one observed generation; the nonempty tombstone is preserved. */
-export function quarantineDaemonWriterLeaseGeneration(
+function quarantineDaemonWriterLeaseGeneration(
   lease: { path: string; owner: DaemonLeaseOwner },
   deps: DaemonWriterLeaseDependencies = {},
 ): DaemonWriterLeaseQuarantineResult {
@@ -311,7 +321,9 @@ export function quarantineDaemonWriterLeaseGeneration(
     }
     if (code === "EPERM") {
       const occupied = inspectWriterLeasePath(tombstone, fs);
-      if (occupied.status === "owned") return { status: "contended", path: tombstone };
+      if (occupied.status === "owned" && sameOwner(occupied.owner, lease.owner)) {
+        return { status: "contended", path: tombstone };
+      }
     }
     throw error;
   }
@@ -368,7 +380,10 @@ export function acquireDaemonWriterLease(
       const confirmed = inspectWriterLeasePath(path, fs);
       if (confirmed.status === "absent") continue;
       if (confirmed.status === "unknown") throw writerBusy(path);
-      if (!sameOwner(confirmed.owner, existing.owner)) continue;
+      if (!sameOwner(confirmed.owner, existing.owner)) {
+        if (attempt === 1) throw writerBusy(path);
+        continue;
+      }
       if (attempt === 1) throw staleReplacementFailed(path);
 
       const quarantine = quarantineDaemonWriterLeaseGeneration(confirmed, deps);

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -161,6 +161,14 @@ function filesystem(deps: DaemonWriterLeaseDependencies): DaemonWriterLeaseFiles
   return { ...DEFAULT_FILESYSTEM, ...deps.filesystem };
 }
 
+/** Resolved filesystem seam. The root-authority in-place migration (C4)
+ * shares it so its atomic steps stay deterministically observable in tests. */
+export function resolveWriterLeaseFilesystem(
+  deps: DaemonWriterLeaseDependencies,
+): DaemonWriterLeaseFilesystem {
+  return filesystem(deps);
+}
+
 function errorCode(error: unknown): string | undefined {
   return (error as NodeJS.ErrnoException)?.code;
 }

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -22,19 +22,49 @@ import {
 } from "@claudexor/core";
 import { daemonDir, isWindowsPipePath } from "./token.js";
 
+/** Marker file whose presence turns a lease directory into the permanent
+ * root-authority barrier (issue #165 D1). The barrier directory deliberately
+ * carries NO top-level owner.json: a pre-fix claimant's lease parse fails
+ * closed on it forever, so it can never quarantine the barrier and take over
+ * a data root last served by a fixed runtime. */
+export const ROOT_AUTHORITY_MARKER_FILE = "root-authority-v2.json";
+/** Nested slot the fixed daemon's ACTIVE writer claim occupies under a barrier. */
+const ROOT_AUTHORITY_ACTIVE_SLOT = "active";
+
 /**
- * Filesystem home of the single-writer lease for a control endpoint. A Unix
+ * Filesystem anchor of the single-writer lease for a control endpoint. A Unix
  * socket FILE anchors its lease right next to itself; a named pipe is not a
  * filesystem entry (nothing can be created in `\\.\pipe\`), so its lease lives
  * in the daemon dir under the pipe's own final segment — which already carries
  * the config-dir digest, keeping concurrent daemons' leases distinct.
  */
-export function writerLeasePath(socketPath: string): string {
+export function writerLeaseAnchorPath(socketPath: string): string {
   if (isWindowsPipePath(socketPath)) {
     const pipeName = socketPath.split(/[\\/]/).pop() || "claudexord-pipe";
     return join(daemonDir(), `${pipeName}.writer`);
   }
   return `${socketPath}.writer`;
+}
+
+/**
+ * Effective single-writer lease address. Once the anchor directory carries the
+ * permanent root-authority barrier marker (issue #165 D1/D4), the live claim
+ * for every FIXED runtime moves to the nested `active.writer` slot inside the
+ * barrier, so inspection, acquisition, termination and operator stop all keep
+ * following one canonical address. Pre-fix runtimes never resolve the nested
+ * slot — they contend on the anchor itself, where the opaque barrier refuses
+ * them. Without a marker the anchor stays the (legacy-compatible) address.
+ */
+export function writerLeasePath(socketPath: string): string {
+  const anchor = writerLeaseAnchorPath(socketPath);
+  try {
+    if (lstatSync(join(anchor, ROOT_AUTHORITY_MARKER_FILE)).isFile()) {
+      return join(anchor, `${ROOT_AUTHORITY_ACTIVE_SLOT}.writer`);
+    }
+  } catch {
+    /* no readable barrier marker -> the anchor is the lease address */
+  }
+  return anchor;
 }
 
 export interface DaemonWriterLease {

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -1,11 +1,22 @@
-import { randomUUID } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  type Stats,
+} from "node:fs";
 import { join } from "node:path";
 import {
+  compareProcessIdentity,
   defaultProcessIdentityService,
   isKnownProcessIdentity,
+  observeProcess,
   type KnownProcessIdentity,
-  type ProcessIdentityReader,
+  type ProcessObservation,
+  type ProcessObservationSource,
 } from "@claudexor/core";
 import { daemonDir, isWindowsPipePath } from "./token.js";
 
@@ -42,60 +53,268 @@ export interface DaemonLeaseOwner {
   identity?: KnownProcessIdentity;
 }
 
-/** Claim single-writer authority before any daemon journal is opened. */
-export function acquireDaemonWriterLease(
-  socketPath: string,
-  deps: { identity?: ProcessIdentityReader } = {},
-): DaemonWriterLease {
-  const path = writerLeasePath(socketPath);
-  const token = randomUUID();
-  const ownerPath = `${path}/owner.json`;
-  const self = (deps.identity ?? defaultProcessIdentityService).self();
-  const owner: DaemonLeaseOwner = {
-    pid: process.pid,
-    token,
-    ...(self.status === "known" ? { identity: self } : {}),
-  };
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      mkdirSync(path, { mode: 0o700 });
-      writeFileSync(ownerPath, `${JSON.stringify(owner)}\n`, {
-        mode: 0o600,
-        flag: "wx",
-      });
-      break;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      const existing = readLeaseOwner(ownerPath);
-      if (!existing || processIsAlive(existing.pid)) throw writerBusy(path);
-      const stale = `${path}.stale-${process.pid}-${randomUUID()}`;
-      try {
-        renameSync(path, stale);
-        rmSync(stale, { recursive: true, force: true });
-      } catch (cleanupError) {
-        if ((cleanupError as NodeJS.ErrnoException).code !== "ENOENT") throw cleanupError;
-      }
-      if (attempt === 1) throw new Error(`could not replace stale daemon writer lease ${path}`);
+export type DaemonLeaseOwnerCapability =
+  | {
+      status: "capable";
+      reason: "identity_match" | "legacy_process_present";
+      observation: ProcessObservation;
     }
+  | {
+      status: "proven_stale";
+      reason: "process_missing" | "identity_mismatch" | "linux_zombie";
+      observation: ProcessObservation;
+    }
+  | {
+      status: "unknown";
+      reason: "identity_unavailable" | "presence_unknown";
+      observation: ProcessObservation;
+    };
+
+export type DaemonWriterLeaseUnknownReason =
+  | "lease_unreadable"
+  | "invalid_lease_path"
+  | "owner_missing"
+  | "owner_unreadable"
+  | "owner_malformed";
+
+export type DaemonWriterLeaseStatus =
+  | { status: "absent"; path: string }
+  | {
+      status: "owned";
+      path: string;
+      owner: DaemonLeaseOwner;
+      capability: DaemonLeaseOwnerCapability;
+    }
+  | { status: "unknown"; path: string; reason: DaemonWriterLeaseUnknownReason };
+
+type RawDaemonWriterLeaseStatus =
+  | { status: "absent"; path: string }
+  | { status: "owned"; path: string; owner: DaemonLeaseOwner }
+  | { status: "unknown"; path: string; reason: DaemonWriterLeaseUnknownReason };
+
+/** Narrow synchronous seam used to deterministically exercise failure/race branches. */
+export interface DaemonWriterLeaseFilesystem {
+  lstat(path: string): Stats;
+  readText(path: string): string;
+  createLeaseDirectory(path: string): void;
+  writeOwner(path: string, data: string): void;
+  rename(from: string, to: string): void;
+  remove(path: string): void;
+}
+
+export interface DaemonWriterLeaseDependencies {
+  identity?: ProcessObservationSource;
+  /** Signal-zero probe: return for present, throw an errno-bearing error otherwise. */
+  probeProcess?: (pid: number) => void;
+  filesystem?: Partial<DaemonWriterLeaseFilesystem>;
+}
+
+const DEFAULT_FILESYSTEM: DaemonWriterLeaseFilesystem = {
+  lstat: (path) => lstatSync(path),
+  readText: (path) => readFileSync(path, "utf8"),
+  createLeaseDirectory: (path) => mkdirSync(path, { mode: 0o700 }),
+  writeOwner: (path, data) =>
+    writeFileSync(path, data, {
+      mode: 0o600,
+      flag: "wx",
+    }),
+  rename: (from, to) => renameSync(from, to),
+  remove: (path) => rmSync(path, { recursive: true, force: true }),
+};
+
+function filesystem(deps: DaemonWriterLeaseDependencies): DaemonWriterLeaseFilesystem {
+  return { ...DEFAULT_FILESYSTEM, ...deps.filesystem };
+}
+
+function errorCode(error: unknown): string | undefined {
+  return (error as NodeJS.ErrnoException)?.code;
+}
+
+function validPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function sameOwner(left: DaemonLeaseOwner, right: DaemonLeaseOwner): boolean {
+  return left.pid === right.pid && left.token === right.token;
+}
+
+function parseLeaseOwner(raw: string): DaemonLeaseOwner | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
   }
-  let released = false;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (!validPositiveInteger(record.pid) || typeof record.token !== "string" || !record.token) {
+    return null;
+  }
+  if (!Object.prototype.hasOwnProperty.call(record, "identity")) {
+    return { pid: record.pid, token: record.token };
+  }
+  if (!isKnownProcessIdentity(record.identity) || record.identity.pid !== record.pid) return null;
+  return { pid: record.pid, token: record.token, identity: record.identity };
+}
+
+function inspectLeaseAfterOwnerMissing(
+  path: string,
+  fs: DaemonWriterLeaseFilesystem,
+): RawDaemonWriterLeaseStatus {
+  try {
+    const lease = fs.lstat(path);
+    if (lease.isSymbolicLink() || !lease.isDirectory()) {
+      return { status: "unknown", path, reason: "invalid_lease_path" };
+    }
+    return { status: "unknown", path, reason: "owner_missing" };
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { status: "absent", path };
+    return { status: "unknown", path, reason: "lease_unreadable" };
+  }
+}
+
+function inspectWriterLeasePath(
+  path: string,
+  fs: DaemonWriterLeaseFilesystem,
+): RawDaemonWriterLeaseStatus {
+  let lease: Stats;
+  try {
+    lease = fs.lstat(path);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return { status: "absent", path };
+    return { status: "unknown", path, reason: "lease_unreadable" };
+  }
+  if (lease.isSymbolicLink() || !lease.isDirectory()) {
+    return { status: "unknown", path, reason: "invalid_lease_path" };
+  }
+
+  const ownerPath = join(path, "owner.json");
+  let ownerStat: Stats;
+  try {
+    ownerStat = fs.lstat(ownerPath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return inspectLeaseAfterOwnerMissing(path, fs);
+    return { status: "unknown", path, reason: "owner_unreadable" };
+  }
+  if (ownerStat.isSymbolicLink() || !ownerStat.isFile()) {
+    return { status: "unknown", path, reason: "owner_malformed" };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readText(ownerPath);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return inspectLeaseAfterOwnerMissing(path, fs);
+    return { status: "unknown", path, reason: "owner_unreadable" };
+  }
+  const owner = parseLeaseOwner(raw);
+  return owner
+    ? { status: "owned", path, owner }
+    : { status: "unknown", path, reason: "owner_malformed" };
+}
+
+type ProcessPresence = "present" | "missing" | "permission_denied" | "unknown";
+
+function probeProcessPresence(pid: number, probe: (pid: number) => void): ProcessPresence {
+  try {
+    probe(pid);
+    return "present";
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === "ESRCH") return "missing";
+    if (code === "EPERM") return "permission_denied";
+    return "unknown";
+  }
+}
+
+export function classifyDaemonLeaseOwner(
+  owner: DaemonLeaseOwner,
+  deps: DaemonWriterLeaseDependencies = {},
+): DaemonLeaseOwnerCapability {
+  const identity = deps.identity ?? defaultProcessIdentityService;
+  const observation = observeProcess(identity, owner.pid);
+  const probe = deps.probeProcess ?? ((pid: number) => process.kill(pid, 0));
+
+  if (observation.identity.status === "missing") {
+    return { status: "proven_stale", reason: "process_missing", observation };
+  }
+
+  if (owner.identity && observation.identity.status === "known") {
+    if (compareProcessIdentity(owner.identity, observation.identity) !== "same") {
+      return { status: "proven_stale", reason: "identity_mismatch", observation };
+    }
+    if (observation.linuxState === "Z") {
+      return { status: "proven_stale", reason: "linux_zombie", observation };
+    }
+    return { status: "capable", reason: "identity_match", observation };
+  }
+
+  if (!owner.identity && observation.identity.status === "known") {
+    if (observation.linuxState === "Z") {
+      return { status: "proven_stale", reason: "linux_zombie", observation };
+    }
+    return { status: "capable", reason: "legacy_process_present", observation };
+  }
+
+  const presence = probeProcessPresence(owner.pid, probe);
+  if (presence === "missing") {
+    return { status: "proven_stale", reason: "process_missing", observation };
+  }
+  if (!owner.identity && (presence === "present" || presence === "permission_denied")) {
+    return { status: "capable", reason: "legacy_process_present", observation };
+  }
+  if (presence === "present" || presence === "permission_denied") {
+    return { status: "unknown", reason: "identity_unavailable", observation };
+  }
+  return { status: "unknown", reason: "presence_unknown", observation };
+}
+
+/** Strict authority read: only a physically missing lease path is `absent`. */
+export function inspectDaemonWriterLease(
+  socketPath: string,
+  deps: DaemonWriterLeaseDependencies = {},
+): DaemonWriterLeaseStatus {
+  const raw = inspectWriterLeasePath(writerLeasePath(socketPath), filesystem(deps));
+  if (raw.status !== "owned") return raw;
   return {
-    path,
-    owner,
-    release: () => {
-      if (released) return;
-      released = true;
-      const current = readLeaseOwner(ownerPath);
-      if (current?.token === token && current.pid === process.pid) {
-        rmSync(path, { recursive: true, force: true });
-      }
-    },
+    ...raw,
+    capability: classifyDaemonLeaseOwner(raw.owner, deps),
   };
 }
 
-/** Read the current writer-lease owner for a socket path (null when free). */
-export function daemonLeaseOwner(socketPath: string): DaemonLeaseOwner | null {
-  return readLeaseOwner(join(writerLeasePath(socketPath), "owner.json"));
+export function writerLeaseTombstonePath(leasePath: string, owner: DaemonLeaseOwner): string {
+  const digest = createHash("sha256")
+    .update(String(owner.pid))
+    .update("\0")
+    .update(owner.token)
+    .digest("hex");
+  return `${leasePath}.stale-${owner.pid}-${digest}`;
+}
+
+export type DaemonWriterLeaseQuarantineResult =
+  { status: "quarantined"; path: string } | { status: "contended"; path: string };
+
+/** Move exactly one observed generation; the nonempty tombstone is preserved. */
+export function quarantineDaemonWriterLeaseGeneration(
+  lease: { path: string; owner: DaemonLeaseOwner },
+  deps: DaemonWriterLeaseDependencies = {},
+): DaemonWriterLeaseQuarantineResult {
+  const fs = filesystem(deps);
+  const tombstone = writerLeaseTombstonePath(lease.path, lease.owner);
+  try {
+    fs.rename(lease.path, tombstone);
+    return { status: "quarantined", path: tombstone };
+  } catch (error) {
+    const code = errorCode(error);
+    if (code === "ENOENT" || code === "EEXIST" || code === "ENOTEMPTY") {
+      return { status: "contended", path: tombstone };
+    }
+    if (code === "EPERM") {
+      const occupied = inspectWriterLeasePath(tombstone, fs);
+      if (occupied.status === "owned") return { status: "contended", path: tombstone };
+    }
+    throw error;
+  }
 }
 
 function writerBusy(path: string): Error {
@@ -105,35 +324,95 @@ function writerBusy(path: string): Error {
   });
 }
 
-function readLeaseOwner(path: string): DaemonLeaseOwner | null {
-  try {
-    const value = JSON.parse(readFileSync(path, "utf8")) as {
-      pid?: unknown;
-      token?: unknown;
-      identity?: unknown;
-    };
-    if (
-      !Number.isSafeInteger(value.pid) ||
-      Number(value.pid) <= 0 ||
-      typeof value.token !== "string"
-    ) {
-      return null;
-    }
-    return {
-      pid: Number(value.pid),
-      token: value.token,
-      ...(isKnownProcessIdentity(value.identity) ? { identity: value.identity } : {}),
-    };
-  } catch {
-    return null;
-  }
+function staleReplacementFailed(path: string): Error {
+  return new Error(`could not replace stale daemon writer lease ${path}`);
 }
 
+/** Claim single-writer authority before any daemon journal is opened. */
+export function acquireDaemonWriterLease(
+  socketPath: string,
+  deps: DaemonWriterLeaseDependencies = {},
+): DaemonWriterLease {
+  const path = writerLeasePath(socketPath);
+  const token = randomUUID();
+  const ownerPath = join(path, "owner.json");
+  const fs = filesystem(deps);
+  const self = (deps.identity ?? defaultProcessIdentityService).self();
+  const owner: DaemonLeaseOwner = {
+    pid: process.pid,
+    token,
+    ...(self.status === "known" ? { identity: self } : {}),
+  };
+  let acquired = false;
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      fs.createLeaseDirectory(path);
+      fs.writeOwner(ownerPath, `${JSON.stringify(owner)}\n`);
+      acquired = true;
+      break;
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") throw error;
+      const existing = inspectWriterLeasePath(path, fs);
+      if (existing.status === "absent") continue;
+      if (existing.status === "unknown") throw writerBusy(path);
+
+      const capability = classifyDaemonLeaseOwner(existing.owner, deps);
+      if (capability.status !== "proven_stale") throw writerBusy(path);
+
+      // Classification may have spanned an orderly release. Re-read the main
+      // generation before mutation: once the observed owner is positively
+      // missing/recycled/Z it cannot itself release after this point, while a
+      // concurrent stale takeover leaves the occupied tombstone below as the
+      // generation fence.
+      const confirmed = inspectWriterLeasePath(path, fs);
+      if (confirmed.status === "absent") continue;
+      if (confirmed.status === "unknown") throw writerBusy(path);
+      if (!sameOwner(confirmed.owner, existing.owner)) continue;
+      if (attempt === 1) throw staleReplacementFailed(path);
+
+      const quarantine = quarantineDaemonWriterLeaseGeneration(confirmed, deps);
+      if (quarantine.status === "quarantined") continue;
+
+      const current = inspectWriterLeasePath(path, fs);
+      if (current.status === "unknown") throw writerBusy(path);
+      if (current.status === "owned" && sameOwner(current.owner, existing.owner)) {
+        throw staleReplacementFailed(path);
+      }
+      // Another contender changed or removed the main generation. The single
+      // remaining creation attempt re-observes it without another quarantine.
+    }
+  }
+  if (!acquired) throw staleReplacementFailed(path);
+
+  let released = false;
+  return {
+    path,
+    owner,
+    release: () => {
+      if (released) return;
+      released = true;
+      const current = inspectWriterLeasePath(path, fs);
+      if (current.status === "owned" && sameOwner(current.owner, owner)) fs.remove(path);
+    },
+  };
+}
+
+/**
+ * Lossy patch-compatible projection. `null` does not prove the lease path is
+ * physically absent; authority-sensitive callers must use strict inspection.
+ */
+export function daemonLeaseOwner(socketPath: string): DaemonLeaseOwner | null {
+  const lease = inspectWriterLeasePath(writerLeasePath(socketPath), DEFAULT_FILESYSTEM);
+  return lease.status === "owned" ? lease.owner : null;
+}
+
+/** Raw signal-zero presence helper; daemon serviceability uses the classifier. */
 export function processIsAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code === "EPERM";
+    return errorCode(error) === "EPERM";
   }
 }

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -74,6 +74,7 @@ export type DaemonLeaseOwnerCapability =
 
 export type DaemonWriterLeaseUnknownReason =
   | "lease_unreadable"
+  | "lease_unstable"
   | "invalid_lease_path"
   | "owner_missing"
   | "owner_unreadable"
@@ -291,12 +292,23 @@ export function inspectDaemonWriterLease(
   socketPath: string,
   deps: DaemonWriterLeaseDependencies = {},
 ): DaemonWriterLeaseStatus {
-  const raw = inspectWriterLeasePath(writerLeasePath(socketPath), filesystem(deps));
-  if (raw.status !== "owned") return raw;
-  return {
-    ...raw,
-    capability: classifyDaemonLeaseOwner(raw.owner, deps),
-  };
+  const path = writerLeasePath(socketPath);
+  const fs = filesystem(deps);
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const raw = inspectWriterLeasePath(path, fs);
+    if (raw.status !== "owned") return raw;
+    const capability = classifyDaemonLeaseOwner(raw.owner, deps);
+    const confirmed = inspectWriterLeasePath(path, fs);
+    if (confirmed.status === "owned" && sameOwner(confirmed.owner, raw.owner)) {
+      return { ...confirmed, capability };
+    }
+    if (attempt === 1) {
+      return confirmed.status === "owned"
+        ? { status: "unknown", path, reason: "lease_unstable" }
+        : confirmed;
+    }
+  }
+  return { status: "unknown", path, reason: "lease_unstable" };
 }
 
 export function writerLeaseTombstonePath(leasePath: string, owner: DaemonLeaseOwner): string {

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -172,6 +172,32 @@ function parseLeaseOwner(raw: string): DaemonLeaseOwner | null {
   return { pid: record.pid, token: record.token, identity: record.identity };
 }
 
+/** Preserve the pre-strict public projection exactly; never use for authority. */
+function parseLegacyLeaseOwner(raw: string): DaemonLeaseOwner | null {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (!validPositiveInteger(record.pid) || typeof record.token !== "string") return null;
+  return {
+    pid: record.pid,
+    token: record.token,
+    ...(isKnownProcessIdentity(record.identity) ? { identity: record.identity } : {}),
+  };
+}
+
+function readLegacyLeaseOwner(path: string): DaemonLeaseOwner | null {
+  try {
+    return parseLegacyLeaseOwner(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
 function inspectLeaseAfterOwnerMissing(
   path: string,
   fs: DaemonWriterLeaseFilesystem,
@@ -362,13 +388,24 @@ function staleReplacementFailed(path: string): Error {
 /** Claim single-writer authority before any daemon journal is opened. */
 export function acquireDaemonWriterLease(
   socketPath: string,
-  deps: DaemonWriterLeaseDependencies = {},
+  deps: { identity?: ProcessIdentityReader } = {},
+  acquisitionDeps: Omit<DaemonWriterLeaseDependencies, "identity"> = {},
 ): DaemonWriterLease {
+  // The second argument is a published compatibility boundary. Read only its
+  // original `identity` field: downstream objects may already use any newer
+  // dependency name for unrelated private/runtime state.
+  const identity = deps.identity;
+  const effectiveDeps: DaemonWriterLeaseDependencies = {
+    identity,
+    observation: acquisitionDeps.observation,
+    probeProcess: acquisitionDeps.probeProcess,
+    filesystem: acquisitionDeps.filesystem,
+  };
   const path = writerLeasePath(socketPath);
   const token = randomUUID();
   const ownerPath = join(path, "owner.json");
-  const fs = filesystem(deps);
-  const self = (deps.identity ?? defaultProcessIdentityService).self();
+  const fs = filesystem(effectiveDeps);
+  const self = (identity ?? defaultProcessIdentityService).self();
   const owner: DaemonLeaseOwner = {
     pid: process.pid,
     token,
@@ -388,7 +425,7 @@ export function acquireDaemonWriterLease(
       if (existing.status === "absent") continue;
       if (existing.status === "unknown") throw writerBusy(path);
 
-      const capability = classifyDaemonLeaseOwner(existing.owner, deps);
+      const capability = classifyDaemonLeaseOwner(existing.owner, effectiveDeps);
       if (capability.status !== "proven_stale") throw writerBusy(path);
 
       // Classification may have spanned an orderly release. Re-read the main
@@ -405,7 +442,7 @@ export function acquireDaemonWriterLease(
       }
       if (attempt === 1) throw staleReplacementFailed(path);
 
-      const quarantine = quarantineDaemonWriterLeaseGeneration(confirmed, deps);
+      const quarantine = quarantineDaemonWriterLeaseGeneration(confirmed, effectiveDeps);
       if (quarantine.status === "quarantined") continue;
 
       const current = inspectWriterLeasePath(path, fs);
@@ -437,8 +474,7 @@ export function acquireDaemonWriterLease(
  * physically absent; authority-sensitive callers must use strict inspection.
  */
 export function daemonLeaseOwner(socketPath: string): DaemonLeaseOwner | null {
-  const lease = inspectWriterLeasePath(writerLeasePath(socketPath), DEFAULT_FILESYSTEM);
-  return lease.status === "owned" ? lease.owner : null;
+  return readLegacyLeaseOwner(join(writerLeasePath(socketPath), "owner.json"));
 }
 
 /** Raw signal-zero presence helper; daemon serviceability uses the classifier. */

--- a/packages/daemon/src/writer-lease.ts
+++ b/packages/daemon/src/writer-lease.ts
@@ -15,8 +15,9 @@ import {
   isKnownProcessIdentity,
   observeProcess,
   type KnownProcessIdentity,
+  type ProcessIdentityReader,
   type ProcessObservation,
-  type ProcessObservationSource,
+  type ProcessObservationReader,
 } from "@claudexor/core";
 import { daemonDir, isWindowsPipePath } from "./token.js";
 
@@ -103,7 +104,9 @@ export interface DaemonWriterLeaseFilesystem {
 }
 
 export interface DaemonWriterLeaseDependencies {
-  identity?: ProcessObservationSource;
+  identity?: ProcessIdentityReader;
+  /** Explicit observation capability; never inferred from an identity reader by property name. */
+  observation?: ProcessObservationReader;
   /** Signal-zero probe: return for present, throw an errno-bearing error otherwise. */
   probeProcess?: (pid: number) => void;
   filesystem?: Partial<DaemonWriterLeaseFilesystem>;
@@ -242,7 +245,10 @@ export function classifyDaemonLeaseOwner(
   deps: DaemonWriterLeaseDependencies = {},
 ): DaemonLeaseOwnerCapability {
   const identity = deps.identity ?? defaultProcessIdentityService;
-  const observation = observeProcess(identity, owner.pid);
+  const observationReader =
+    deps.observation ??
+    (identity === defaultProcessIdentityService ? defaultProcessIdentityService : undefined);
+  const observation = observeProcess(identity, owner.pid, observationReader);
   const probe = deps.probeProcess ?? ((pid: number) => process.kill(pid, 0));
 
   if (observation.identity.status === "missing") {

--- a/packages/journal/src/index.ts
+++ b/packages/journal/src/index.ts
@@ -1,19 +1,14 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { gzipSync } from "node:zlib";
 import {
   closeSync,
   constants,
-  existsSync,
   fchmodSync,
   fstatSync,
   ftruncateSync,
   fsyncSync,
-  lstatSync,
   openSync,
-  readFileSync,
   renameSync,
-  rmSync,
-  writeSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { ensureCanonicalPrivateDirectory, fsyncDirectory } from "@claudexor/util";
@@ -30,7 +25,26 @@ import {
   type FrameHeader,
   type JournalRecord,
 } from "./frame-codec.js";
+import {
+  appendAndSync,
+  ensurePrivateFile,
+  readDescriptor,
+  readIntent,
+  removeFile,
+  writeIntent,
+} from "./journal-files.js";
+import { cursorError, encodeCursor, JournalCursorError } from "./journal-cursor.js";
+import { journalPartitionDirectory } from "./journal-partition.js";
+import {
+  fingerprintPreparedJournal,
+  inspectPreparedJournal,
+  type JournalPreparationReceipt,
+  type PreparedJournalInspection,
+} from "./read-only-preparation.js";
 export type { JournalRecord } from "./frame-codec.js";
+export type { JournalPreparationReceipt } from "./read-only-preparation.js";
+export { JournalCursorError } from "./journal-cursor.js";
+export { journalPartitionDirectory } from "./journal-partition.js";
 export type JournalRecoveryLocation =
   { kind: "byte"; byteOffset: number } | { kind: "cursor"; epoch: string; seq: number };
 
@@ -51,17 +65,7 @@ export interface DurableJournalOptions {
   compactionThresholdBytes?: number;
 }
 
-export function journalPartitionDirectory(rootDir: string, partition: string): string {
-  if (!partition.trim()) throw new Error("journal partition must not be empty");
-  const slug = partition.replace(/[^A-Za-z0-9._-]+/g, "-").slice(0, 48) || "partition";
-  return join(rootDir, `${slug}-${sha256(Buffer.from(partition)).slice(0, 12)}`);
-}
-
-interface AppendIntent {
-  v: 1;
-  offset: number;
-  length: number;
-}
+const PREPARED_JOURNAL = Symbol("prepared-journal");
 
 export class JournalRecoveryRequiredError extends Error {
   readonly code: string = "journal_recovery_required";
@@ -97,13 +101,6 @@ export class JournalAppendUncertainError extends JournalRecoveryRequiredError {
   }
 }
 
-export class JournalCursorError extends Error {
-  readonly code = "journal_cursor_invalid";
-  readonly status = 409;
-  readonly retryable = true;
-  readonly requiredActions = ["resnapshot"];
-}
-
 /** Single-writer, checksummed journal. A returned append has reached fsync. */
 export class DurableJournal {
   readonly options: Readonly<DurableJournalOptions>;
@@ -111,33 +108,65 @@ export class DurableJournal {
   readonly path: string;
   private readonly now: () => Date;
   private readonly appendFrame: (fd: number, bytes: Buffer) => void;
-  private fd: number;
+  private fd = -1;
   private readonly entries: JournalRecord[] = [];
   private epoch: string;
   private nextSeq = 1;
   private previousFrameHash = ZERO_HASH;
   private knownFileBytes = 0;
   private recovery: JournalRecoveryState = { status: "ready", discardedTailBytes: 0 };
+  private preparationState: PreparedJournalInspection | null = null;
+  private writable = false;
   private closed = false;
 
-  constructor(options: DurableJournalOptions) {
+  static prepare(options: DurableJournalOptions): DurableJournal {
+    if (!options.partition.trim()) throw new Error("journal partition must not be empty");
+    const partitionDir = journalPartitionDirectory(options.rootDir, options.partition);
+    const prepared = inspectPreparedJournal({
+      rootDir: options.rootDir,
+      partitionDir,
+      journalPath: join(partitionDir, "journal.bin"),
+      intentPath: join(partitionDir, "append.pending.json"),
+      partition: options.partition,
+      initialEpoch: (options.epochFactory ?? randomUUID)(),
+    });
+    const InternalJournal = DurableJournal as unknown as {
+      new (
+        value: DurableJournalOptions,
+        token: typeof PREPARED_JOURNAL,
+        inspection: PreparedJournalInspection,
+      ): DurableJournal;
+    };
+    return new InternalJournal(options, PREPARED_JOURNAL, prepared);
+  }
+
+  constructor(options: DurableJournalOptions);
+  constructor(
+    options: DurableJournalOptions,
+    token?: typeof PREPARED_JOURNAL,
+    prepared?: PreparedJournalInspection,
+  ) {
     if (!options.partition.trim()) throw new Error("journal partition must not be empty");
     this.options = Object.freeze({ ...options });
     this.now = options.now ?? (() => new Date());
     this.appendFrame = options.appendAndSync ?? appendAndSync;
-    ensureCanonicalPrivateDirectory(options.rootDir);
     this.partitionDir = journalPartitionDirectory(options.rootDir, options.partition);
-    ensureCanonicalPrivateDirectory(this.partitionDir);
     this.path = join(this.partitionDir, "journal.bin");
-    ensurePrivateFile(this.path);
-    this.fd = openSync(this.path, constants.O_RDWR | constants.O_APPEND | constants.O_NOFOLLOW);
-    const stat = fstatSync(this.fd);
-    if (!stat.isFile() || stat.nlink !== 1) throw new Error("journal file is not privately owned");
-    if ((stat.mode & 0o777) !== 0o600) {
-      fchmodSync(this.fd, 0o600);
-      fsyncSync(this.fd);
+    if (token === PREPARED_JOURNAL && prepared) {
+      this.preparationState = prepared;
+      this.recovery = structuredClone(prepared.recovery);
+      for (const record of prepared.records) this.entries.push(cloneJson(record));
+      this.epoch = prepared.epoch;
+      this.nextSeq = prepared.nextSeq;
+      this.previousFrameHash = prepared.previousFrameHash;
+      this.knownFileBytes = prepared.knownFileBytes;
+      return;
     }
+    ensureCanonicalPrivateDirectory(options.rootDir);
     this.epoch = (options.epochFactory ?? randomUUID)();
+    ensureCanonicalPrivateDirectory(this.partitionDir);
+    ensurePrivateFile(this.path);
+    this.openWriter();
     this.recover();
     if (
       this.recovery.status === "ready" &&
@@ -152,6 +181,45 @@ export class DurableJournal {
     return structuredClone(this.recovery);
   }
 
+  preparation(): JournalPreparationReceipt {
+    this.assertOpen();
+    if (!this.preparationState) throw new Error("journal was not opened through preparation");
+    return structuredClone(this.preparationState.receipt);
+  }
+
+  revalidatePreparation(): void {
+    this.assertOpen();
+    if (!this.preparationState) throw new Error("journal was not opened through preparation");
+    const actual = fingerprintPreparedJournal(this.options.rootDir, this.partitionDir);
+    if (actual !== this.preparationState.receipt.fingerprint) {
+      throw new Error("journal changed since read-only preparation");
+    }
+  }
+
+  activatePrepared(): void {
+    this.assertOpen();
+    if (!this.preparationState) throw new Error("journal was not opened through preparation");
+    if (this.writable) return;
+    if (this.recovery.status === "recovery_required") {
+      throw new JournalRecoveryRequiredError(this.recovery);
+    }
+    this.revalidatePreparation();
+    ensureCanonicalPrivateDirectory(this.options.rootDir);
+    ensureCanonicalPrivateDirectory(this.partitionDir);
+    ensurePrivateFile(this.path);
+    this.entries.length = 0;
+    this.nextSeq = 1;
+    this.previousFrameHash = ZERO_HASH;
+    this.knownFileBytes = 0;
+    this.recovery = { status: "ready", discardedTailBytes: 0 };
+    this.openWriter();
+    this.recover();
+    const activatedRecovery = this.state();
+    if (activatedRecovery.status === "recovery_required") {
+      throw new JournalRecoveryRequiredError(activatedRecovery);
+    }
+  }
+
   records<T = unknown>(afterSeq = 0): JournalRecord<T>[] {
     this.assertReadable();
     return this.entries
@@ -162,7 +230,7 @@ export class DurableJournal {
   close(): void {
     if (this.closed) return;
     this.closed = true;
-    closeSync(this.fd);
+    if (this.fd >= 0) closeSync(this.fd);
   }
 
   currentCursor(): string {
@@ -196,6 +264,7 @@ export class DurableJournal {
   /** Atomically replace physical frames with one checksummed compressed frame. */
   compact(): { beforeBytes: number; afterBytes: number; records: number } | null {
     this.assertReadable();
+    this.assertWritable();
     if (this.entries.length === 0) return null;
     const logical: CompactedRecord[] = this.entries.map((record) => ({
       time: record.time,
@@ -300,6 +369,7 @@ export class DurableJournal {
    * no prefix can become durable on its own. */
   appendBatch(records: readonly { type: string; payload: unknown }[]): JournalRecord[] {
     this.assertReadable();
+    this.assertWritable();
     if (records.length === 0) throw new Error("journal append batch must not be empty");
     for (const record of records) {
       if (!record.type.trim()) throw new Error("journal record type must not be empty");
@@ -402,6 +472,17 @@ export class DurableJournal {
     return join(this.partitionDir, "append.pending.json");
   }
 
+  private openWriter(): void {
+    this.fd = openSync(this.path, constants.O_RDWR | constants.O_APPEND | constants.O_NOFOLLOW);
+    const stat = fstatSync(this.fd);
+    if (!stat.isFile() || stat.nlink !== 1) throw new Error("journal file is not privately owned");
+    if ((stat.mode & 0o777) !== 0o600) {
+      fchmodSync(this.fd, 0o600);
+      fsyncSync(this.fd);
+    }
+    this.writable = true;
+  }
+
   private requireRecovery(
     byteOffset: number,
     reason: string,
@@ -423,96 +504,13 @@ export class DurableJournal {
     }
   }
 
+  private assertWritable(): void {
+    if (!this.writable) throw new Error("journal preparation is not activated");
+  }
+
   private assertOpen(): void {
     if (this.closed) throw new Error("journal writer is closed");
   }
-}
-
-function appendAndSync(fd: number, bytes: Buffer): void {
-  let offset = 0;
-  while (offset < bytes.length) offset += writeSync(fd, bytes, offset, bytes.length - offset);
-  fsyncSync(fd);
-}
-
-function ensurePrivateFile(path: string): void {
-  if (!existsSync(path)) {
-    const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
-    try {
-      fsyncSync(fd);
-    } finally {
-      closeSync(fd);
-    }
-    fsyncDirectory(dirname(path));
-  }
-  const stat = lstatSync(path);
-  if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
-    throw new Error("journal path is not a private regular file");
-  }
-}
-
-function readDescriptor(fd: number): Buffer {
-  const size = Number(fstatSync(fd, { bigint: true }).size);
-  if (!Number.isSafeInteger(size) || size < 0) throw new Error("journal file size is invalid");
-  const bytes = readFileSync(fd);
-  if (bytes.length !== size) throw new Error("journal changed while being read");
-  return bytes;
-}
-
-function readIntent(path: string): AppendIntent | null {
-  if (!existsSync(path)) return null;
-  const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
-  try {
-    const stat = fstatSync(fd);
-    if (!stat.isFile() || stat.nlink !== 1 || stat.size > 1024) throw new Error("unsafe file");
-    const value = JSON.parse(readFileSync(fd, "utf8")) as unknown;
-    if (
-      !isRecord(value) ||
-      value.v !== 1 ||
-      !Number.isSafeInteger(value.offset) ||
-      Number(value.offset) < 0 ||
-      !Number.isSafeInteger(value.length) ||
-      Number(value.length) <= 0
-    )
-      throw new Error("invalid shape");
-    return value as unknown as AppendIntent;
-  } finally {
-    closeSync(fd);
-  }
-}
-
-function writeIntent(path: string, value: AppendIntent): void {
-  const temp = `${path}.${randomUUID()}.tmp`;
-  const bytes = Buffer.from(`${JSON.stringify(value)}\n`);
-  const fd = openSync(temp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
-  try {
-    let offset = 0;
-    while (offset < bytes.length) offset += writeSync(fd, bytes, offset, bytes.length - offset);
-    fsyncSync(fd);
-  } finally {
-    closeSync(fd);
-  }
-  renameSync(temp, path);
-  fsyncDirectory(dirname(path));
-}
-
-function removeFile(path: string): void {
-  if (!existsSync(path)) return;
-  rmSync(path);
-  fsyncDirectory(dirname(path));
-}
-
-function encodeCursor(partition: string, epoch: string, seq: number): string {
-  return Buffer.from(JSON.stringify({ v: 1, p: partition, e: epoch, s: seq })).toString(
-    "base64url",
-  );
-}
-
-function cursorError(detail: string): JournalCursorError {
-  return new JournalCursorError(`journal cursor is ${detail}; resnapshot is required`);
-}
-
-function sha256(bytes: Buffer): string {
-  return createHash("sha256").update(bytes).digest("hex");
 }
 
 function cloneJson<T>(value: T): T {

--- a/packages/journal/src/index.ts
+++ b/packages/journal/src/index.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { gzipSync } from "node:zlib";
 import {
   closeSync,
   constants,
@@ -8,23 +7,12 @@ import {
   ftruncateSync,
   fsyncSync,
   openSync,
-  renameSync,
 } from "node:fs";
-import { dirname, join } from "node:path";
-import { ensureCanonicalPrivateDirectory, fsyncDirectory } from "@claudexor/util";
-import { encodeJournalPayload, prepareAppendBatch } from "./append-batch.js";
-import {
-  COMPACTED_SNAPSHOT,
-  HASH_BYTES,
-  MAX_PAYLOAD_BYTES,
-  ZERO_HASH,
-  encodeFrame,
-  replayFrames,
-  type CompactedRecord,
-  type CompactedSnapshotPayload,
-  type FrameHeader,
-  type JournalRecord,
-} from "./frame-codec.js";
+import { join } from "node:path";
+import { ensureCanonicalPrivateDirectory } from "@claudexor/util";
+import { prepareAppendBatch } from "./append-batch.js";
+import { ZERO_HASH, replayFrames, type JournalRecord } from "./frame-codec.js";
+import { compactJournalFile } from "./journal-compaction.js";
 import {
   appendAndSync,
   ensurePrivateFile,
@@ -186,7 +174,10 @@ export class DurableJournal {
     this.assertOpen();
     if (!this.preparationState) throw new Error("journal was not opened through preparation");
     const actual = fingerprintPreparedJournal(this.options.rootDir, this.partitionDir);
-    if (actual !== this.preparationState.fingerprint) {
+    if (
+      actual.fingerprint !== this.preparationState.fingerprint ||
+      actual.preparationIdentity !== this.preparationState.preparationIdentity
+    ) {
       throw new Error("journal changed since read-only preparation");
     }
   }
@@ -194,26 +185,31 @@ export class DurableJournal {
   activatePrepared(): void {
     this.assertOpen();
     if (!this.preparationState) throw new Error("journal was not opened through preparation");
-    if (this.writable) return;
     if (this.recovery.status === "recovery_required") {
+      this.closeWriter();
       throw new JournalRecoveryRequiredError(this.recovery);
     }
-    this.revalidatePreparation();
-    ensureCanonicalPrivateDirectory(this.options.rootDir);
-    ensureCanonicalPrivateDirectory(this.partitionDir);
-    ensurePrivateFile(this.path);
-    this.entries.length = 0;
-    this.nextSeq = 1;
-    this.previousFrameHash = ZERO_HASH;
-    this.knownFileBytes = 0;
-    this.recovery = { status: "ready", discardedTailBytes: 0 };
-    this.openWriter();
-    this.recover();
-    const activatedRecovery = this.state();
-    if (activatedRecovery.status === "recovery_required") {
-      throw new JournalRecoveryRequiredError(activatedRecovery);
+    if (this.writable) return;
+    try {
+      this.revalidatePreparation();
+      ensureCanonicalPrivateDirectory(this.options.rootDir);
+      ensureCanonicalPrivateDirectory(this.partitionDir);
+      ensurePrivateFile(this.path);
+      this.entries.length = 0;
+      this.nextSeq = 1;
+      this.previousFrameHash = ZERO_HASH;
+      this.knownFileBytes = 0;
+      this.recovery = { status: "ready", discardedTailBytes: 0 };
+      this.openWriter();
+      this.recover();
+      const activatedRecovery = this.state();
+      if (activatedRecovery.status === "recovery_required") {
+        throw new JournalRecoveryRequiredError(activatedRecovery);
+      }
+      this.compactAtThreshold();
+    } catch (error) {
+      this.failPreparedActivation(error);
     }
-    this.compactAtThreshold();
   }
 
   records<T = unknown>(afterSeq = 0): JournalRecord<T>[] {
@@ -226,7 +222,7 @@ export class DurableJournal {
   close(): void {
     if (this.closed) return;
     this.closed = true;
-    if (this.fd >= 0) closeSync(this.fd);
+    this.closeWriter();
   }
 
   currentCursor(): string {
@@ -261,67 +257,26 @@ export class DurableJournal {
   compact(): { beforeBytes: number; afterBytes: number; records: number } | null {
     this.assertReadable();
     this.assertWritable();
-    if (this.entries.length === 0) return null;
-    const logical: CompactedRecord[] = this.entries.map((record) => ({
-      time: record.time,
-      type: record.type,
-      payload: cloneJson(record.payload),
-    }));
-    const compressed = gzipSync(Buffer.from(JSON.stringify(logical)));
-    const payload: CompactedSnapshotPayload = {
-      version: 1,
-      count: logical.length,
-      encoding: "gzip-base64",
-      data: compressed.toString("base64"),
-    };
-    const payloadBytes = encodeJournalPayload(payload);
-    // Oversized history stays readable in its existing frames; compaction is
-    // an optimization, not a corruption or recovery boundary.
-    if (payloadBytes.length > MAX_PAYLOAD_BYTES) return null;
-    const epoch = randomUUID();
-    const header: FrameHeader = {
+    const result = compactJournalFile({
+      path: this.path,
       partition: this.options.partition,
-      epoch,
-      seq: 1,
-      previousFrameHash: ZERO_HASH,
-      time: this.now().toISOString(),
-      type: COMPACTED_SNAPSHOT,
-      logicalSpan: logical.length,
-    };
-    const frame = encodeFrame(header, payloadBytes);
-    if (frame.length >= this.knownFileBytes) return null;
-    const temp = `${this.path}.${randomUUID()}.compact`;
-    const tempFd = openSync(temp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
-    try {
-      appendAndSync(tempFd, frame);
-    } finally {
-      closeSync(tempFd);
-    }
-    const beforeBytes = this.knownFileBytes;
-    renameSync(temp, this.path);
-    fsyncDirectory(dirname(this.path));
+      entries: this.entries,
+      knownFileBytes: this.knownFileBytes,
+      now: this.now,
+    });
+    if (!result) return null;
     closeSync(this.fd);
+    this.fd = -1;
+    this.writable = false;
     this.fd = openSync(this.path, constants.O_RDWR | constants.O_APPEND | constants.O_NOFOLLOW);
-    const frameHash = frame.subarray(frame.length - HASH_BYTES).toString("hex");
+    this.writable = true;
     this.entries.length = 0;
-    for (const [index, record] of logical.entries()) {
-      this.entries.push({
-        partition: this.options.partition,
-        epoch,
-        seq: index + 1,
-        previousFrameHash: index === 0 ? ZERO_HASH : frameHash,
-        frameHash,
-        time: record.time,
-        type: record.type,
-        payload: cloneJson(record.payload),
-        byteOffset: 0,
-      });
-    }
-    this.epoch = epoch;
-    this.nextSeq = logical.length + 1;
-    this.previousFrameHash = frameHash;
-    this.knownFileBytes = frame.length;
-    return { beforeBytes, afterBytes: frame.length, records: logical.length };
+    for (const record of result.records) this.entries.push(record);
+    this.epoch = result.epoch;
+    this.nextSeq = result.nextSeq;
+    this.previousFrameHash = result.previousFrameHash;
+    this.knownFileBytes = result.knownFileBytes;
+    return result.receipt;
   }
 
   sequenceAfter(cursor: string | null | undefined): number {
@@ -482,6 +437,35 @@ export class DurableJournal {
   private compactAtThreshold(): void {
     const threshold = this.options.compactionThresholdBytes ?? 8 * 1024 * 1024;
     if (this.recovery.status === "ready" && this.knownFileBytes >= threshold) this.compact();
+  }
+
+  private closeWriter(): void {
+    const fd = this.fd;
+    this.fd = -1;
+    this.writable = false;
+    if (fd < 0) return;
+    try {
+      closeSync(fd);
+    } catch {
+      /* best-effort revocation: the handle number is never reused by this writer */
+    }
+  }
+
+  private failPreparedActivation(error: unknown): never {
+    this.closeWriter();
+    this.entries.length = 0;
+    this.nextSeq = 1;
+    this.previousFrameHash = ZERO_HASH;
+    this.knownFileBytes = 0;
+    const recovery =
+      error instanceof JournalRecoveryRequiredError
+        ? error.recovery
+        : this.requireRecovery(
+            0,
+            `prepared activation failed: ${error instanceof Error ? error.message : String(error)}`,
+          );
+    this.recovery = structuredClone(recovery);
+    throw new JournalRecoveryRequiredError(recovery);
   }
 
   private requireRecovery(

--- a/packages/journal/src/index.ts
+++ b/packages/journal/src/index.ts
@@ -115,7 +115,7 @@ export class DurableJournal {
   private previousFrameHash = ZERO_HASH;
   private knownFileBytes = 0;
   private recovery: JournalRecoveryState = { status: "ready", discardedTailBytes: 0 };
-  private preparationState: PreparedJournalInspection | null = null;
+  private preparationState: JournalPreparationReceipt | null = null;
   private writable = false;
   private closed = false;
 
@@ -153,9 +153,9 @@ export class DurableJournal {
     this.partitionDir = journalPartitionDirectory(options.rootDir, options.partition);
     this.path = join(this.partitionDir, "journal.bin");
     if (token === PREPARED_JOURNAL && prepared) {
-      this.preparationState = prepared;
+      this.preparationState = prepared.receipt;
       this.recovery = structuredClone(prepared.recovery);
-      for (const record of prepared.records) this.entries.push(cloneJson(record));
+      for (const record of prepared.records) this.entries.push(record);
       this.epoch = prepared.epoch;
       this.nextSeq = prepared.nextSeq;
       this.previousFrameHash = prepared.previousFrameHash;
@@ -168,12 +168,7 @@ export class DurableJournal {
     ensurePrivateFile(this.path);
     this.openWriter();
     this.recover();
-    if (
-      this.recovery.status === "ready" &&
-      this.knownFileBytes >= (options.compactionThresholdBytes ?? 8 * 1024 * 1024)
-    ) {
-      this.compact();
-    }
+    this.compactAtThreshold();
   }
 
   state(): JournalRecoveryState {
@@ -184,14 +179,14 @@ export class DurableJournal {
   preparation(): JournalPreparationReceipt {
     this.assertOpen();
     if (!this.preparationState) throw new Error("journal was not opened through preparation");
-    return structuredClone(this.preparationState.receipt);
+    return structuredClone(this.preparationState);
   }
 
   revalidatePreparation(): void {
     this.assertOpen();
     if (!this.preparationState) throw new Error("journal was not opened through preparation");
     const actual = fingerprintPreparedJournal(this.options.rootDir, this.partitionDir);
-    if (actual !== this.preparationState.receipt.fingerprint) {
+    if (actual !== this.preparationState.fingerprint) {
       throw new Error("journal changed since read-only preparation");
     }
   }
@@ -218,6 +213,7 @@ export class DurableJournal {
     if (activatedRecovery.status === "recovery_required") {
       throw new JournalRecoveryRequiredError(activatedRecovery);
     }
+    this.compactAtThreshold();
   }
 
   records<T = unknown>(afterSeq = 0): JournalRecord<T>[] {
@@ -481,6 +477,11 @@ export class DurableJournal {
       fsyncSync(this.fd);
     }
     this.writable = true;
+  }
+
+  private compactAtThreshold(): void {
+    const threshold = this.options.compactionThresholdBytes ?? 8 * 1024 * 1024;
+    if (this.recovery.status === "ready" && this.knownFileBytes >= threshold) this.compact();
   }
 
   private requireRecovery(

--- a/packages/journal/src/journal-compaction.ts
+++ b/packages/journal/src/journal-compaction.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from "node:crypto";
+import { closeSync, constants, openSync, renameSync } from "node:fs";
+import { dirname } from "node:path";
+import { gzipSync } from "node:zlib";
+import { fsyncDirectory } from "@claudexor/util";
+import { encodeJournalPayload } from "./append-batch.js";
+import {
+  COMPACTED_SNAPSHOT,
+  HASH_BYTES,
+  MAX_PAYLOAD_BYTES,
+  ZERO_HASH,
+  encodeFrame,
+  type CompactedRecord,
+  type CompactedSnapshotPayload,
+  type FrameHeader,
+  type JournalRecord,
+} from "./frame-codec.js";
+import { appendAndSync } from "./journal-files.js";
+
+export interface JournalCompactionResult {
+  receipt: { beforeBytes: number; afterBytes: number; records: number };
+  records: JournalRecord[];
+  epoch: string;
+  nextSeq: number;
+  previousFrameHash: string;
+  knownFileBytes: number;
+}
+
+export function compactJournalFile(input: {
+  path: string;
+  partition: string;
+  entries: readonly JournalRecord[];
+  knownFileBytes: number;
+  now: () => Date;
+}): JournalCompactionResult | null {
+  if (input.entries.length === 0) return null;
+  const logical: CompactedRecord[] = input.entries.map((record) => ({
+    time: record.time,
+    type: record.type,
+    payload: cloneJson(record.payload),
+  }));
+  const compressed = gzipSync(Buffer.from(JSON.stringify(logical)));
+  const payload: CompactedSnapshotPayload = {
+    version: 1,
+    count: logical.length,
+    encoding: "gzip-base64",
+    data: compressed.toString("base64"),
+  };
+  const payloadBytes = encodeJournalPayload(payload);
+  if (payloadBytes.length > MAX_PAYLOAD_BYTES) return null;
+  const epoch = randomUUID();
+  const header: FrameHeader = {
+    partition: input.partition,
+    epoch,
+    seq: 1,
+    previousFrameHash: ZERO_HASH,
+    time: input.now().toISOString(),
+    type: COMPACTED_SNAPSHOT,
+    logicalSpan: logical.length,
+  };
+  const frame = encodeFrame(header, payloadBytes);
+  if (frame.length >= input.knownFileBytes) return null;
+  const temp = `${input.path}.${randomUUID()}.compact`;
+  const tempFd = openSync(temp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  try {
+    appendAndSync(tempFd, frame);
+  } finally {
+    closeSync(tempFd);
+  }
+  renameSync(temp, input.path);
+  fsyncDirectory(dirname(input.path));
+  const frameHash = frame.subarray(frame.length - HASH_BYTES).toString("hex");
+  const records = logical.map((record, index) => ({
+    partition: input.partition,
+    epoch,
+    seq: index + 1,
+    previousFrameHash: index === 0 ? ZERO_HASH : frameHash,
+    frameHash,
+    time: record.time,
+    type: record.type,
+    payload: cloneJson(record.payload),
+    byteOffset: 0,
+  }));
+  return {
+    receipt: {
+      beforeBytes: input.knownFileBytes,
+      afterBytes: frame.length,
+      records: logical.length,
+    },
+    records,
+    epoch,
+    nextSeq: logical.length + 1,
+    previousFrameHash: frameHash,
+    knownFileBytes: frame.length,
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/packages/journal/src/journal-cursor.ts
+++ b/packages/journal/src/journal-cursor.ts
@@ -1,0 +1,16 @@
+export class JournalCursorError extends Error {
+  readonly code = "journal_cursor_invalid";
+  readonly status = 409;
+  readonly retryable = true;
+  readonly requiredActions = ["resnapshot"];
+}
+
+export function encodeCursor(partition: string, epoch: string, seq: number): string {
+  return Buffer.from(JSON.stringify({ v: 1, p: partition, e: epoch, s: seq })).toString(
+    "base64url",
+  );
+}
+
+export function cursorError(detail: string): JournalCursorError {
+  return new JournalCursorError(`journal cursor is ${detail}; resnapshot is required`);
+}

--- a/packages/journal/src/journal-files.ts
+++ b/packages/journal/src/journal-files.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeSync,
+} from "node:fs";
+import { dirname } from "node:path";
+import { fsyncDirectory } from "@claudexor/util";
+
+export interface AppendIntent {
+  v: 1;
+  offset: number;
+  length: number;
+}
+
+export function appendAndSync(fd: number, bytes: Buffer): void {
+  let offset = 0;
+  while (offset < bytes.length) offset += writeSync(fd, bytes, offset, bytes.length - offset);
+  fsyncSync(fd);
+}
+
+export function ensurePrivateFile(path: string): void {
+  if (!existsSync(path)) {
+    const fd = openSync(path, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+    fsyncDirectory(dirname(path));
+  }
+  const stat = lstatSync(path);
+  if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) {
+    throw new Error("journal path is not a private regular file");
+  }
+}
+
+export function readDescriptor(fd: number): Buffer {
+  const size = Number(fstatSync(fd, { bigint: true }).size);
+  if (!Number.isSafeInteger(size) || size < 0) throw new Error("journal file size is invalid");
+  const bytes = readFileSync(fd);
+  if (bytes.length !== size) throw new Error("journal changed while being read");
+  return bytes;
+}
+
+export function readIntent(path: string): AppendIntent | null {
+  if (!existsSync(path)) return null;
+  const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+  try {
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.nlink !== 1 || stat.size > 1024) throw new Error("unsafe file");
+    const value = JSON.parse(readFileSync(fd, "utf8")) as unknown;
+    if (
+      !isRecord(value) ||
+      value.v !== 1 ||
+      !Number.isSafeInteger(value.offset) ||
+      Number(value.offset) < 0 ||
+      !Number.isSafeInteger(value.length) ||
+      Number(value.length) <= 0
+    ) {
+      throw new Error("invalid shape");
+    }
+    return value as unknown as AppendIntent;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+export function writeIntent(path: string, value: AppendIntent): void {
+  const temp = `${path}.${randomUUID()}.tmp`;
+  const bytes = Buffer.from(`${JSON.stringify(value)}\n`);
+  const fd = openSync(temp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
+  try {
+    let offset = 0;
+    while (offset < bytes.length) offset += writeSync(fd, bytes, offset, bytes.length - offset);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+  renameSync(temp, path);
+  fsyncDirectory(dirname(path));
+}
+
+export function removeFile(path: string): void {
+  if (!existsSync(path)) return;
+  rmSync(path);
+  fsyncDirectory(dirname(path));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/journal/src/journal-partition.ts
+++ b/packages/journal/src/journal-partition.ts
@@ -1,0 +1,9 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+
+export function journalPartitionDirectory(rootDir: string, partition: string): string {
+  if (!partition.trim()) throw new Error("journal partition must not be empty");
+  const slug = partition.replace(/[^A-Za-z0-9._-]+/g, "-").slice(0, 48) || "partition";
+  const digest = createHash("sha256").update(Buffer.from(partition)).digest("hex");
+  return join(rootDir, `${slug}-${digest.slice(0, 12)}`);
+}

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -147,7 +147,7 @@ describe("DurableJournal read-only preparation", () => {
     expect(existsSync(join(partitionDir, "append.pending.json"))).toBe(false);
     expect(prepared.records().map((record) => record.type)).toEqual([
       "accepted",
-      "journal.recovery_discarded_append",
+      "journal.recovery_tail_discarded",
     ]);
     prepared.close();
   });

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  DurableJournal,
+  journalPartitionDirectory,
+  type DurableJournalOptions,
+  type JournalRecord,
+  type JournalRecoveryState,
+} from "./index.js";
+
+interface JournalPreparationReceipt {
+  fingerprint: string;
+  virtual: boolean;
+  deferredRepair: null | {
+    kind: "discard_unacknowledged_append";
+    discardedBytes: number;
+  };
+}
+
+interface PreparedJournal extends DurableJournal {
+  preparation(): JournalPreparationReceipt;
+  revalidatePreparation(): void;
+  activatePrepared(): void;
+}
+
+function prepareJournal(options: DurableJournalOptions): PreparedJournal {
+  const prepare = (
+    DurableJournal as unknown as {
+      prepare(options: DurableJournalOptions): PreparedJournal;
+    }
+  ).prepare;
+  return prepare(options);
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-journal-prepare-")));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function treeReceipt(path: string): string {
+  const hash = createHash("sha256");
+  const visit = (entryPath: string, relative: string): void => {
+    if (!existsSync(entryPath)) {
+      hash.update(`missing\0${relative}\0`);
+      return;
+    }
+    const stat = lstatSync(entryPath, { bigint: true });
+    hash.update(
+      `${relative}\0${stat.mode}\0${stat.uid}\0${stat.gid}\0${stat.nlink}\0${stat.size}\0${stat.mtimeNs}\0${stat.ctimeNs}\0`,
+    );
+    if (stat.isFile()) hash.update(readFileSync(entryPath));
+    if (stat.isDirectory()) {
+      for (const name of readdirSync(entryPath).sort()) {
+        visit(join(entryPath, name), relative ? `${relative}/${name}` : name);
+      }
+    }
+  };
+  visit(path, "");
+  return hash.digest("hex");
+}
+
+function preparedState(value: PreparedJournal): {
+  state: JournalRecoveryState;
+  records: JournalRecord[];
+  receipt: JournalPreparationReceipt;
+} {
+  return { state: value.state(), records: value.records(), receipt: value.preparation() };
+}
+
+describe("DurableJournal read-only preparation", () => {
+  it("keeps a missing registered partition virtual until explicit activation", () => {
+    const journalRoot = join(root, "journal");
+    const partitionDir = journalPartitionDirectory(journalRoot, "project:missing");
+    const before = treeReceipt(root);
+
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "project:missing" });
+    expect(preparedState(prepared)).toMatchObject({
+      state: { status: "ready" },
+      records: [],
+      receipt: { virtual: true, deferredRepair: null },
+    });
+    expect(existsSync(journalRoot)).toBe(false);
+    expect(existsSync(partitionDir)).toBe(false);
+    expect(treeReceipt(root)).toBe(before);
+
+    prepared.revalidatePreparation();
+    expect(treeReceipt(root)).toBe(before);
+    prepared.activatePrepared();
+    expect(existsSync(partitionDir)).toBe(true);
+    expect(prepared.state().status).toBe("ready");
+    prepared.close();
+  });
+
+  it("defers an uncertain append repair without truncating, deleting intent, or appending a receipt", () => {
+    const journalRoot = join(root, "journal");
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.append("accepted", { value: 1 });
+    seeded.close();
+    const crashed = new DurableJournal({
+      rootDir: journalRoot,
+      partition: "global",
+      appendAndSync: (fd, frame) => {
+        writeSync(fd, frame, 0, 3);
+        throw new Error("simulated uncertain append");
+      },
+    });
+    expect(() => crashed.append("unacknowledged", { value: 2 })).toThrow(/uncertain/);
+    const partitionDir = crashed.partitionDir;
+    crashed.close();
+    const before = treeReceipt(partitionDir);
+
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    expect(preparedState(prepared)).toMatchObject({
+      state: { status: "ready" },
+      records: [{ type: "accepted", payload: { value: 1 } }],
+      receipt: {
+        virtual: false,
+        deferredRepair: { kind: "discard_unacknowledged_append", discardedBytes: 3 },
+      },
+    });
+    expect(treeReceipt(partitionDir)).toBe(before);
+    expect(existsSync(join(partitionDir, "append.pending.json"))).toBe(true);
+    prepared.revalidatePreparation();
+    prepared.activatePrepared();
+    expect(existsSync(join(partitionDir, "append.pending.json"))).toBe(false);
+    expect(prepared.records().map((record) => record.type)).toEqual([
+      "accepted",
+      "journal.recovery_discarded_append",
+    ]);
+    prepared.close();
+  });
+
+  it("reports corrupt and non-private input without changing bytes or permissions", () => {
+    const journalRoot = join(root, "journal");
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.append("accepted", { value: 1 });
+    const path = seeded.path;
+    const partitionDir = seeded.partitionDir;
+    seeded.close();
+    const bytes = readFileSync(path);
+    bytes[0] = (bytes[0] ?? 0) ^ 0xff;
+    rmSync(path);
+    const fd = openSync(path, "wx", 0o600);
+    writeFileSync(fd, bytes);
+    closeSync(fd);
+    chmodSync(path, 0o640);
+    const before = treeReceipt(partitionDir);
+    const mode = statSync(path).mode & 0o777;
+
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    expect(prepared.state().status).toBe("recovery_required");
+    expect(treeReceipt(partitionDir)).toBe(before);
+    expect(statSync(path).mode & 0o777).toBe(mode);
+    prepared.close();
+  });
+
+  it("fails closed before activation when any prepared byte changes", () => {
+    const journalRoot = join(root, "journal");
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.append("accepted", { value: 1 });
+    const path = seeded.path;
+    seeded.close();
+
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    const fd = openSync(path, "a");
+    writeFileSync(fd, Buffer.from([0]));
+    closeSync(fd);
+    const changed = treeReceipt(prepared.partitionDir);
+
+    expect(() => prepared.revalidatePreparation()).toThrow(/changed since read-only preparation/);
+    expect(() => prepared.activatePrepared()).toThrow(/changed since read-only preparation/);
+    expect(treeReceipt(prepared.partitionDir)).toBe(changed);
+    prepared.close();
+  });
+});

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -1,22 +1,26 @@
 import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import {
   chmodSync,
   closeSync,
   existsSync,
   lstatSync,
+  mkdirSync,
   mkdtempSync,
   openSync,
   readFileSync,
   readdirSync,
   realpathSync,
+  renameSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
   writeSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DurableJournal,
   journalPartitionDirectory,
@@ -27,6 +31,7 @@ import {
 
 interface JournalPreparationReceipt {
   fingerprint: string;
+  preparationIdentity: string;
   virtual: boolean;
   deferredRepair: null | {
     kind: "discard_unacknowledged_append";
@@ -174,8 +179,13 @@ describe("DurableJournal read-only preparation", () => {
     const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
     const receiptBefore = prepared.preparation();
     expect(prepared.records()).toHaveLength(logicalRecordCount);
-    expect(Object.keys(receiptBefore).sort()).toEqual(["deferredRepair", "fingerprint", "virtual"]);
-    expect(JSON.stringify(receiptBefore).length).toBeLessThan(256);
+    expect(Object.keys(receiptBefore).sort()).toEqual([
+      "deferredRepair",
+      "fingerprint",
+      "preparationIdentity",
+      "virtual",
+    ]);
+    expect(JSON.stringify(receiptBefore).length).toBeLessThan(384);
     prepared.activatePrepared();
     expect(prepared.records()).toHaveLength(logicalRecordCount);
     expect(prepared.preparation()).toEqual(receiptBefore);
@@ -261,6 +271,169 @@ describe("DurableJournal read-only preparation", () => {
     expect(() => prepared.revalidatePreparation()).toThrow(/changed since read-only preparation/);
     expect(() => prepared.activatePrepared()).toThrow(/changed since read-only preparation/);
     expect(treeReceipt(prepared.partitionDir)).toBe(changed);
+    prepared.close();
+  });
+
+  it("treats an existing non-directory partition path as recovery-required without writes", () => {
+    for (const kind of ["regular", "symlink"] as const) {
+      const journalRoot = join(root, `non-directory-${kind}`);
+      const partitionDir = journalPartitionDirectory(journalRoot, "global");
+      mkdirSync(journalRoot, { mode: 0o700 });
+      if (kind === "regular") {
+        writeFileSync(partitionDir, "partition-sentinel", { mode: 0o600 });
+      } else {
+        const outside = join(root, `outside-${kind}`);
+        mkdirSync(outside, { mode: 0o700 });
+        writeFileSync(join(outside, "sentinel"), "outside-sentinel", { mode: 0o600 });
+        symlinkSync(outside, partitionDir);
+      }
+      const before = treeReceipt(root);
+
+      const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+      expect(prepared.state()).toMatchObject({ status: "recovery_required" });
+      expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+      expect(treeReceipt(root)).toBe(before);
+      prepared.close();
+    }
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "treats a FIFO partition path as recovery-required without opening it",
+    () => {
+      const journalRoot = join(root, "fifo-partition");
+      const partitionDir = journalPartitionDirectory(journalRoot, "global");
+      mkdirSync(journalRoot, { mode: 0o700 });
+      execFileSync("mkfifo", [partitionDir]);
+      const before = treeReceipt(root);
+
+      const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+      expect(prepared.state()).toMatchObject({ status: "recovery_required" });
+      expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+      expect(treeReceipt(root)).toBe(before);
+      prepared.close();
+    },
+  );
+
+  it("rejects non-private trusted roots, journal roots, and partitions without tightening modes", () => {
+    for (const target of ["trusted-root", "root", "partition"] as const) {
+      const daemonRoot = join(root, `public-${target}`);
+      let journalRoot = daemonRoot;
+      mkdirSync(daemonRoot, { mode: 0o700 });
+      if (target === "trusted-root") journalRoot = join(daemonRoot, "journal");
+      const partitionDir = journalPartitionDirectory(journalRoot, "global");
+      if (target === "partition") mkdirSync(partitionDir, { mode: 0o700 });
+      const unsafePath =
+        target === "trusted-root" ? daemonRoot : target === "root" ? journalRoot : partitionDir;
+      chmodSync(unsafePath, 0o755);
+      const before = treeReceipt(root);
+
+      const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+      expect(prepared.state()).toMatchObject({ status: "recovery_required" });
+      expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+      expect(treeReceipt(root)).toBe(before);
+      expect(statSync(unsafePath).mode & 0o777).toBe(0o755);
+      prepared.close();
+    }
+  });
+
+  it.runIf(typeof process.getuid === "function")(
+    "reports a foreign-owned root through a privilege-free uid observation",
+    () => {
+      const journalRoot = join(root, "foreign-owner");
+      mkdirSync(journalRoot, { mode: 0o700 });
+      const actualUid = process.getuid!();
+      const uid = vi.spyOn(process, "getuid").mockReturnValue(actualUid + 1);
+      try {
+        const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+        expect(prepared.state()).toMatchObject({ status: "recovery_required" });
+        expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+        prepared.close();
+      } finally {
+        uid.mockRestore();
+      }
+      expect(statSync(journalRoot).uid).toBe(actualUid);
+    },
+  );
+
+  it("rejects a symlinked root ancestor without reading or writing the outside tree", () => {
+    for (const kind of ["root", "ancestor"] as const) {
+      const outside = join(root, `outside-journal-${kind}`);
+      mkdirSync(outside, { mode: 0o700 });
+      writeFileSync(join(outside, "sentinel"), "outside-sentinel", { mode: 0o600 });
+      const link = join(root, `journal-${kind}-link`);
+      let journalRoot = link;
+      if (kind === "ancestor") {
+        mkdirSync(join(outside, "journal"), { mode: 0o700 });
+        journalRoot = join(link, "journal");
+      }
+      symlinkSync(outside, link);
+      const before = treeReceipt(root);
+
+      const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+      expect(prepared.state()).toMatchObject({ status: "recovery_required" });
+      expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+      expect(treeReceipt(root)).toBe(before);
+      expect(readFileSync(join(outside, "sentinel"), "utf8")).toBe("outside-sentinel");
+      prepared.close();
+    }
+  });
+
+  it("detects a byte-identical partition-root replacement by path identity", () => {
+    const journalRoot = join(root, "identity-replacement");
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.append("accepted", { value: 1 });
+    const partitionDir = seeded.partitionDir;
+    const journalBytes = readFileSync(seeded.path);
+    seeded.close();
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    renameSync(partitionDir, `${partitionDir}.original`);
+    mkdirSync(partitionDir, { mode: 0o700 });
+    writeFileSync(join(partitionDir, "journal.bin"), journalBytes, { mode: 0o600 });
+    const replacement = treeReceipt(partitionDir);
+
+    expect(() => prepared.revalidatePreparation()).toThrow(/changed since read-only preparation/);
+    expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+    expect(treeReceipt(partitionDir)).toBe(replacement);
+    prepared.close();
+  });
+
+  it("contains traversal-like partition ids inside the journal root", () => {
+    const journalRoot = join(root, "traversal-journal");
+    const outside = join(root, "outside-partition");
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "../../outside-partition" });
+
+    expect(prepared.partitionDir.startsWith(`${journalRoot}/`)).toBe(true);
+    expect(existsSync(outside)).toBe(false);
+    prepared.activatePrepared();
+    expect(existsSync(prepared.partitionDir)).toBe(true);
+    expect(existsSync(outside)).toBe(false);
+    prepared.close();
+  });
+
+  it("closes and poisons a direct prepared writer when post-open replay fails", () => {
+    const journalRoot = join(root, "direct-writer-cleanup");
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.append("accepted", { value: 1 });
+    seeded.close();
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    const originalRevalidate = prepared.revalidatePreparation.bind(prepared);
+    prepared.revalidatePreparation = () => {
+      originalRevalidate();
+      const fd = openSync(prepared.path, "a");
+      try {
+        writeSync(fd, Buffer.from([0]));
+      } finally {
+        closeSync(fd);
+      }
+    };
+
+    expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+    const internals = prepared as unknown as { fd: number; writable: boolean };
+    expect(internals.fd).toBe(-1);
+    expect(internals.writable).toBe(false);
+    expect(prepared.state()).toMatchObject({ status: "recovery_required" });
+    expect(() => prepared.activatePrepared()).toThrow(/requires recovery/);
+    expect(() => prepared.append("must-not-write", {})).toThrow(/requires recovery/);
     prepared.close();
   });
 });

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -113,6 +113,75 @@ describe("DurableJournal read-only preparation", () => {
     prepared.close();
   });
 
+  it("matches normal reopen compaction when a prepared journal is promoted", () => {
+    const seed = (journalRoot: string): number => {
+      const journal = new DurableJournal({
+        rootDir: journalRoot,
+        partition: "global",
+        now: () => new Date("2026-08-13T00:00:00.000Z"),
+        epochFactory: () => "seed-epoch",
+      });
+      for (let index = 0; index < 100; index += 1) {
+        journal.append("probe.saved", { index, repeated: "same-value".repeat(20) });
+      }
+      const bytes = journal.physicalBytes();
+      journal.close();
+      return bytes;
+    };
+    const normalRoot = join(root, "normal");
+    const preparedRoot = join(root, "prepared");
+    const normalBefore = seed(normalRoot);
+    const preparedBefore = seed(preparedRoot);
+
+    const normal = new DurableJournal({
+      rootDir: normalRoot,
+      partition: "global",
+      compactionThresholdBytes: 1,
+      now: () => new Date("2026-08-13T00:00:00.000Z"),
+    });
+    const promoted = prepareJournal({
+      rootDir: preparedRoot,
+      partition: "global",
+      compactionThresholdBytes: 1,
+      now: () => new Date("2026-08-13T00:00:00.000Z"),
+    });
+    expect(promoted.physicalBytes()).toBe(preparedBefore);
+    promoted.activatePrepared();
+
+    expect(normal.physicalBytes()).toBeLessThan(normalBefore);
+    expect(promoted.physicalBytes()).toBeLessThan(preparedBefore);
+    expect(promoted.physicalBytes()).toBe(normal.physicalBytes());
+    expect(promoted.records().map(({ type, payload }) => ({ type, payload }))).toEqual(
+      normal.records().map(({ type, payload }) => ({ type, payload })),
+    );
+    normal.close();
+    promoted.close();
+  });
+
+  it("keeps only a compact receipt alongside a prepared large logical history", () => {
+    const journalRoot = join(root, "large-history");
+    const logicalRecordCount = 20_000;
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.appendBatch(
+      Array.from({ length: logicalRecordCount }, (_, index) => ({
+        type: "grown.history",
+        payload: { index, repeated: "same-value" },
+      })),
+    );
+    expect(seeded.compact()).toMatchObject({ records: logicalRecordCount });
+    seeded.close();
+
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    const receiptBefore = prepared.preparation();
+    expect(prepared.records()).toHaveLength(logicalRecordCount);
+    expect(Object.keys(receiptBefore).sort()).toEqual(["deferredRepair", "fingerprint", "virtual"]);
+    expect(JSON.stringify(receiptBefore).length).toBeLessThan(256);
+    prepared.activatePrepared();
+    expect(prepared.records()).toHaveLength(logicalRecordCount);
+    expect(prepared.preparation()).toEqual(receiptBefore);
+    prepared.close();
+  });
+
   it("defers an uncertain append repair without truncating, deleting intent, or appending a receipt", () => {
     const journalRoot = join(root, "journal");
     const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });

--- a/packages/journal/src/read-only-preparation.ts
+++ b/packages/journal/src/read-only-preparation.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import {
+  type BigIntStats,
   closeSync,
   constants,
   fstatSync,
@@ -10,11 +11,12 @@ import {
   readlinkSync,
   realpathSync,
 } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { ZERO_HASH, replayFrames, type JournalRecord } from "./frame-codec.js";
 
 export interface JournalPreparationReceipt {
   fingerprint: string;
+  preparationIdentity: string;
   virtual: boolean;
   deferredRepair: null | {
     kind: "discard_unacknowledged_append";
@@ -49,6 +51,7 @@ interface AppendIntent {
 
 interface TreeSnapshot {
   fingerprint: string;
+  preparationIdentity: string;
   rootExists: boolean;
   partitionExists: boolean;
   entries: Set<string>;
@@ -123,7 +126,12 @@ export function inspectPreparedJournal(input: {
   const last = records.at(-1);
   const virtual = !tree.rootExists || !tree.partitionExists || journalBytes === undefined;
   return {
-    receipt: { fingerprint: tree.fingerprint, virtual, deferredRepair },
+    receipt: {
+      fingerprint: tree.fingerprint,
+      preparationIdentity: tree.preparationIdentity,
+      virtual,
+      deferredRepair,
+    },
     recovery: problem
       ? {
           status: "recovery_required",
@@ -140,45 +148,88 @@ export function inspectPreparedJournal(input: {
   };
 }
 
-export function fingerprintPreparedJournal(rootDir: string, partitionDir: string): string {
-  return snapshotTree(rootDir, partitionDir).fingerprint;
+export function fingerprintPreparedJournal(
+  rootDir: string,
+  partitionDir: string,
+): Pick<JournalPreparationReceipt, "fingerprint" | "preparationIdentity"> {
+  const observed = snapshotTree(rootDir, partitionDir);
+  return {
+    fingerprint: observed.fingerprint,
+    preparationIdentity: observed.preparationIdentity,
+  };
 }
 
 function snapshotTree(rootDir: string, partitionDir: string): TreeSnapshot {
-  const hash = createHash("sha256");
+  const contentHash = createHash("sha256");
+  const identityHash = createHash("sha256");
   const files = new Map<string, Buffer>();
   const entries = new Set<string>();
   const problems: string[] = [];
-  const root = inspectEntry(rootDir, "root", hash, files, problems, true);
+  if (!inspectTrustedParent(dirname(resolve(rootDir)), identityHash, problems)) {
+    contentHash.update("root\0unreachable\0");
+    return finishSnapshot({
+      contentHash,
+      identityHash,
+      rootExists: false,
+      partitionExists: false,
+      entries,
+      files,
+      problems,
+    });
+  }
+  const root = inspectEntry(rootDir, "root", contentHash, identityHash, files, problems, false);
   if (root.kind !== "directory") {
-    hash.update("partition\0unreachable\0");
-    return {
-      fingerprint: hash.digest("hex"),
+    contentHash.update("partition\0unreachable\0");
+    identityHash.update("partition\0unreachable\0");
+    return finishSnapshot({
+      contentHash,
+      identityHash,
       rootExists: root.kind !== "missing",
       partitionExists: false,
       entries,
       files,
       problems,
-    };
+    });
   }
-  const partition = inspectEntry(partitionDir, "partition", hash, files, problems, true);
+  const partition = inspectEntry(
+    partitionDir,
+    "partition",
+    contentHash,
+    identityHash,
+    files,
+    problems,
+    false,
+  );
   if (partition.kind === "directory") {
-    walkPartition(partitionDir, partitionDir, hash, files, entries, problems);
+    walkPartition(
+      partitionDir,
+      partitionDir,
+      partition.stat,
+      contentHash,
+      identityHash,
+      files,
+      entries,
+      problems,
+    );
   }
-  return {
-    fingerprint: hash.digest("hex"),
+  assertDirectoryUnchanged(rootDir, root.stat, problems, "root");
+  return finishSnapshot({
+    contentHash,
+    identityHash,
     rootExists: true,
     partitionExists: partition.kind !== "missing",
     entries,
     files,
     problems,
-  };
+  });
 }
 
 function walkPartition(
   path: string,
   partitionDir: string,
-  hash: ReturnType<typeof createHash>,
+  before: BigIntStats,
+  contentHash: ReturnType<typeof createHash>,
+  identityHash: ReturnType<typeof createHash>,
   files: Map<string, Buffer>,
   entries: Set<string>,
   problems: string[],
@@ -188,86 +239,249 @@ function walkPartition(
     names = readdirSync(path).sort();
   } catch (error) {
     problems.push(`journal partition cannot be listed: ${safeMessage(error)}`);
-    hash.update(`list-error\0${safeMessage(error)}\0`);
+    contentHash.update(`list-error\0${safeMessage(error)}\0`);
+    identityHash.update(`list-error\0${safeMessage(error)}\0`);
     return;
   }
   for (const name of names) {
     const child = `${path}/${name}`;
     const relative = child.slice(partitionDir.length + 1);
     entries.add(child);
-    const inspected = inspectEntry(child, relative, hash, files, problems, true);
+    const inspected = inspectEntry(
+      child,
+      relative,
+      contentHash,
+      identityHash,
+      files,
+      problems,
+      true,
+    );
     if (inspected.kind === "directory") {
-      walkPartition(child, partitionDir, hash, files, entries, problems);
+      walkPartition(
+        child,
+        partitionDir,
+        inspected.stat,
+        contentHash,
+        identityHash,
+        files,
+        entries,
+        problems,
+      );
     }
   }
+  try {
+    if (readdirSync(path).sort().join("\0") !== names.join("\0")) {
+      problems.push(`journal directory entries changed while being read: ${path}`);
+    }
+  } catch (error) {
+    problems.push(`journal partition cannot be relisted: ${safeMessage(error)}`);
+  }
+  assertDirectoryUnchanged(path, before, problems, path);
 }
 
 function inspectEntry(
   path: string,
   label: string,
-  hash: ReturnType<typeof createHash>,
+  contentHash: ReturnType<typeof createHash>,
+  identityHash: ReturnType<typeof createHash>,
   files: Map<string, Buffer>,
   problems: string[],
-  strictMode: boolean,
-): { kind: "missing" | "directory" | "file" | "other" } {
-  let stat: ReturnType<typeof lstatSync>;
+  allowFile: boolean,
+): { kind: "missing" | "other" } | { kind: "directory" | "file"; stat: BigIntStats } {
+  let stat: BigIntStats;
   try {
-    stat = lstatSync(path);
+    stat = lstatSync(path, { bigint: true });
   } catch (error) {
     if (errorCode(error) === "ENOENT") {
-      hash.update(`${label}\0missing\0`);
+      contentHash.update(`${label}\0missing\0`);
+      identityHash.update(`${label}\0missing\0`);
+      assertStillMissing(path, problems, label);
       return { kind: "missing" };
     }
     problems.push(`${label} cannot be inspected: ${safeMessage(error)}`);
-    hash.update(`${label}\0error\0${safeMessage(error)}\0`);
+    contentHash.update(`${label}\0error\0${safeMessage(error)}\0`);
+    identityHash.update(`${label}\0error\0${safeMessage(error)}\0`);
     return { kind: "other" };
   }
-  hash.update(
-    stat.isDirectory() && label === "root"
-      ? `${label}\0${stat.dev}\0${stat.ino}\0${stat.mode}\0${stat.uid}\0${stat.gid}\0`
-      : `${label}\0${stat.dev}\0${stat.ino}\0${stat.mode}\0${stat.uid}\0${stat.gid}\0${stat.nlink}\0${stat.size}\0${stat.mtimeMs}\0${stat.ctimeMs}\0`,
-  );
+  contentHash.update(`${label}\0${semanticMetadata(stat)}\0`);
+  identityHash.update(`${label}\0${identityMetadata(stat)}\0`);
   if (stat.isSymbolicLink()) {
-    hash.update(`symlink\0${readlinkSync(path)}\0`);
+    try {
+      const target = readlinkSync(path);
+      contentHash.update(`symlink\0${target}\0`);
+      identityHash.update(`symlink\0${target}\0`);
+    } catch (error) {
+      problems.push(`${label} symbolic-link target cannot be read: ${safeMessage(error)}`);
+    }
     problems.push(`${label} is a symbolic link`);
     return { kind: "other" };
   }
-  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+  if (typeof process.getuid === "function" && stat.uid !== BigInt(process.getuid())) {
     problems.push(`${label} is not owned by the current user`);
   }
   if (stat.isDirectory()) {
-    if (realpathSync.native(path) !== resolve(path)) problems.push(`${label} is not canonical`);
-    if (strictMode && process.platform !== "win32" && (stat.mode & 0o777) !== 0o700) {
-      problems.push(`${label} is not private`);
+    let safe = true;
+    try {
+      if (realpathSync.native(path) !== resolve(path)) {
+        problems.push(`${label} is not canonical`);
+        safe = false;
+      }
+    } catch (error) {
+      problems.push(`${label} cannot be resolved canonically: ${safeMessage(error)}`);
+      safe = false;
     }
-    return { kind: "directory" };
+    if (process.platform !== "win32" && Number(stat.mode & 0o777n) !== 0o700) {
+      problems.push(`${label} is not private`);
+      safe = false;
+    }
+    if (typeof process.getuid === "function" && stat.uid !== BigInt(process.getuid())) safe = false;
+    return safe ? { kind: "directory", stat } : { kind: "other" };
   }
-  if (!stat.isFile() || stat.nlink !== 1) {
+  if (!allowFile || !stat.isFile() || stat.nlink !== 1n) {
     problems.push(`${label} is not a private regular file`);
     return { kind: "other" };
   }
-  if (strictMode && process.platform !== "win32" && (stat.mode & 0o777) !== 0o600) {
+  if (process.platform !== "win32" && Number(stat.mode & 0o777n) !== 0o600) {
     problems.push(`${label} is not private`);
   }
   try {
     const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
     try {
-      const opened = fstatSync(fd);
-      if (opened.dev !== stat.dev || opened.ino !== stat.ino || !opened.isFile()) {
+      const opened = fstatSync(fd, { bigint: true });
+      if (
+        opened.dev !== stat.dev ||
+        opened.ino !== stat.ino ||
+        !opened.isFile() ||
+        observationMetadata(opened) !== observationMetadata(stat)
+      ) {
         throw new Error("pathname identity changed while being read");
       }
       const bytes = readFileSync(fd);
-      if (bytes.length !== opened.size) throw new Error("file changed while being read");
+      const after = fstatSync(fd, { bigint: true });
+      if (
+        BigInt(bytes.length) !== opened.size ||
+        observationMetadata(opened) !== observationMetadata(after)
+      ) {
+        throw new Error("file changed while being read");
+      }
+      const namedAfter = lstatSync(path, { bigint: true });
+      if (observationMetadata(stat) !== observationMetadata(namedAfter)) {
+        throw new Error("pathname identity changed after being read");
+      }
       files.set(path, bytes);
-      hash.update(bytes);
+      contentHash.update(bytes);
     } finally {
       closeSync(fd);
     }
   } catch (error) {
     problems.push(`${label} cannot be read safely: ${safeMessage(error)}`);
-    hash.update(`read-error\0${safeMessage(error)}\0`);
+    contentHash.update(`read-error\0${safeMessage(error)}\0`);
+    identityHash.update(`read-error\0${safeMessage(error)}\0`);
   }
-  return { kind: "file" };
+  return { kind: "file", stat };
+}
+
+function finishSnapshot(input: {
+  contentHash: ReturnType<typeof createHash>;
+  identityHash: ReturnType<typeof createHash>;
+  rootExists: boolean;
+  partitionExists: boolean;
+  entries: Set<string>;
+  files: Map<string, Buffer>;
+  problems: string[];
+}): TreeSnapshot {
+  const fingerprint = input.contentHash.digest("hex");
+  input.identityHash.update(`content\0${fingerprint}\0`);
+  return {
+    fingerprint,
+    preparationIdentity: input.identityHash.digest("hex"),
+    rootExists: input.rootExists,
+    partitionExists: input.partitionExists,
+    entries: input.entries,
+    files: input.files,
+    problems: input.problems,
+  };
+}
+
+function inspectTrustedParent(
+  path: string,
+  identityHash: ReturnType<typeof createHash>,
+  problems: string[],
+): boolean {
+  try {
+    const before = lstatSync(path, { bigint: true });
+    identityHash.update(`trusted-parent\0${identityMetadata(before)}\0`);
+    if (
+      before.isSymbolicLink() ||
+      !before.isDirectory() ||
+      realpathSync.native(path) !== path ||
+      (typeof process.getuid === "function" && before.uid !== BigInt(process.getuid())) ||
+      (process.platform !== "win32" && Number(before.mode & 0o777n) !== 0o700)
+    ) {
+      problems.push("journal root parent is not canonical and private");
+      return false;
+    }
+    const after = lstatSync(path, { bigint: true });
+    if (observationMetadata(before) !== observationMetadata(after)) {
+      problems.push("journal root parent changed while being inspected");
+      return false;
+    }
+    return true;
+  } catch (error) {
+    problems.push(`journal root parent cannot be inspected: ${safeMessage(error)}`);
+    identityHash.update(`trusted-parent-error\0${safeMessage(error)}\0`);
+    return false;
+  }
+}
+
+function assertDirectoryUnchanged(
+  path: string,
+  before: BigIntStats,
+  problems: string[],
+  label: string,
+): void {
+  try {
+    const after = lstatSync(path, { bigint: true });
+    if (observationMetadata(before) !== observationMetadata(after)) {
+      problems.push(`${label} changed while being inspected`);
+    }
+  } catch (error) {
+    problems.push(`${label} became unavailable while being inspected: ${safeMessage(error)}`);
+  }
+}
+
+function assertStillMissing(path: string, problems: string[], label: string): void {
+  try {
+    lstatSync(path);
+    problems.push(`${label} appeared while being inspected`);
+  } catch (error) {
+    if (errorCode(error) !== "ENOENT") {
+      problems.push(`${label} missing state is ambiguous: ${safeMessage(error)}`);
+    }
+  }
+}
+
+function semanticMetadata(stat: BigIntStats): string {
+  const base = [entryType(stat), stat.mode & 0o777n, stat.uid, stat.gid];
+  if (!stat.isDirectory()) base.push(stat.nlink, stat.size);
+  return base.join(":");
+}
+
+function identityMetadata(stat: BigIntStats): string {
+  const base = [stat.dev, stat.ino, entryType(stat), stat.mode & 0o777n, stat.uid, stat.gid];
+  if (!stat.isDirectory()) base.push(stat.nlink);
+  return base.join(":");
+}
+
+function observationMetadata(stat: BigIntStats): string {
+  return [identityMetadata(stat), stat.size, stat.mtimeNs, stat.ctimeNs].join(":");
+}
+
+function entryType(stat: BigIntStats): string {
+  if (stat.isDirectory()) return "directory";
+  if (stat.isFile()) return "file";
+  if (stat.isSymbolicLink()) return "symlink";
+  return "other";
 }
 
 function parseIntent(bytes: Buffer): AppendIntent {

--- a/packages/journal/src/read-only-preparation.ts
+++ b/packages/journal/src/read-only-preparation.ts
@@ -1,0 +1,301 @@
+import { createHash } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  realpathSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import { ZERO_HASH, replayFrames, type JournalRecord } from "./frame-codec.js";
+
+export interface JournalPreparationReceipt {
+  fingerprint: string;
+  virtual: boolean;
+  deferredRepair: null | {
+    kind: "discard_unacknowledged_append";
+    discardedBytes: number;
+  };
+}
+
+export type PreparedJournalRecovery =
+  | { status: "ready"; discardedTailBytes: number }
+  | {
+      status: "recovery_required";
+      location: { kind: "byte"; byteOffset: number };
+      reason: string;
+      discardedTailBytes: number;
+    };
+
+export interface PreparedJournalInspection {
+  receipt: JournalPreparationReceipt;
+  recovery: PreparedJournalRecovery;
+  records: JournalRecord[];
+  epoch: string;
+  nextSeq: number;
+  previousFrameHash: string;
+  knownFileBytes: number;
+}
+
+interface AppendIntent {
+  v: 1;
+  offset: number;
+  length: number;
+}
+
+interface TreeSnapshot {
+  fingerprint: string;
+  rootExists: boolean;
+  partitionExists: boolean;
+  entries: Set<string>;
+  files: Map<string, Buffer>;
+  problems: string[];
+}
+
+export function inspectPreparedJournal(input: {
+  rootDir: string;
+  partitionDir: string;
+  journalPath: string;
+  intentPath: string;
+  partition: string;
+  initialEpoch: string;
+}): PreparedJournalInspection {
+  const tree = snapshotTree(input.rootDir, input.partitionDir);
+  const journalBytes = tree.files.get(input.journalPath);
+  const intentBytes = tree.files.get(input.intentPath);
+  const unexpected = [...tree.entries].filter(
+    (path) => path !== input.journalPath && path !== input.intentPath,
+  );
+  let problem = tree.problems[0] ?? null;
+  let byteOffset = 0;
+  let deferredRepair: JournalPreparationReceipt["deferredRepair"] = null;
+
+  if (
+    !problem &&
+    journalBytes === undefined &&
+    (intentBytes !== undefined || tree.partitionExists)
+  ) {
+    if (intentBytes !== undefined || unexpected.length > 0) {
+      problem = "journal file is missing while partition state exists";
+    }
+  }
+
+  let logicalBytes = journalBytes ?? Buffer.alloc(0);
+  if (!problem && intentBytes !== undefined) {
+    try {
+      const intent = parseIntent(intentBytes);
+      const prefix = replayFrames(logicalBytes.subarray(0, intent.offset), input.partition);
+      if (
+        intent.offset > logicalBytes.length ||
+        logicalBytes.length > intent.offset + intent.length ||
+        prefix.error ||
+        prefix.incompleteOffset !== null
+      ) {
+        problem = "append intent does not match the journal prefix";
+        byteOffset = intent.offset;
+      } else {
+        deferredRepair = {
+          kind: "discard_unacknowledged_append",
+          discardedBytes: logicalBytes.length - intent.offset,
+        };
+        logicalBytes = logicalBytes.subarray(0, intent.offset);
+      }
+    } catch (error) {
+      problem = `append intent is malformed: ${safeMessage(error)}`;
+    }
+  }
+
+  const decoded = replayFrames(logicalBytes, input.partition);
+  if (!problem && decoded.incompleteOffset !== null) {
+    problem = "unexplained suffix without append intent";
+    byteOffset = decoded.incompleteOffset;
+  }
+  if (!problem && decoded.error) {
+    problem = decoded.error.reason;
+    byteOffset = decoded.error.offset;
+  }
+
+  const records = problem ? [] : decoded.records;
+  const last = records.at(-1);
+  const virtual = !tree.rootExists || !tree.partitionExists || journalBytes === undefined;
+  return {
+    receipt: { fingerprint: tree.fingerprint, virtual, deferredRepair },
+    recovery: problem
+      ? {
+          status: "recovery_required",
+          location: { kind: "byte", byteOffset },
+          reason: problem,
+          discardedTailBytes: 0,
+        }
+      : { status: "ready", discardedTailBytes: 0 },
+    records,
+    epoch: last?.epoch ?? input.initialEpoch,
+    nextSeq: (last?.seq ?? 0) + 1,
+    previousFrameHash: last?.frameHash ?? ZERO_HASH,
+    knownFileBytes: logicalBytes.length,
+  };
+}
+
+export function fingerprintPreparedJournal(rootDir: string, partitionDir: string): string {
+  return snapshotTree(rootDir, partitionDir).fingerprint;
+}
+
+function snapshotTree(rootDir: string, partitionDir: string): TreeSnapshot {
+  const hash = createHash("sha256");
+  const files = new Map<string, Buffer>();
+  const entries = new Set<string>();
+  const problems: string[] = [];
+  const root = inspectEntry(rootDir, "root", hash, files, problems, true);
+  if (root.kind !== "directory") {
+    hash.update("partition\0unreachable\0");
+    return {
+      fingerprint: hash.digest("hex"),
+      rootExists: root.kind !== "missing",
+      partitionExists: false,
+      entries,
+      files,
+      problems,
+    };
+  }
+  const partition = inspectEntry(partitionDir, "partition", hash, files, problems, true);
+  if (partition.kind === "directory") {
+    walkPartition(partitionDir, partitionDir, hash, files, entries, problems);
+  }
+  return {
+    fingerprint: hash.digest("hex"),
+    rootExists: true,
+    partitionExists: partition.kind !== "missing",
+    entries,
+    files,
+    problems,
+  };
+}
+
+function walkPartition(
+  path: string,
+  partitionDir: string,
+  hash: ReturnType<typeof createHash>,
+  files: Map<string, Buffer>,
+  entries: Set<string>,
+  problems: string[],
+): void {
+  let names: string[];
+  try {
+    names = readdirSync(path).sort();
+  } catch (error) {
+    problems.push(`journal partition cannot be listed: ${safeMessage(error)}`);
+    hash.update(`list-error\0${safeMessage(error)}\0`);
+    return;
+  }
+  for (const name of names) {
+    const child = `${path}/${name}`;
+    const relative = child.slice(partitionDir.length + 1);
+    entries.add(child);
+    const inspected = inspectEntry(child, relative, hash, files, problems, true);
+    if (inspected.kind === "directory") {
+      walkPartition(child, partitionDir, hash, files, entries, problems);
+    }
+  }
+}
+
+function inspectEntry(
+  path: string,
+  label: string,
+  hash: ReturnType<typeof createHash>,
+  files: Map<string, Buffer>,
+  problems: string[],
+  strictMode: boolean,
+): { kind: "missing" | "directory" | "file" | "other" } {
+  let stat: ReturnType<typeof lstatSync>;
+  try {
+    stat = lstatSync(path);
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      hash.update(`${label}\0missing\0`);
+      return { kind: "missing" };
+    }
+    problems.push(`${label} cannot be inspected: ${safeMessage(error)}`);
+    hash.update(`${label}\0error\0${safeMessage(error)}\0`);
+    return { kind: "other" };
+  }
+  hash.update(
+    stat.isDirectory() && label === "root"
+      ? `${label}\0${stat.dev}\0${stat.ino}\0${stat.mode}\0${stat.uid}\0${stat.gid}\0`
+      : `${label}\0${stat.dev}\0${stat.ino}\0${stat.mode}\0${stat.uid}\0${stat.gid}\0${stat.nlink}\0${stat.size}\0${stat.mtimeMs}\0${stat.ctimeMs}\0`,
+  );
+  if (stat.isSymbolicLink()) {
+    hash.update(`symlink\0${readlinkSync(path)}\0`);
+    problems.push(`${label} is a symbolic link`);
+    return { kind: "other" };
+  }
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) {
+    problems.push(`${label} is not owned by the current user`);
+  }
+  if (stat.isDirectory()) {
+    if (realpathSync.native(path) !== resolve(path)) problems.push(`${label} is not canonical`);
+    if (strictMode && process.platform !== "win32" && (stat.mode & 0o777) !== 0o700) {
+      problems.push(`${label} is not private`);
+    }
+    return { kind: "directory" };
+  }
+  if (!stat.isFile() || stat.nlink !== 1) {
+    problems.push(`${label} is not a private regular file`);
+    return { kind: "other" };
+  }
+  if (strictMode && process.platform !== "win32" && (stat.mode & 0o777) !== 0o600) {
+    problems.push(`${label} is not private`);
+  }
+  try {
+    const fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    try {
+      const opened = fstatSync(fd);
+      if (opened.dev !== stat.dev || opened.ino !== stat.ino || !opened.isFile()) {
+        throw new Error("pathname identity changed while being read");
+      }
+      const bytes = readFileSync(fd);
+      if (bytes.length !== opened.size) throw new Error("file changed while being read");
+      files.set(path, bytes);
+      hash.update(bytes);
+    } finally {
+      closeSync(fd);
+    }
+  } catch (error) {
+    problems.push(`${label} cannot be read safely: ${safeMessage(error)}`);
+    hash.update(`read-error\0${safeMessage(error)}\0`);
+  }
+  return { kind: "file" };
+}
+
+function parseIntent(bytes: Buffer): AppendIntent {
+  if (bytes.length > 1024) throw new Error("unsafe file");
+  const value = JSON.parse(bytes.toString("utf8")) as unknown;
+  if (
+    !isRecord(value) ||
+    value.v !== 1 ||
+    !Number.isSafeInteger(value.offset) ||
+    Number(value.offset) < 0 ||
+    !Number.isSafeInteger(value.length) ||
+    Number(value.length) <= 0
+  ) {
+    throw new Error("invalid shape");
+  }
+  return value as unknown as AppendIntent;
+}
+
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === "object" && "code" in error
+    ? String((error as { code?: unknown }).code)
+    : undefined;
+}
+
+function safeMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/schema/generated/ControlHandshakeResponse.schema.json
+++ b/packages/schema/generated/ControlHandshakeResponse.schema.json
@@ -42,6 +42,14 @@
           ],
           "additionalProperties": false,
           "description": "Build identity of the serving engine."
+        },
+        "servingMode": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "recovery_only"
+          ],
+          "description": "Product admission: 'recovery_only' keeps normal product routes closed while recovery control stays reachable; absent means 'normal'."
         }
       },
       "required": [

--- a/packages/schema/src/operation.ts
+++ b/packages/schema/src/operation.ts
@@ -36,6 +36,18 @@ export const ControlHandshakeResponse = z
       })
       .strict()
       .describe("Build identity of the serving engine."),
+    /** Product admission of the serving daemon (issue #165 D5). Transport/
+     * protocol success stays separate from product readiness: `recovery_only`
+     * means the recovery control plane is online but normal product routes
+     * are closed; clients keep polling the handshake and hydrate once the
+     * mode is `normal`. Optional on the wire so pre-#165 daemons (which are
+     * always serving normally) remain decodable. */
+    servingMode: z
+      .enum(["normal", "recovery_only"])
+      .optional()
+      .describe(
+        "Product admission: 'recovery_only' keeps normal product routes closed while recovery control stays reachable; absent means 'normal'.",
+      ),
   })
   .strict()
   .describe("Successful control-plane negotiation.");

--- a/scripts/complexity-baseline.json
+++ b/scripts/complexity-baseline.json
@@ -1,5 +1,5 @@
 {
-  "apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel.swift": 1532,
+  "apps/macos/ClaudexorApp/Sources/ClaudexorApp/AppModel.swift": 1479,
   "apps/macos/ClaudexorApp/Sources/ClaudexorApp/AuthSheet.swift": 576,
   "apps/macos/ClaudexorApp/Sources/ClaudexorApp/DomainModels.swift": 624,
   "apps/macos/ClaudexorApp/Sources/ClaudexorApp/OpsScreens.swift": 435,

--- a/scripts/lib/real-harness-battery-state.mjs
+++ b/scripts/lib/real-harness-battery-state.mjs
@@ -109,9 +109,30 @@ function canonicalFuturePath(path) {
   return canonical;
 }
 
-export function assertNoPreexistingDaemon({ statusCode, socketIsAlive, leaseIsAlive }) {
+/** Project the strict daemon writer-lease status into the battery's three
+ * authority facts. A stale owner is healable by the normal start path, but
+ * only physical absence proves cleanup and only a capable owner can be bound
+ * as this battery's shutdown target. */
+export function projectBatteryDaemonLease(status) {
+  if (status?.status === "absent") {
+    return { startAllowed: true, capableOwner: null, physicallyAbsent: true };
+  }
+  if (status?.status === "owned" && status.capability?.status === "proven_stale") {
+    return { startAllowed: true, capableOwner: null, physicallyAbsent: false };
+  }
+  if (status?.status === "owned" && status.capability?.status === "capable") {
+    return {
+      startAllowed: false,
+      capableOwner: status.owner ?? null,
+      physicallyAbsent: false,
+    };
+  }
+  return { startAllowed: false, capableOwner: null, physicallyAbsent: false };
+}
+
+export function assertNoPreexistingDaemon({ statusCode, socketIsAlive, lease }) {
   if (statusCode === 0) throw new Error("refusing a pre-existing Claudexor daemon");
-  if (socketIsAlive || leaseIsAlive) {
+  if (socketIsAlive || !lease.startAllowed) {
     throw new Error("daemon preflight found a live socket or writer-lease owner");
   }
 }

--- a/scripts/lib/real-harness-battery-state.test.mjs
+++ b/scripts/lib/real-harness-battery-state.test.mjs
@@ -24,6 +24,7 @@ import {
   evaluateRequiredNativeRoutes,
   isBatteryRepoRoot,
   isCrossFamilyConvergenceRefusal,
+  projectBatteryDaemonLease,
   relevantRunAttemptKeys,
   resolveRealHarnessBatteryLayout,
   runtimeReplacementIdentityFromHandshake,
@@ -140,12 +141,57 @@ test("daemon preflight fails closed on each live ownership surface", () => {
   const clear = {
     statusCode: 1,
     socketIsAlive: false,
-    leaseIsAlive: false,
+    lease: { startAllowed: true, capableOwner: null, physicallyAbsent: true },
   };
   expect(() => assertNoPreexistingDaemon(clear)).not.toThrow();
   expect(() => assertNoPreexistingDaemon({ ...clear, statusCode: 0 })).toThrow(/pre-existing/);
   expect(() => assertNoPreexistingDaemon({ ...clear, socketIsAlive: true })).toThrow(/live socket/);
-  expect(() => assertNoPreexistingDaemon({ ...clear, leaseIsAlive: true })).toThrow(/writer-lease/);
+  expect(() =>
+    assertNoPreexistingDaemon({
+      ...clear,
+      lease: { startAllowed: false, capableOwner: null, physicallyAbsent: false },
+    }),
+  ).toThrow(/writer-lease/);
+});
+
+test("battery writer authority distinguishes start, cleanup owner, and physical release", () => {
+  const owner = { pid: 41, token: "owner" };
+  expect(projectBatteryDaemonLease({ status: "absent", path: "/tmp/d.writer" })).toEqual({
+    startAllowed: true,
+    capableOwner: null,
+    physicallyAbsent: true,
+  });
+  expect(
+    projectBatteryDaemonLease({
+      status: "owned",
+      path: "/tmp/d.writer",
+      owner,
+      capability: { status: "proven_stale", reason: "linux_zombie" },
+    }),
+  ).toEqual({ startAllowed: true, capableOwner: null, physicallyAbsent: false });
+  expect(
+    projectBatteryDaemonLease({
+      status: "owned",
+      path: "/tmp/d.writer",
+      owner,
+      capability: { status: "capable", reason: "identity_match" },
+    }),
+  ).toEqual({ startAllowed: false, capableOwner: owner, physicallyAbsent: false });
+  expect(
+    projectBatteryDaemonLease({
+      status: "owned",
+      path: "/tmp/d.writer",
+      owner,
+      capability: { status: "unknown", reason: "identity_unavailable" },
+    }),
+  ).toEqual({ startAllowed: false, capableOwner: null, physicallyAbsent: false });
+  expect(
+    projectBatteryDaemonLease({
+      status: "unknown",
+      path: "/tmp/d.writer",
+      reason: "owner_malformed",
+    }),
+  ).toEqual({ startAllowed: false, capableOwner: null, physicallyAbsent: false });
 });
 
 test("daemon cleanup authority is bound to the exact writer lease", () => {

--- a/scripts/lib/wire-fixtures.mjs
+++ b/scripts/lib/wire-fixtures.mjs
@@ -45,6 +45,16 @@ export function buildWireFixtures() {
     operationsPath: "/v2/operations",
     engine: { version: "3.1.0", sha: "unknown", entry: "/opt/claudexor/daemon.js" },
   });
+  // Recovery-only admission (issue #165 D5): transport/protocol succeed while
+  // product routes stay closed; Swift must decode servingMode losslessly so
+  // the I-A loop can keep the existing Connecting behavior until normal.
+  add("handshake-response-recovery-only", "ControlHandshakeResponse", {
+    protocolMajor: schema.CONTROL_PROTOCOL_MAJOR,
+    compatible: true,
+    operationsPath: "/v2/operations",
+    engine: { version: "3.4.0", sha: "b".repeat(40), entry: "/opt/claudexor/daemon.js" },
+    servingMode: "recovery_only",
+  });
 
   add("problem-minimal", "ControlProblem", {
     code: "plan_not_ready",

--- a/scripts/real-harness-battery.mjs
+++ b/scripts/real-harness-battery.mjs
@@ -387,6 +387,14 @@ async function startBatteryDaemon() {
   });
   if (!response.ok) throw new Error(`battery daemon handshake failed (HTTP ${response.status})`);
   const handshake = await response.json();
+  // C7e: the battery drives real product routes — a recovery-only daemon
+  // (absent servingMode = a pre-#165 daemon serving normally) is a hard stop.
+  const servingMode = handshake?.servingMode ?? "normal";
+  if (servingMode !== "normal") {
+    throw new Error(
+      `battery daemon is serving ${servingMode}; refusing to run the battery against a recovery plane`,
+    );
+  }
   // Capture the identity before candidate validation. A mismatching but valid
   // fresh daemon must still be stopped through the identity-bound RPC.
   runtimeState.daemonIdentity = runtimeReplacementIdentityFromHandshake(handshake);

--- a/scripts/real-harness-battery.mjs
+++ b/scripts/real-harness-battery.mjs
@@ -31,6 +31,7 @@ import {
   evaluateRequiredNativeRoutes,
   isBatteryRepoRoot,
   isCrossFamilyConvergenceRefusal,
+  projectBatteryDaemonLease,
   relevantRunAttemptKeys,
   resolveRealHarnessBatteryLayout,
   runtimeReplacementIdentityFromHandshake,
@@ -81,9 +82,8 @@ const { ArtifactStore } = artifactStoreModule;
 const {
   awaitDaemonTermination,
   DaemonClient,
-  daemonLeaseOwner,
   defaultSocketPath,
-  processIsAlive,
+  inspectDaemonWriterLease,
   readToken,
   socketAlive,
 } = daemonModule;
@@ -331,12 +331,12 @@ async function startBatteryDaemon() {
     name: "daemon-preflight",
     envRetry: false,
   });
-  const preflightLease = daemonLeaseOwner(socketPath);
+  const preflightLease = projectBatteryDaemonLease(inspectDaemonWriterLease(socketPath));
   const preflightSocketAlive = await socketAlive(socketPath);
   assertNoPreexistingDaemon({
     statusCode: preflight.code,
     socketIsAlive: preflightSocketAlive,
-    leaseIsAlive: Boolean(preflightLease && processIsAlive(preflightLease.pid)),
+    lease: preflightLease,
   });
 
   const started = runCliJson(["daemon", "start"], {
@@ -344,20 +344,21 @@ async function startBatteryDaemon() {
     envRetry: false,
   });
   const startedPid = started.json?.pid;
-  const lease = daemonLeaseOwner(socketPath);
-  if (Number.isSafeInteger(startedPid) && startedPid > 0 && lease?.pid === startedPid) {
+  const lease = projectBatteryDaemonLease(inspectDaemonWriterLease(socketPath));
+  const capableOwner = lease.capableOwner;
+  if (Number.isSafeInteger(startedPid) && startedPid > 0 && capableOwner?.pid === startedPid) {
     const token = readToken();
     if (token) {
       // Capture cleanup authority as soon as the detached child proves writer
       // ownership. A later readiness/handshake failure must not leak it.
       runtimeState.daemonOwned = true;
-      runtimeState.daemonLease = lease;
+      runtimeState.daemonLease = capableOwner;
       runtimeState.daemonClient = new DaemonClient(socketPath, token);
       evidence.daemon.start = {
         pid: startedPid,
         ready: started.json?.ready === true,
         alreadyRunning: started.json?.alreadyRunning === true,
-        processIdentity: lease.identity?.status ?? null,
+        processIdentity: capableOwner.identity?.status ?? null,
       };
     }
   }
@@ -370,7 +371,7 @@ async function startBatteryDaemon() {
   ) {
     throw new Error(`battery could not prove a fresh daemon start; inspect ${started.log}`);
   }
-  if (!runtimeState.daemonOwned || !lease || lease.pid !== startedPid) {
+  if (!runtimeState.daemonOwned || !capableOwner || capableOwner.pid !== startedPid) {
     throw new Error("fresh daemon pid does not own the writer lease; refusing cleanup authority");
   }
 
@@ -413,7 +414,7 @@ async function stopBatteryDaemon() {
   const socketPath = defaultSocketPath();
   const expectedOwner = runtimeState.daemonLease;
   const client = runtimeState.daemonClient;
-  const currentOwner = daemonLeaseOwner(socketPath);
+  const currentOwner = projectBatteryDaemonLease(inspectDaemonWriterLease(socketPath)).capableOwner;
   if (!client || !sameDaemonLease(expectedOwner, currentOwner)) {
     evidence.daemon.stop = {
       stopped: false,
@@ -433,7 +434,9 @@ async function stopBatteryDaemon() {
       (options) => awaitDaemonTermination(socketPath, options),
       expectedOwner,
     );
-    const leaseReleased = daemonLeaseOwner(socketPath) === null;
+    const leaseReleased = projectBatteryDaemonLease(
+      inspectDaemonWriterLease(socketPath),
+    ).physicallyAbsent;
     const valid = termination.outcome !== "still_alive" && leaseReleased;
     evidence.daemon.stop = {
       stopped: valid,


### PR DESCRIPTION
A daemon that died or got killed could leave the shared data root in a state where the next start either refused to serve at all or, worse, ran destructive recovery against journals that another writer still owned. This change makes startup safe on any root it finds, and it keeps a broken root usable enough to repair itself without a restart.

Startup now runs in two stages. The first stage is strictly read-only: it inspects the writer lease, prepares every journal partition, and computes a verdict without touching a byte. Only after the daemon wins a persistent root authority barrier does the second stage revalidate the preparation, advance the authority floor, run crash garbage collection, and activate the journals. A stale flat-layout root from an older daemon is migrated in place with no window where the anchor file is absent, and staleness is only ever concluded from a proven-dead writer, never guessed.

When any partition needs recovery, the daemon comes up in a recovery_only serving mode instead of refusing to start. Product routes answer with a typed error, while the recovery routes stay available so the operator can inspect partitions and quarantine the corrupt one. A successful quarantine reopens the journals and completes normal admission in the same process, so the daemon walks itself from recovery_only to normal without a restart. The serving mode is reported honestly everywhere a client could act on it: the control handshake, the CLI daemon start report, remote commands, the macOS app reconciler, and the harness battery all refuse to treat a recovering daemon as ready.

The review waves for this work caught two regressions in the recovery path itself, both fixed and confirmed live here. Quarantining one partition used to create shared recovery infrastructure on disk, which retroactively changed the preparation identity of every sibling partition and falsely marked a healthy global journal as needing recovery; the identity computation now treats the existence of that daemon-owned parent directory as neutral while still failing closed on any real tampering. And the setup supervisor could be started twice after an in-process reopen, leaving an orphaned monitor loop; starting it is now serialized and idempotent.

Verified with red-first tests for every fix, the focused daemon and CLI suites, the live reopen and provenance suites against the built daemon, and real spawns on a fresh root, a corrupt-project root repaired in process, and a stale flat root migrated in place. Typecheck, formatting, and the complexity gate are green. Two changesets are included.

Closes #159. Closes #165.
