### PR TITLE
fix(cli): wait through the transient recovery-only startup window before failing readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ Release history for Claudexor. The current version is declared in the root
   recovers automatically from Linux zombie writer leases while keeping live
   or uncertain owners fail-closed, survives disconnected RPC followers
   instead of crashing, and treats web access as optional for every non-off
-  policy with native Cursor web approvals for managed read-only runs.
+  policy with native Cursor web approvals for managed read-only runs. CLI
+  readiness waits through the transient recovery-only startup window: acting
+  commands and `daemon start` keep re-handshaking until normal admission
+  opens or the start budget expires, so a healthy journal-heavy startup is
+  never misreported as a recovery-blocked daemon.
 
 - **v3.3.16** (2026-08-15) — The macOS packager now removes the exact
   pre-3.3.13 `dist/Claudexor.app` only after a successful Swift build produces

--- a/packages/cli/src/daemon-run.test.ts
+++ b/packages/cli/src/daemon-run.test.ts
@@ -399,6 +399,24 @@ const RECOVERY_ONLY_200 = () => ({
   }),
 });
 
+/** A normally-serving daemon's handshake (stage 4 completed). */
+const NORMAL_200 = () => ({
+  status: 200,
+  body: JSON.stringify({
+    protocolMajor: 3,
+    compatible: true,
+    operationsPath: "/v2/operations",
+    engine: { version: CLAUDEXOR_VERSION, sha: "unknown", entry: "/opt/claudexor/daemon.js" },
+    servingMode: "normal",
+  }),
+});
+
+/** Stage-3→4 startup: the first N handshakes report recovery_only, then normal. */
+const STARTUP_WINDOW_200 = (recoveryHandshakes: number) => {
+  let seen = 0;
+  return () => (seen++ < recoveryHandshakes ? RECOVERY_ONLY_200() : NORMAL_200());
+};
+
 describe("absence vs refusal discrimination (#93)", () => {
   let dir: string;
   let prevConfigDir: string | undefined;
@@ -560,12 +578,14 @@ describe("absence vs refusal discrimination (#93)", () => {
     expect(conn!.engine.servingMode).toBe("recovery_only");
   });
 
-  it("ensureDaemon: a recovery-only daemon fails typed + retryable, never proceeding into route refusals (C7d)", async () => {
+  it("ensureDaemon: a daemon that STAYS recovery-only past the budget fails typed + retryable, never proceeding into route refusals (C7d)", async () => {
     socketServer = await fakeDaemonSocket(process.env.CLAUDEXOR_DAEMON_SOCK as string);
     const api = await fakeControlApi(RECOVERY_ONLY_200);
     httpServer = api.server;
     writeDaemonFixture(api.port);
-    const err: unknown = await ensureDaemon().then(
+    // Short budget: a genuinely blocked root never opens normal admission, so
+    // the bounded wait must end in the SAME typed error as before, only later.
+    const err: unknown = await ensureDaemon(600).then(
       () => null,
       (thrown: unknown) => thrown,
     );
@@ -574,6 +594,39 @@ describe("absence vs refusal discrimination (#93)", () => {
     expect(problem.code).toBe("daemon_recovery_only");
     expect(problem.retryable).toBe(true);
     expect(problem.message).toContain("serving recovery only");
+  });
+
+  it("ensureDaemon: a HEALTHY daemon still in startup stage 4 (transient recovery_only handshake) is waited for, not failed (CR3)", async () => {
+    // D5 stage 3 writes the pointer with admission closed; stage 4 opens
+    // normal admission after journal recovery. ensureDaemon must ride that
+    // window out within its budget instead of throwing daemon_recovery_only
+    // at a healthy auto-start.
+    socketServer = await fakeDaemonSocket(process.env.CLAUDEXOR_DAEMON_SOCK as string);
+    const api = await fakeControlApi(STARTUP_WINDOW_200(2));
+    httpServer = api.server;
+    writeDaemonFixture(api.port);
+    const conn = await ensureDaemon(5_000);
+    expect(conn.engine.servingMode).toBe("normal");
+  });
+
+  it("waitForDaemonReady: reports the TERMINAL servingMode, not the transient stage-3 recovery_only (CR3)", async () => {
+    socketServer = await fakeDaemonSocket(process.env.CLAUDEXOR_DAEMON_SOCK as string);
+    const api = await fakeControlApi(STARTUP_WINDOW_200(2));
+    httpServer = api.server;
+    writeDaemonFixture(api.port);
+    const conn = await waitForDaemonReady(5_000);
+    expect(conn).not.toBeNull();
+    expect(conn!.engine.servingMode).toBe("normal");
+  });
+
+  it("waitForDaemonReady: a genuinely blocked root is reported honestly as recovery_only at the deadline (CR3)", async () => {
+    socketServer = await fakeDaemonSocket(process.env.CLAUDEXOR_DAEMON_SOCK as string);
+    const api = await fakeControlApi(RECOVERY_ONLY_200);
+    httpServer = api.server;
+    writeDaemonFixture(api.port);
+    const conn = await waitForDaemonReady(600);
+    expect(conn).not.toBeNull();
+    expect(conn!.engine.servingMode).toBe("recovery_only");
   });
 
   it("ensureDaemon: a typed refusal short-circuits (no 10s control-API wait, no NO_CONTROL_API flatten)", async () => {

--- a/packages/cli/src/daemon-run.ts
+++ b/packages/cli/src/daemon-run.ts
@@ -96,6 +96,10 @@ export async function ensureDaemon(
   const socketPath = defaultSocketPath();
   let client = new DaemonClient(socketPath, token);
   let launch: DetachedDaemonLaunch | null = null;
+  // ONE shared budget for the whole readiness sequence (socket, pointer,
+  // normal admission): a journal-heavy startup may spend most of it in any
+  // single phase, and stacking per-phase budgets would multiply the worst case.
+  const overallDeadline = Date.now() + timeoutMs;
 
   const ok = await daemonReachable(client);
   if (!ok) {
@@ -109,9 +113,8 @@ export async function ensureDaemon(
       env: harnessRuntimeEnv(),
     });
     // Wait for the socket to accept connections (health round-trip).
-    const deadline = Date.now() + timeoutMs;
     let started = false;
-    while (Date.now() < deadline) {
+    while (Date.now() < overallDeadline) {
       await sleep(150);
       // Re-read the token: ensureToken() above generated it before spawn, and the
       // daemon reuses the same per-user token file, so this client stays valid.
@@ -146,6 +149,22 @@ export async function ensureDaemon(
     );
   }
   launch?.markReady();
+  // C7d × D5: the daemon binds its transport and writes the pointer in
+  // startup stage 3 with product admission still CLOSED (handshake reports
+  // recovery_only), and only stage 4 — journal revalidation, crash-GC, the
+  // full recover(), activation — opens normal admission. On journal-heavy
+  // roots stage 4 takes the tens of seconds this shared start budget exists
+  // for, so a recovery_only handshake here is AMBIGUOUS between "still
+  // starting" and "genuinely blocked". Keep re-handshaking until the budget
+  // expires; a genuinely blocked root never opens normal and still gets the
+  // typed error below (the macOS app connect loop waits the same way).
+  while (reached.engine.servingMode !== "normal" && Date.now() < overallDeadline) {
+    await sleep(150);
+    if (launch?.failure()) throw launch.callerError("normal_admission_wait", timeoutMs);
+    // Absence mid-wait (daemon died or is restarting) keeps the last observed
+    // identity: the loop stays bounded and the deadline names the state.
+    reached = (await controlApiReachable()) ?? reached;
+  }
   // C7d: acting paths must not proceed into a wall of daemon_recovery_only
   // route refusals — name the recovery state once, typed and retryable.
   if (reached.engine.servingMode !== "normal") {
@@ -201,12 +220,19 @@ export async function waitForDaemonReady(
   abort?: () => Error | null,
 ): Promise<{ client: DaemonClientType; addr: ControlApiAddress; engine: EngineIdentity } | null> {
   const deadline = Date.now() + timeoutMs;
+  // D5: a reachable daemon may still be mid-startup (stage 3 binds the
+  // transport recovery-only; stage 4 opens normal admission after journal
+  // recovery). Report the TERMINAL mode, not the transient stage-3 value:
+  // keep polling a recovery_only handshake until it opens normal or the
+  // budget expires — a genuinely blocked root is then reported honestly.
+  let last: Awaited<ReturnType<typeof connectDaemonIfRunning>> = null;
   for (;;) {
     const conn = await connectDaemonIfRunning();
-    if (conn) return conn;
+    if (conn?.engine.servingMode === "normal") return conn;
+    last = conn ?? last;
     const failure = abort?.();
     if (failure) throw failure;
-    if (Date.now() >= deadline) return null;
+    if (Date.now() >= deadline) return last;
     await sleep(150);
   }
 }


### PR DESCRIPTION
## Summary

- The two-stage daemon startup (#165, D5) binds the transport and writes the control-api pointer in stage 3 with product admission still closed, so the first CLI handshake can observe `servingMode: recovery_only` on a healthy startup. Stage 4 (journal revalidation, crash-GC, full recovery, activation) opens normal admission afterwards — on journal-heavy roots tens of seconds later, which is exactly what the shared 90s start budget exists for.
- `ensureDaemon` treated that transient handshake as terminal and immediately threw the typed `daemon_recovery_only` error, failing acting commands against a healthy auto-start; `waitForDaemonReady` returned on the first handshake, so `claudexor daemon start` could report the transient stage-3 mode.
- Both now keep re-handshaking within the existing budget and only name the recovery state once it expires: a genuinely blocked root still gets the same typed error / honest recovery-only report, while a healthy startup is waited through (matching the macOS app connect-loop semantics).

Reachability was proven on a fresh empty root with the frozen 3.4.0 daemon: the log shows the control API listening ~40ms before "normal product admission open", and the window scales with journal size.

## Test plan

- [x] Red-first: the two new window tests fail against the previous implementation (immediate throw / transient report)
- [x] `packages/cli/src/daemon-run.test.ts` green (28/28), including the updated deadline-semantics pin for the genuinely-blocked case
- [x] Full CLI suite green (1011 passed), typecheck, typecheck:tests, format:check, canary
