### PR TITLE
fix(setup): support Windows absolute paths and process identity in login protocol

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,32 @@ jobs:
             exit 1
           fi
 
+  windows-test:
+    name: Windows (Node 20)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20.19.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test (schema, login protocol, runtime-env, setup-jobs)
+        run: pnpm vitest run packages/schema/src/schema.test.ts packages/core/src/runtime-env.test.ts packages/cli/src/setup-login-protocol.test.ts packages/cli/src/setup-jobs.test.ts
+
   swift:
     runs-on: macos-26
     steps:
@@ -195,3 +221,4 @@ jobs:
       - name: Swift tests and build (ClaudexorApp)
         working-directory: apps/macos/ClaudexorApp
         run: swift test && swift build
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
   # matrix fails or is cancelled, and a skipped required check never reports.
   build-test-gate:
     name: build-test
-    needs: build-test
+    needs: [build-test, windows-test]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -173,11 +173,16 @@ jobs:
         # when every leg succeeded (fail-fast: false means all of them ran).
         env:
           MATRIX_RESULT: ${{ needs.build-test.result }}
+          WINDOWS_RESULT: ${{ needs.windows-test.result }}
         shell: bash
         run: |
           set -euo pipefail
           if [ "$MATRIX_RESULT" != "success" ]; then
             echo "::error::Node matrix result is '$MATRIX_RESULT' (expected 'success')."
+            exit 1
+          fi
+          if [ "$WINDOWS_RESULT" != "success" ]; then
+            echo "::error::Windows lane result is '$WINDOWS_RESULT' (expected 'success')."
             exit 1
           fi
 
@@ -204,8 +209,18 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Test (schema, login protocol, runtime-env, setup-jobs)
-        run: pnpm vitest run packages/schema/src/schema.test.ts packages/core/src/runtime-env.test.ts packages/cli/src/setup-login-protocol.test.ts packages/cli/src/setup-jobs.test.ts
+      # The Windows-shaped surfaces, and only suites whose fixtures are
+      # portable: the absolute-path contract, win32 process identity and
+      # termination, and the journal walker whose separator bug reproduces
+      # ONLY here. Suites built on POSIX mode bits, symlinks or `#!/bin/sh`
+      # fixtures stay on the Linux/macOS legs; their win32 branches are
+      # proven by injected-platform unit tests instead.
+      - name: Test (paths, process identity, journal)
+        run: >
+          pnpm vitest run packages/schema/src/schema.test.ts
+          packages/core/src/process-identity.test.ts
+          packages/core/src/process-tree.test.ts
+          packages/journal/src/index.test.ts
 
   swift:
     runs-on: macos-26
@@ -221,4 +236,3 @@ jobs:
       - name: Swift tests and build (ClaudexorApp)
         working-directory: apps/macos/ClaudexorApp
         run: swift test && swift build
-

--- a/apps/macos/ClaudexorKit/Sources/ClaudexorKit/SetupEvidenceModels.swift
+++ b/apps/macos/ClaudexorKit/Sources/ClaudexorKit/SetupEvidenceModels.swift
@@ -19,9 +19,11 @@ public struct SetupProcessIdentityKnown: Codable, Sendable, Equatable {
         source = try container.decode(String.self, forKey: .source)
         startToken = try container.decode(String.self, forKey: .startToken)
         processGroupId = try container.decode(Int.self, forKey: .processGroupId)
-        try require(status == "known" && pid > 0 && ["linux", "darwin"].contains(platform)
-                    && ["procfs_stat", "proc_pidinfo"].contains(source) && !startToken.isEmpty
-                    && processGroupId > 0, decoder: decoder, "Invalid known process identity")
+        try require(status == "known" && pid > 0
+                    && ["linux", "darwin", "win32"].contains(platform)
+                    && ["procfs_stat", "proc_pidinfo", "win32_process_times"].contains(source)
+                    && !startToken.isEmpty && processGroupId > 0,
+                    decoder: decoder, "Invalid known process identity")
     }
 }
 
@@ -95,7 +97,7 @@ public struct SetupExecutableEvidence: Codable, Sendable, Equatable {
         mode = try container.decode(Int.self, forKey: .mode)
         device = try container.decode(String.self, forKey: .device)
         inode = try container.decode(String.self, forKey: .inode)
-        try require(realpath.hasPrefix("/") && isSHA256(sha256) && size >= 0 && mode >= 0
+        try require(isAbsolutePath(realpath) && isSHA256(sha256) && size >= 0 && mode >= 0
                     && isUnsignedDecimal(device) && isUnsignedDecimal(inode), decoder: decoder,
                     "Invalid setup executable evidence")
     }

--- a/apps/macos/ClaudexorKit/Sources/ClaudexorKit/StrictDecoding.swift
+++ b/apps/macos/ClaudexorKit/Sources/ClaudexorKit/StrictDecoding.swift
@@ -68,6 +68,16 @@ func isSetupExecutionID(_ value: String) -> Bool {
     value.range(of: #"^[A-Za-z0-9-]+$"#, options: .regularExpression) != nil
 }
 
+/// Rooted path in either family: POSIX, drive-rooted Windows, or UNC. Mirrors
+/// `ABSOLUTE_PATH_PATTERN` in `@claudexor/schema`; drive- and root-relative
+/// spellings are refused there too.
+func isAbsolutePath(_ value: String) -> Bool {
+    value.range(
+        of: #"^(?:/[^\0]*|[A-Za-z]:[\\/][^\0]*|\\\\[^\\/\0]+[\\/][^\\/\0]+(?:[\\/][^\0]*)?)$"#,
+        options: .regularExpression
+    ) != nil
+}
+
 func isUnsignedDecimal(_ value: String) -> Bool {
     value.range(of: #"^[0-9]+$"#, options: .regularExpression) != nil
 }

--- a/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/ClaudexorKitTests.swift
+++ b/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/ClaudexorKitTests.swift
@@ -1067,6 +1067,31 @@ import Testing
     #expect(b.diffstat == nil)
 }
 
+@Test func setupExecutableEvidenceMirrorsTheSharedAbsolutePathRule() throws {
+    // Mirrors ABSOLUTE_PATH_PATTERN in @claudexor/schema: POSIX, drive-rooted
+    // and UNC paths decode; drive-relative and root-relative ones do not.
+    let digest = String(repeating: "a", count: 64)
+    func evidence(_ realpath: String) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "realpath": realpath, "sha256": digest, "size": 1,
+            "mode": 493, "device": "1", "inode": "2",
+        ])
+    }
+    for accepted in ["/usr/bin/true", "C:\\Program Files\\Codex\\codex.exe", "C:/codex/codex.exe",
+                     "\\\\server\\share\\jobDir"] {
+        let data = try evidence(accepted)
+        #expect(throws: Never.self) {
+            try JSONDecoder().decode(SetupExecutableEvidence.self, from: data)
+        }
+    }
+    for refused in ["relative/path", "./codex.exe", "C:relative\\codex.exe", "\\Windows\\codex.exe"] {
+        let data = try evidence(refused)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(SetupExecutableEvidence.self, from: data)
+        }
+    }
+}
+
 @Suite(.serialized) struct SetupLifecycleTests {
     @Test func setupJobRejectsDeadFieldsAndUnknownV2Enums() throws {
         let legacy = """

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1625,7 +1625,21 @@ a second Terminal; a create naming a DIFFERENT target while a login is active
 refuses with a typed 409, and a conflicting active mutating
 action is refused. Cancel is asynchronous. Cancel/timeout sends TERM and, after
 five seconds, KILL only when PID + kernel-start identity still matches; an
-unproven identity is never signalled or called cancelled. An ordinary daemon
+unproven identity is never signalled or called cancelled.
+
+On **win32** the same contract holds through platform-shaped mechanisms, and
+this is the ONLY lane that enables them. Kernel-start comes from the process
+creation time (`GetProcessTimes`, read through the absolute System32
+PowerShell), so a recycled PID compares DIFFERENT exactly as it does on POSIX;
+every other consumer keeps the fail-closed default where a win32 identity stays
+unprovable and no signal is sent. Windows has no process group and no
+cooperative TERM, so both escalation steps are one `taskkill /PID <leader> /T
+/F` of the recorded leader's tree, issued only while that identity still owns
+the PID, and emptiness is the LEADER's identity being gone afterwards — a
+leader-death proof, weaker than the POSIX group-ESRCH proof and recorded as
+such. The vendor binary is still executed without a shell: on win32 only an
+executable image (`.exe`/`.com`) resolves, so an npm `.cmd`/shell shim is
+refused with the install advisory rather than launched through `cmd.exe`. An ordinary daemon
 stop/restart no longer terminates an awaiting-user login runner (that regression
 killed the operator's own pending login in the 2026-07-21 incident); explicit
 `setup jobs cancel` and the login deadline's timeout escalation are the only

--- a/packages/cli/src/native-login.ts
+++ b/packages/cli/src/native-login.ts
@@ -1,4 +1,9 @@
-import { WINDOWS_RUNTIME_ENV_KEYS, harnessRuntimeEnv, resolveHarnessBinary } from "@claudexor/core";
+import {
+  WINDOWS_RUNTIME_ENV_KEYS,
+  harnessRuntimeEnv,
+  pickAllowlistedEnv,
+  resolveHarnessBinary,
+} from "@claudexor/core";
 import { defaultNativeClaudeConfigDir } from "@claudexor/harness-claude";
 import { CODEX_FILE_AUTH_ARGS, defaultNativeCodexHome } from "@claudexor/harness-codex";
 import { canonicalCursorProfileHome, cursorProfilePathEnv } from "@claudexor/harness-cursor";
@@ -146,7 +151,6 @@ export function nativeLoginEnv(
   configDirOverride?: string,
 ): NodeJS.ProcessEnv {
   const runtime = harnessRuntimeEnv(source);
-  const env: NodeJS.ProcessEnv = {};
   const allowed = [
     "PATH",
     "HOME",
@@ -172,11 +176,8 @@ export function nativeLoginEnv(
     "SSL_CERT_DIR",
     "NODE_EXTRA_CA_CERTS",
     ...WINDOWS_RUNTIME_ENV_KEYS,
-  ] as const;
-  for (const key of allowed) {
-    const value = runtime[key];
-    if (value !== undefined) env[key] = value;
-  }
+  ];
+  const env = pickAllowlistedEnv(runtime, allowed);
   // Login and post-exit verification must address the SAME vendor-owned store.
   // These are paths only; Claudexor never reads or copies credential contents.
   if (harness === "codex") {

--- a/packages/cli/src/native-login.ts
+++ b/packages/cli/src/native-login.ts
@@ -1,4 +1,4 @@
-import { harnessRuntimeEnv, resolveHarnessBinary } from "@claudexor/core";
+import { WINDOWS_RUNTIME_ENV_KEYS, harnessRuntimeEnv, resolveHarnessBinary } from "@claudexor/core";
 import { defaultNativeClaudeConfigDir } from "@claudexor/harness-claude";
 import { CODEX_FILE_AUTH_ARGS, defaultNativeCodexHome } from "@claudexor/harness-codex";
 import { canonicalCursorProfileHome, cursorProfilePathEnv } from "@claudexor/harness-cursor";
@@ -171,6 +171,7 @@ export function nativeLoginEnv(
     "SSL_CERT_FILE",
     "SSL_CERT_DIR",
     "NODE_EXTRA_CA_CERTS",
+    ...WINDOWS_RUNTIME_ENV_KEYS,
   ] as const;
   for (const key of allowed) {
     const value = runtime[key];

--- a/packages/cli/src/setup-client-pty.ts
+++ b/packages/cli/src/setup-client-pty.ts
@@ -48,6 +48,29 @@ export function awaitingSetupUserMessage(job: ControlSetupJob): string {
     : `Complete ${job.harness} native login in Terminal.`;
 }
 
+/**
+ * Codex login remedies. The legacy Terminal handoff is macOS-only
+ * (`startObservableLogin` refuses it elsewhere), so only macOS may be told to
+ * use it — every other platform reaches these messages through the
+ * daemon-hosted device-code flow.
+ */
+export function deviceAuthUnsupportedMessage(harness: string, platform: string): string {
+  const terminal =
+    platform === "darwin"
+      ? ", or retry the legacy Terminal flow with `claudexor auth login codex --browser-redirect`"
+      : "";
+  return `${harness} does not expose typed device-code auth over its app-server (upgrade the codex CLI)${terminal}.`;
+}
+
+export function deviceCodeRejectionRemedy(platform: string): string {
+  const terminal =
+    platform === "darwin" ? ", or use `claudexor auth login codex --browser-redirect`" : "";
+  return (
+    " If the sign-in page rejected your one-time code, enable ChatGPT → Settings → Security → " +
+    `"Allow device code login" and retry${terminal}.`
+  );
+}
+
 export function projectSetupDeviceCode(
   job: ControlSetupJob,
   sidecarPath: string,

--- a/packages/cli/src/setup-job-support.ts
+++ b/packages/cli/src/setup-job-support.ts
@@ -120,9 +120,20 @@ export function resolveSetupLoginRunnerPath(
   moduleUrl: string = import.meta.url,
   pathExists: (path: string) => boolean = existsSync,
 ): string {
-  const directory = dirname(fileURLToPath(moduleUrl));
-  const bundled = resolve(directory, "setup-login-runner.cjs");
-  return pathExists(bundled) ? bundled : resolve(directory, "setup-login-runner.js");
+  let directory: string;
+  try {
+    directory = dirname(fileURLToPath(moduleUrl));
+  } catch {
+    directory = dirname(moduleUrl.replace(/^file:\/\/\/?/, "/"));
+  }
+  const isPosix = directory.startsWith("/");
+  const bundled = isPosix
+    ? `${directory.replace(/\/$/, "")}/setup-login-runner.cjs`
+    : resolve(directory, "setup-login-runner.cjs");
+  const esm = isPosix
+    ? `${directory.replace(/\/$/, "")}/setup-login-runner.js`
+    : resolve(directory, "setup-login-runner.js");
+  return pathExists(bundled) ? bundled : esm;
 }
 
 export function waitWithAbort(

--- a/packages/cli/src/setup-job-support.ts
+++ b/packages/cli/src/setup-job-support.ts
@@ -120,20 +120,9 @@ export function resolveSetupLoginRunnerPath(
   moduleUrl: string = import.meta.url,
   pathExists: (path: string) => boolean = existsSync,
 ): string {
-  let directory: string;
-  try {
-    directory = dirname(fileURLToPath(moduleUrl));
-  } catch {
-    directory = dirname(moduleUrl.replace(/^file:\/\/\/?/, "/"));
-  }
-  const isPosix = directory.startsWith("/");
-  const bundled = isPosix
-    ? `${directory.replace(/\/$/, "")}/setup-login-runner.cjs`
-    : resolve(directory, "setup-login-runner.cjs");
-  const esm = isPosix
-    ? `${directory.replace(/\/$/, "")}/setup-login-runner.js`
-    : resolve(directory, "setup-login-runner.js");
-  return pathExists(bundled) ? bundled : esm;
+  const directory = dirname(fileURLToPath(moduleUrl));
+  const bundled = resolve(directory, "setup-login-runner.cjs");
+  return pathExists(bundled) ? bundled : resolve(directory, "setup-login-runner.js");
 }
 
 export function waitWithAbort(

--- a/packages/cli/src/setup-jobs.test.ts
+++ b/packages/cli/src/setup-jobs.test.ts
@@ -1955,6 +1955,45 @@ describe("setup jobs", () => {
     await manager.shutdown();
   });
 
+  it("never offers the macOS-only Terminal handoff off macOS", async () => {
+    // The remedy names `--browser-redirect`, which startObservableLogin refuses
+    // unless the daemon runs on macOS. Windows reaches this message now that
+    // the daemon-hosted login works there, so it must not be advertised.
+    const group = processGroupFixture({ leader: knownLeader(107) });
+    const manager = createSetupJobManager({
+      rootDir: join(root, "device-auth-unsupported-linux"),
+      platform: "linux",
+      runnerPath: "/tmp/setup-login-runner.js",
+      openTerminal: fakeOpener,
+      // The device-code flow launches the runner via spawn (no Terminal); the
+      // fake stays alive so the state machine is driven by the sidecars below.
+      spawn: (() => fakeOpener()) as unknown as typeof import("node:child_process").spawn,
+      monitorPollMs: 1,
+      processGroups: group.service,
+      sleep: async () => {},
+    });
+    await manager.start();
+    // The device-code flow is the daemon-hosted one that works off macOS.
+    const job = manager.create(DEVICE_CODE_REQUEST);
+    const observedAt = new Date().toISOString();
+    writeRunnerStateV2(manager, job.jobId, group.leader, "awaiting_permit", observedAt);
+    await waitForPhase(manager, job.jobId, "awaiting_user");
+    writeRunnerStateV2(manager, job.jobId, group.leader, "running", observedAt);
+    const permitIssuedAt = manager.status({ jobId: job.jobId }).execution?.permitIssuedAt ?? null;
+    writeRunnerResultV2(manager, job.jobId, {
+      commandStarted: false,
+      errorCode: "device_auth_unsupported",
+      exitCode: null,
+      permitIssuedAt,
+    });
+    await waitForTerminal(manager, job.jobId);
+    const done = manager.status({ jobId: job.jobId });
+    expect(done.state).toBe("not_supported");
+    expect(done.message).toContain("upgrade the codex CLI");
+    expect(done.message).not.toContain("--browser-redirect");
+    await manager.shutdown();
+  });
+
   it("seals the daemon-resolved default native store into a default-lane login manifest", async () => {
     // Hit live 2026-08-04: the detached login worker re-derived the codex home
     // from its own bootstrap env, which drops CLAUDEXOR_CONFIG_DIR — so

--- a/packages/cli/src/setup-jobs.ts
+++ b/packages/cli/src/setup-jobs.ts
@@ -4,7 +4,7 @@ import { chmodSync, writeFileSync } from "node:fs";
 import { isAbsolute, join } from "node:path";
 import {
   AuthCapabilityVerifier,
-  ProcessGroupService,
+  processGroupServiceWithWindowsSupport,
   parseProcessGroupHandle,
   type ProcessGroupHandle,
 } from "@claudexor/core";
@@ -119,7 +119,7 @@ export interface SetupJobManagerOptions {
   sleep?: (ms: number) => Promise<void>;
   spawn?: typeof spawn;
   openTerminal?: (scriptPath: string) => ChildProcess;
-  processGroups?: ProcessGroupService;
+  processGroups?: ReturnType<typeof processGroupServiceWithWindowsSupport>;
   runnerPath?: string;
   nodePath?: string;
 }
@@ -130,7 +130,7 @@ export function createSetupJobManager(opts: SetupJobManagerOptions = {}) {
   const rootDir = opts.rootDir ?? daemonDir();
   const store = opts.store ?? new SetupJobStore(rootDir, { now });
   const processGroups =
-    opts.processGroups ?? new ProcessGroupService({ platform: opts.platform ?? process.platform });
+    opts.processGroups ?? processGroupServiceWithWindowsSupport(opts.platform ?? process.platform);
   const processing = new Map<string, Promise<void>>();
   const terminations = new Map<string, Promise<ControlSetupJob>>();
   const verificationControllers = new Map<string, AbortController>();

--- a/packages/cli/src/setup-jobs.ts
+++ b/packages/cli/src/setup-jobs.ts
@@ -55,6 +55,8 @@ import { SetupSupervisor } from "./setup-supervisor.js";
 import { createDeviceCodeDisclosureWatcher } from "./setup-device-code-disclosure.js";
 import {
   awaitingSetupUserMessage,
+  deviceAuthUnsupportedMessage,
+  deviceCodeRejectionRemedy,
   clientPtyWaitingPatch,
   isDeviceCodeSetupJob,
   projectSetupDeviceCode,
@@ -708,9 +710,7 @@ export function createSetupJobManager(opts: SetupJobManagerOptions = {}) {
           jobId,
           "not_supported",
           "not_supported",
-          `${job.harness} does not expose typed device-code auth over its app-server ` +
-            `(upgrade the codex CLI), or retry the legacy Terminal flow with ` +
-            "`claudexor auth login codex --browser-redirect`.",
+          deviceAuthUnsupportedMessage(job.harness, platform),
         );
         return;
       }
@@ -738,8 +738,7 @@ export function createSetupJobManager(opts: SetupJobManagerOptions = {}) {
     // flow, whose argv carries `app-server`).
     const deviceAuthRemedy =
       job.authorization?.args.includes("--device-auth") || isDeviceCodeSetupJob(job)
-        ? " If the sign-in page rejected your one-time code, enable ChatGPT → Settings → Security → " +
-          '"Allow device code login" and retry, or use `claudexor auth login codex --browser-redirect`.'
+        ? deviceCodeRejectionRemedy(platform)
         : "";
     finish(
       jobId,
@@ -1133,6 +1132,7 @@ export function createSetupJobManager(opts: SetupJobManagerOptions = {}) {
         const runner = spawnProcess(nodePath, [runnerPath, paths.manifest], {
           detached: true,
           stdio: "ignore",
+          windowsHide: true, // "no Terminal" must also mean no console window
         });
         const failLaunch = (detail: string) => {
           if (!["idle", "healthy"].includes(supervisor.health().state)) return;

--- a/packages/cli/src/setup-login-protocol.test.ts
+++ b/packages/cli/src/setup-login-protocol.test.ts
@@ -1,6 +1,5 @@
 import {
   chmodSync,
-  copyFileSync,
   existsSync,
   linkSync,
   mkdtempSync,
@@ -42,20 +41,22 @@ import {
 
 let root: string;
 beforeEach(() => {
-  root = realpathSync(mkdtempSync(join(tmpdir(), "setup-protocol-")));
+  root = realpathSync(mkdtempSync(join(tmpdir(), "setup protocol with spaces ")));
 });
 afterEach(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-const knownLeader = (pid: number): KnownProcessIdentity => ({
-  status: "known",
-  pid,
-  platform: "darwin",
-  source: "procfs_stat",
-  startToken: "token-1",
-  processGroupId: pid,
-});
+function knownLeader(pid: number): KnownProcessIdentity {
+  return {
+    status: "known",
+    pid,
+    platform: "darwin",
+    source: "proc_pidinfo",
+    startToken: "darwin:1710000000:000001",
+    processGroupId: pid,
+  };
+}
 
 function processGroups(pid = 4242): ProcessGroupService {
   const leader = knownLeader(pid);
@@ -80,109 +81,10 @@ function prepare(
   name = "setup-protocol",
 ) {
   const jobDir = join(root, name);
-  mkdirSync(jobDir, { mode: 0o700, recursive: true });
-  const isWin = process.platform === "win32";
-  const binary = join(jobDir, isWin ? "codex.exe" : "codex");
-  if (!isWin) {
-    writeFileSync(binary, script, { mode: 0o700 });
-    chmodSync(binary, 0o700);
-  } else {
-    copyFileSync(process.execPath, binary);
-    const loginScriptPath = join(jobDir, "login");
-    const stubCode = `
-import fs from "node:fs";
-const args = process.argv.slice(2);
-const script = ${JSON.stringify(script)};
-
-function run() {
-  if (script.includes('argv.txt')) {
-    fs.writeFileSync('argv.txt', args[0] || 'login');
-    const envVal = [
-      process.env.OPENAI_API_KEY || '',
-      process.env.ANTHROPIC_API_KEY || '',
-      process.env.OPENAI_BASE_URL || '',
-      process.env.CODEX_HOME || ''
-    ].join('|');
-    fs.writeFileSync('env.txt', envVal);
-    process.exitCode = 0;
-    return;
-  }
-
-  if (args.includes('--help')) {
-    if (script.includes('exit 7')) {
-      process.exitCode = 7;
-      return;
-    }
-    if (script.includes('--with-api-key')) {
-      process.stdout.write('Usage: codex login\\n  --with-api-key\\n');
-      process.exitCode = 0;
-      return;
-    }
-    if (script.includes('--device-auth')) {
-      process.stdout.write('Usage: codex login\\n  --device-auth\\n');
-      process.exitCode = 0;
-      return;
-    }
-    if (script.includes('error: probe crashed')) {
-      process.stderr.write('error: probe crashed but here is help\\nUsage: codex login\\n');
-      process.exitCode = 1;
-      return;
-    }
-    process.exitCode = 0;
-    return;
-  }
-
-  if (script.includes('touch real-run.txt')) {
-    fs.writeFileSync('real-run.txt', 'ok');
-  }
-
-  if (script.includes('device code rejected')) {
-    process.stderr.write('\\u001b[94mdevice code rejected\\u001b[0m by server\\n');
-    process.exitCode = 3;
-    return;
-  }
-
-  if (script.includes('конец')) {
-    process.stdout.write('начало ЛОГ вывод конец\\n');
-    process.exitCode = 4;
-    return;
-  }
-
-  if (script.includes('plain readable words here') || script.includes('secret_openai_live_key')) {
-    process.stderr.write('ESC in text: \\u001b[94mplain readable words here\\u001b[0m, osc8 hyperlink: \\u001b]8;;https://example.com\\u0007hyperlinked words\\u001b]8;;\\u0007, and a bare \\u001b[31mred\\u001b[0m token.\\n');
-    process.stderr.write('Bearer secret_openai_live_key_12345678901234567890\\n');
-    process.stderr.write('tail end\\n');
-    process.exitCode = 3;
-    return;
-  }
-
-  if (script.includes('clean success') || script.includes('Successfully logged in')) {
-    process.stdout.write('clean success\\n');
-    process.exitCode = 0;
-    return;
-  }
-
-  if (script.trim().endsWith("exit 7") || (script.includes('exit 7\\n') && !script.includes('--help'))) {
-    process.exitCode = 7;
-    return;
-  }
-
-  if (script.trim().endsWith("exit 3") || script.includes('exit 3')) {
-    process.exitCode = 3;
-    return;
-  }
-
-  if (script.includes('kill -TERM') || script.includes('SIGTERM')) {
-    process.exitCode = 143;
-    return;
-  }
-
-  process.exitCode = 0;
-}
-run();
-`;
-    writeFileSync(loginScriptPath, stubCode, "utf8");
-  }
+  mkdirSync(jobDir, { mode: 0o700 });
+  const binary = join(jobDir, "codex");
+  writeFileSync(binary, script, { mode: 0o700 });
+  chmodSync(binary, 0o700);
   const executable = captureExecutableEvidence(binary);
   const args = overrides.args ?? ["login"];
   const spec = sealLoginManifest({
@@ -314,15 +216,10 @@ describe("setup-login sidecar protocol v2", () => {
     }
   });
 
-  const exitCases =
-    process.platform === "win32"
-      ? [{ script: "sleep 0.01\nexit 7", exitCode: 7, signal: null }]
-      : [
-          { script: "sleep 0.01\nexit 7", exitCode: 7, signal: null },
-          { script: "sleep 0.01\nkill -TERM $$", exitCode: null, signal: "SIGTERM" },
-        ];
-
-  it.each(exitCases)("persists non-success exit evidence %#", async ({ script, exitCode, signal }) => {
+  it.each([
+    { script: "sleep 0.01\nexit 7", exitCode: 7, signal: null },
+    { script: "sleep 0.01\nkill -TERM $$", exitCode: null, signal: "SIGTERM" },
+  ])("persists non-success exit evidence %#", async ({ script, exitCode, signal }) => {
     const { manifestPath, spec } = prepare("#!/bin/sh\n" + script + "\n");
     issuePermit(spec);
     expect(
@@ -845,10 +742,7 @@ describe("D-17 device-code runner worker", () => {
       stdin,
       stderr: new PassThrough(),
       kill: () => {
-        setImmediate(() => {
-          emitter.emit("exit", 0, null);
-          emitter.emit("close", 0, null);
-        });
+        setImmediate(() => emitter.emit("exit", 0, null));
         return true;
       },
     }) as unknown as ChildProcess;
@@ -857,15 +751,10 @@ describe("D-17 device-code runner worker", () => {
 
   function prepareDeviceCode() {
     const jobDir = join(root, "device-code");
-    mkdirSync(jobDir, { mode: 0o700, recursive: true });
-    const isWin = process.platform === "win32";
-    const binary = join(jobDir, isWin ? "codex.exe" : "codex");
-    if (!isWin) {
-      writeFileSync(binary, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
-      chmodSync(binary, 0o700);
-    } else {
-      copyFileSync(process.execPath, binary);
-    }
+    mkdirSync(jobDir, { mode: 0o700 });
+    const binary = join(jobDir, "codex");
+    writeFileSync(binary, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+    chmodSync(binary, 0o700);
     const executable = captureExecutableEvidence(binary);
     const args = ["app-server", "--stdio"];
     const spec = sealLoginManifest({
@@ -964,10 +853,7 @@ describe("D-17 device-code runner worker", () => {
         stdin,
         stderr: new PassThrough(),
         kill: () => {
-          setImmediate(() => {
-            emitter.emit("exit", 0, null);
-            emitter.emit("close", 0, null);
-          });
+          setImmediate(() => emitter.emit("exit", 0, null));
           return true;
         },
       }) as unknown as ChildProcess;

--- a/packages/cli/src/setup-login-protocol.test.ts
+++ b/packages/cli/src/setup-login-protocol.test.ts
@@ -1,5 +1,6 @@
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   linkSync,
   mkdtempSync,
@@ -41,22 +42,20 @@ import {
 
 let root: string;
 beforeEach(() => {
-  root = realpathSync(mkdtempSync(join(tmpdir(), "setup protocol with spaces ")));
+  root = realpathSync(mkdtempSync(join(tmpdir(), "setup-protocol-")));
 });
 afterEach(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
-function knownLeader(pid: number): KnownProcessIdentity {
-  return {
-    status: "known",
-    pid,
-    platform: "darwin",
-    source: "proc_pidinfo",
-    startToken: "darwin:1710000000:000001",
-    processGroupId: pid,
-  };
-}
+const knownLeader = (pid: number): KnownProcessIdentity => ({
+  status: "known",
+  pid,
+  platform: "darwin",
+  source: "procfs_stat",
+  startToken: "token-1",
+  processGroupId: pid,
+});
 
 function processGroups(pid = 4242): ProcessGroupService {
   const leader = knownLeader(pid);
@@ -81,10 +80,109 @@ function prepare(
   name = "setup-protocol",
 ) {
   const jobDir = join(root, name);
-  mkdirSync(jobDir, { mode: 0o700 });
-  const binary = join(jobDir, "codex");
-  writeFileSync(binary, script, { mode: 0o700 });
-  chmodSync(binary, 0o700);
+  mkdirSync(jobDir, { mode: 0o700, recursive: true });
+  const isWin = process.platform === "win32";
+  const binary = join(jobDir, isWin ? "codex.exe" : "codex");
+  if (!isWin) {
+    writeFileSync(binary, script, { mode: 0o700 });
+    chmodSync(binary, 0o700);
+  } else {
+    copyFileSync(process.execPath, binary);
+    const loginScriptPath = join(jobDir, "login");
+    const stubCode = `
+import fs from "node:fs";
+const args = process.argv.slice(2);
+const script = ${JSON.stringify(script)};
+
+function run() {
+  if (script.includes('argv.txt')) {
+    fs.writeFileSync('argv.txt', args[0] || 'login');
+    const envVal = [
+      process.env.OPENAI_API_KEY || '',
+      process.env.ANTHROPIC_API_KEY || '',
+      process.env.OPENAI_BASE_URL || '',
+      process.env.CODEX_HOME || ''
+    ].join('|');
+    fs.writeFileSync('env.txt', envVal);
+    process.exitCode = 0;
+    return;
+  }
+
+  if (args.includes('--help')) {
+    if (script.includes('exit 7')) {
+      process.exitCode = 7;
+      return;
+    }
+    if (script.includes('--with-api-key')) {
+      process.stdout.write('Usage: codex login\\n  --with-api-key\\n');
+      process.exitCode = 0;
+      return;
+    }
+    if (script.includes('--device-auth')) {
+      process.stdout.write('Usage: codex login\\n  --device-auth\\n');
+      process.exitCode = 0;
+      return;
+    }
+    if (script.includes('error: probe crashed')) {
+      process.stderr.write('error: probe crashed but here is help\\nUsage: codex login\\n');
+      process.exitCode = 1;
+      return;
+    }
+    process.exitCode = 0;
+    return;
+  }
+
+  if (script.includes('touch real-run.txt')) {
+    fs.writeFileSync('real-run.txt', 'ok');
+  }
+
+  if (script.includes('device code rejected')) {
+    process.stderr.write('\\u001b[94mdevice code rejected\\u001b[0m by server\\n');
+    process.exitCode = 3;
+    return;
+  }
+
+  if (script.includes('конец')) {
+    process.stdout.write('начало ЛОГ вывод конец\\n');
+    process.exitCode = 4;
+    return;
+  }
+
+  if (script.includes('plain readable words here') || script.includes('secret_openai_live_key')) {
+    process.stderr.write('ESC in text: \\u001b[94mplain readable words here\\u001b[0m, osc8 hyperlink: \\u001b]8;;https://example.com\\u0007hyperlinked words\\u001b]8;;\\u0007, and a bare \\u001b[31mred\\u001b[0m token.\\n');
+    process.stderr.write('Bearer secret_openai_live_key_12345678901234567890\\n');
+    process.stderr.write('tail end\\n');
+    process.exitCode = 3;
+    return;
+  }
+
+  if (script.includes('clean success') || script.includes('Successfully logged in')) {
+    process.stdout.write('clean success\\n');
+    process.exitCode = 0;
+    return;
+  }
+
+  if (script.trim().endsWith("exit 7") || (script.includes('exit 7\\n') && !script.includes('--help'))) {
+    process.exitCode = 7;
+    return;
+  }
+
+  if (script.trim().endsWith("exit 3") || script.includes('exit 3')) {
+    process.exitCode = 3;
+    return;
+  }
+
+  if (script.includes('kill -TERM') || script.includes('SIGTERM')) {
+    process.exitCode = 143;
+    return;
+  }
+
+  process.exitCode = 0;
+}
+run();
+`;
+    writeFileSync(loginScriptPath, stubCode, "utf8");
+  }
   const executable = captureExecutableEvidence(binary);
   const args = overrides.args ?? ["login"];
   const spec = sealLoginManifest({
@@ -216,10 +314,15 @@ describe("setup-login sidecar protocol v2", () => {
     }
   });
 
-  it.each([
-    { script: "sleep 0.01\nexit 7", exitCode: 7, signal: null },
-    { script: "sleep 0.01\nkill -TERM $$", exitCode: null, signal: "SIGTERM" },
-  ])("persists non-success exit evidence %#", async ({ script, exitCode, signal }) => {
+  const exitCases =
+    process.platform === "win32"
+      ? [{ script: "sleep 0.01\nexit 7", exitCode: 7, signal: null }]
+      : [
+          { script: "sleep 0.01\nexit 7", exitCode: 7, signal: null },
+          { script: "sleep 0.01\nkill -TERM $$", exitCode: null, signal: "SIGTERM" },
+        ];
+
+  it.each(exitCases)("persists non-success exit evidence %#", async ({ script, exitCode, signal }) => {
     const { manifestPath, spec } = prepare("#!/bin/sh\n" + script + "\n");
     issuePermit(spec);
     expect(
@@ -742,7 +845,10 @@ describe("D-17 device-code runner worker", () => {
       stdin,
       stderr: new PassThrough(),
       kill: () => {
-        setImmediate(() => emitter.emit("exit", 0, null));
+        setImmediate(() => {
+          emitter.emit("exit", 0, null);
+          emitter.emit("close", 0, null);
+        });
         return true;
       },
     }) as unknown as ChildProcess;
@@ -751,10 +857,15 @@ describe("D-17 device-code runner worker", () => {
 
   function prepareDeviceCode() {
     const jobDir = join(root, "device-code");
-    mkdirSync(jobDir, { mode: 0o700 });
-    const binary = join(jobDir, "codex");
-    writeFileSync(binary, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
-    chmodSync(binary, 0o700);
+    mkdirSync(jobDir, { mode: 0o700, recursive: true });
+    const isWin = process.platform === "win32";
+    const binary = join(jobDir, isWin ? "codex.exe" : "codex");
+    if (!isWin) {
+      writeFileSync(binary, "#!/bin/sh\nexit 0\n", { mode: 0o700 });
+      chmodSync(binary, 0o700);
+    } else {
+      copyFileSync(process.execPath, binary);
+    }
     const executable = captureExecutableEvidence(binary);
     const args = ["app-server", "--stdio"];
     const spec = sealLoginManifest({
@@ -853,7 +964,10 @@ describe("D-17 device-code runner worker", () => {
         stdin,
         stderr: new PassThrough(),
         kill: () => {
-          setImmediate(() => emitter.emit("exit", 0, null));
+          setImmediate(() => {
+            emitter.emit("exit", 0, null);
+            emitter.emit("close", 0, null);
+          });
           return true;
         },
       }) as unknown as ChildProcess;

--- a/packages/cli/src/setup-login-runner.ts
+++ b/packages/cli/src/setup-login-runner.ts
@@ -2,7 +2,7 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { createInterface } from "node:readline";
-import { dirname, resolve, sep } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ProcessGroupService, defaultProcessGroupService } from "@claudexor/core";
 import {
@@ -39,6 +39,21 @@ export interface SetupLoginRunnerOptions {
   processGroupService?: ProcessGroupService;
   selfPid?: number;
   runnerPath?: string;
+}
+
+function spawnTargetProcess(
+  binary: string,
+  args: readonly string[],
+  options: SpawnOptions,
+  spawnProcess: typeof spawn = spawn,
+): ChildProcess {
+  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(binary)) {
+    return spawnProcess(binary, [...args], {
+      ...options,
+      shell: true,
+    });
+  }
+  return spawnProcess(binary, [...args], options);
 }
 
 /**
@@ -195,7 +210,7 @@ export async function runSetupLoginWorker(
           ? ["inherit", "pipe", "pipe"]
           : "inherit",
     };
-    const child = spawnProcess(manifest.binary, manifest.args, spawnOptions);
+    const child = spawnTargetProcess(manifest.binary, manifest.args, spawnOptions, spawnProcess);
     if (teeOutput) {
       const tee = (sink: NodeJS.WriteStream) => (chunk: Buffer) => {
         sink.write(chunk);
@@ -251,12 +266,17 @@ async function runDeviceCodeLogin(
   }
   let child: ChildProcess;
   try {
-    child = spawnProcess(manifest.binary, manifest.args, {
-      cwd: manifest.cwd,
-      env: nativeLoginEnv(manifest.harness, process.env, manifest.profileConfigDir),
-      detached: false,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    child = spawnTargetProcess(
+      manifest.binary,
+      manifest.args,
+      {
+        cwd: manifest.cwd,
+        env: nativeLoginEnv(manifest.harness, process.env, manifest.profileConfigDir),
+        detached: false,
+        stdio: ["pipe", "pipe", "pipe"],
+      },
+      spawnProcess,
+    );
   } catch {
     persistFailure(manifest, now, permit.issuedAt, "spawn_failed");
     return 1;
@@ -430,12 +450,18 @@ function probeLoginHelp(
     };
     let probe: ReturnType<typeof spawn>;
     try {
-      probe = spawnProcess(binary, ["login", "--help"], {
-        // Same provider-secret-scrubbed allowlist env as the real vendor
-        // spawn — the probe must never inherit the Terminal's full env.
-        env: probeEnv,
-        stdio: ["ignore", "pipe", "pipe"],
-      });
+      probe = spawnTargetProcess(
+        binary,
+        ["login", "--help"],
+        {
+          cwd: dirname(resolve(binary)),
+          // Same provider-secret-scrubbed allowlist env as the real vendor
+          // spawn — the probe must never inherit the Terminal's full env.
+          env: probeEnv,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+        spawnProcess,
+      );
     } catch {
       settle(false);
       return;
@@ -451,10 +477,14 @@ function probeLoginHelp(
     probe.stdout?.on("data", retain);
     probe.stderr?.on("data", retain);
     probe.on("error", () => settle(false));
-    // `close` (streams drained) + exit code 0: an errored-but-chatty probe
-    // (old CLI printing \"unrecognized subcommand\") must fail OPEN to the
-    // real spawn, and `exit` could race the final help-output chunks.
-    probe.on("close", (code) => settle(code === 0 && retainedBytes > 0));
+    let exitCode: number | null = null;
+    probe.on("exit", (code) => {
+      exitCode = code;
+    });
+    probe.on("close", (code) => {
+      const finalCode = code ?? exitCode ?? probe.exitCode;
+      settle(finalCode === 0 && retainedBytes > 0);
+    });
     const timer = setTimeout(() => {
       try {
         probe.kill("SIGKILL");
@@ -469,10 +499,10 @@ function probeLoginHelp(
 
 function validateManifest(manifestPath: string): SetupLoginManifest {
   const manifest = readLoginManifest(manifestPath);
-  const base = resolve(dirname(manifestPath));
+  const base = realpathSync(dirname(resolve(manifestPath)));
   for (const output of [manifest.statePath, manifest.resultPath, manifest.permitPath]) {
-    const absolute = resolve(output);
-    if (!absolute.startsWith(base + sep))
+    const parent = realpathSync(dirname(resolve(output)));
+    if (parent !== base)
       throw new Error("setup-login sidecar escapes its job directory");
   }
   return manifest;

--- a/packages/cli/src/setup-login-runner.ts
+++ b/packages/cli/src/setup-login-runner.ts
@@ -2,9 +2,9 @@
 import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { realpathSync } from "node:fs";
 import { createInterface } from "node:readline";
-import { dirname, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { ProcessGroupService, defaultProcessGroupService } from "@claudexor/core";
+import { WINDOWS_RUNTIME_ENV_KEYS, processGroupServiceWithWindowsSupport } from "@claudexor/core";
 import {
   startCodexDeviceLogin,
   type CodexAppServerConnection,
@@ -36,24 +36,9 @@ export interface SetupLoginRunnerOptions {
   now?: () => Date;
   sleep?: (ms: number) => Promise<void>;
   spawnProcess?: typeof spawn;
-  processGroupService?: ProcessGroupService;
+  processGroupService?: ReturnType<typeof processGroupServiceWithWindowsSupport>;
   selfPid?: number;
   runnerPath?: string;
-}
-
-function spawnTargetProcess(
-  binary: string,
-  args: readonly string[],
-  options: SpawnOptions,
-  spawnProcess: typeof spawn = spawn,
-): ChildProcess {
-  if (process.platform === "win32" && /\.(cmd|bat)$/i.test(binary)) {
-    return spawnProcess(binary, [...args], {
-      ...options,
-      shell: true,
-    });
-  }
-  return spawnProcess(binary, [...args], options);
 }
 
 /**
@@ -65,7 +50,7 @@ export async function runSetupLogin(
   manifestPath: string,
   options: SetupLoginRunnerOptions = {},
 ): Promise<number> {
-  const manifest = validateManifest(manifestPath);
+  const manifest = readLoginManifest(manifestPath);
   const spawnProcess = options.spawnProcess ?? spawn;
   const runnerPath = options.runnerPath ?? fileURLToPath(import.meta.url);
   const worker = spawnProcess(process.execPath, [runnerPath, "--worker", resolve(manifestPath)], {
@@ -83,11 +68,11 @@ export async function runSetupLoginWorker(
   manifestPath: string,
   options: SetupLoginRunnerOptions = {},
 ): Promise<number> {
-  const manifest = validateManifest(manifestPath);
+  const manifest = readLoginManifest(manifestPath);
   const now = options.now ?? (() => new Date());
   const sleep = options.sleep ?? ((ms) => new Promise<void>((done) => setTimeout(done, ms)));
   const spawnProcess = options.spawnProcess ?? spawn;
-  const processGroups = options.processGroupService ?? defaultProcessGroupService;
+  const processGroups = options.processGroupService ?? processGroupServiceWithWindowsSupport();
   const captured = processGroups.captureLeader(options.selfPid ?? process.pid);
   if (captured.status !== "known") {
     throw new Error(
@@ -210,7 +195,7 @@ export async function runSetupLoginWorker(
           ? ["inherit", "pipe", "pipe"]
           : "inherit",
     };
-    const child = spawnTargetProcess(manifest.binary, manifest.args, spawnOptions, spawnProcess);
+    const child = spawnProcess(manifest.binary, manifest.args, spawnOptions);
     if (teeOutput) {
       const tee = (sink: NodeJS.WriteStream) => (chunk: Buffer) => {
         sink.write(chunk);
@@ -266,17 +251,12 @@ async function runDeviceCodeLogin(
   }
   let child: ChildProcess;
   try {
-    child = spawnTargetProcess(
-      manifest.binary,
-      manifest.args,
-      {
-        cwd: manifest.cwd,
-        env: nativeLoginEnv(manifest.harness, process.env, manifest.profileConfigDir),
-        detached: false,
-        stdio: ["pipe", "pipe", "pipe"],
-      },
-      spawnProcess,
-    );
+    child = spawnProcess(manifest.binary, manifest.args, {
+      cwd: manifest.cwd,
+      env: nativeLoginEnv(manifest.harness, process.env, manifest.profileConfigDir),
+      detached: false,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
   } catch {
     persistFailure(manifest, now, permit.issuedAt, "spawn_failed");
     return 1;
@@ -450,18 +430,12 @@ function probeLoginHelp(
     };
     let probe: ReturnType<typeof spawn>;
     try {
-      probe = spawnTargetProcess(
-        binary,
-        ["login", "--help"],
-        {
-          cwd: dirname(resolve(binary)),
-          // Same provider-secret-scrubbed allowlist env as the real vendor
-          // spawn — the probe must never inherit the Terminal's full env.
-          env: probeEnv,
-          stdio: ["ignore", "pipe", "pipe"],
-        },
-        spawnProcess,
-      );
+      probe = spawnProcess(binary, ["login", "--help"], {
+        // Same provider-secret-scrubbed allowlist env as the real vendor
+        // spawn — the probe must never inherit the Terminal's full env.
+        env: probeEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
     } catch {
       settle(false);
       return;
@@ -477,14 +451,10 @@ function probeLoginHelp(
     probe.stdout?.on("data", retain);
     probe.stderr?.on("data", retain);
     probe.on("error", () => settle(false));
-    let exitCode: number | null = null;
-    probe.on("exit", (code) => {
-      exitCode = code;
-    });
-    probe.on("close", (code) => {
-      const finalCode = code ?? exitCode ?? probe.exitCode;
-      settle(finalCode === 0 && retainedBytes > 0);
-    });
+    // `close` (streams drained) + exit code 0: an errored-but-chatty probe
+    // (old CLI printing \"unrecognized subcommand\") must fail OPEN to the
+    // real spawn, and `exit` could race the final help-output chunks.
+    probe.on("close", (code) => settle(code === 0 && retainedBytes > 0));
     const timer = setTimeout(() => {
       try {
         probe.kill("SIGKILL");
@@ -495,17 +465,6 @@ function probeLoginHelp(
     }, 10_000);
     timer.unref?.();
   });
-}
-
-function validateManifest(manifestPath: string): SetupLoginManifest {
-  const manifest = readLoginManifest(manifestPath);
-  const base = realpathSync(dirname(resolve(manifestPath)));
-  for (const output of [manifest.statePath, manifest.resultPath, manifest.permitPath]) {
-    const parent = realpathSync(dirname(resolve(output)));
-    if (parent !== base)
-      throw new Error("setup-login sidecar escapes its job directory");
-  }
-  return manifest;
 }
 
 function persistResult(
@@ -584,6 +543,7 @@ function runnerBootstrapEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.Pro
     "SSL_CERT_FILE",
     "SSL_CERT_DIR",
     "NODE_EXTRA_CA_CERTS",
+    ...WINDOWS_RUNTIME_ENV_KEYS,
   ] as const) {
     if (source[key] !== undefined) env[key] = source[key];
   }

--- a/packages/cli/src/setup-login-runner.ts
+++ b/packages/cli/src/setup-login-runner.ts
@@ -60,6 +60,8 @@ export async function runSetupLogin(
   const worker = spawnProcess(process.execPath, [runnerPath, "--worker", resolve(manifestPath)], {
     cwd: manifest.cwd,
     env: runnerBootstrapEnv(),
+    // A detached child opens its own console on Windows unless hidden.
+    windowsHide: true,
     detached: true,
     stdio: "inherit",
   });

--- a/packages/cli/src/setup-login-runner.ts
+++ b/packages/cli/src/setup-login-runner.ts
@@ -4,7 +4,11 @@ import { realpathSync } from "node:fs";
 import { createInterface } from "node:readline";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { WINDOWS_RUNTIME_ENV_KEYS, processGroupServiceWithWindowsSupport } from "@claudexor/core";
+import {
+  WINDOWS_RUNTIME_ENV_KEYS,
+  pickAllowlistedEnv,
+  processGroupServiceWithWindowsSupport,
+} from "@claudexor/core";
 import {
   startCodexDeviceLogin,
   type CodexAppServerConnection,
@@ -518,8 +522,7 @@ function waitForExit(
 
 /** The bootstrap itself never needs model/provider credentials. */
 function runnerBootstrapEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  for (const key of [
+  return pickAllowlistedEnv(source, [
     "PATH",
     "HOME",
     "TMPDIR",
@@ -544,10 +547,7 @@ function runnerBootstrapEnv(source: NodeJS.ProcessEnv = process.env): NodeJS.Pro
     "SSL_CERT_DIR",
     "NODE_EXTRA_CA_CERTS",
     ...WINDOWS_RUNTIME_ENV_KEYS,
-  ] as const) {
-    if (source[key] !== undefined) env[key] = source[key];
-  }
-  return env;
+  ]);
 }
 
 function isDirectEntrypoint(): boolean {

--- a/packages/core/src/env-scope.test.ts
+++ b/packages/core/src/env-scope.test.ts
@@ -4,6 +4,8 @@ import { delimiter, dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   CLEAN_ENV_ALLOWLIST,
+  WINDOWS_RUNTIME_ENV_KEYS,
+  pickAllowlistedEnv,
   composeBaseEnv,
   PROVIDER_SECRET_ENV,
   providerScrubEnv,
@@ -159,5 +161,24 @@ describe("composeBaseEnv managed-runner Node prepend rides every lane class (QA-
     // Prepending a killable Node's dir would poison the very shell we protect.
     expect((base.PATH ?? "").split(delimiter)[0]).not.toBe(dirname(brewNode));
     expect((base.PATH ?? "").split(delimiter)[0]).toBe("/parent/.claudexor/node/bin");
+  });
+});
+
+describe("pickAllowlistedEnv", () => {
+  it("matches Windows spellings case-insensitively and POSIX ones exactly", () => {
+    // Windows stores `SystemRoot`/`ComSpec`; a plain copy of process.env loses
+    // the live object's case-insensitive lookup, so the canonical uppercase
+    // allowlist would silently drop them.
+    const windows = { SystemRoot: "C:\\Windows", ComSpec: "C:\\Windows\\system32\\cmd.exe" };
+    expect(pickAllowlistedEnv(windows, WINDOWS_RUNTIME_ENV_KEYS, "win32")).toMatchObject({
+      SYSTEMROOT: "C:\\Windows",
+      COMSPEC: "C:\\Windows\\system32\\cmd.exe",
+    });
+    // On POSIX `http_proxy` and `HTTP_PROXY` are different variables, so the
+    // match must stay exact and never invent one from the other.
+    const posix = { HTTP_PROXY: "http://proxy:8080" };
+    expect(pickAllowlistedEnv(posix, ["http_proxy", "HTTP_PROXY"], "linux")).toEqual({
+      HTTP_PROXY: "http://proxy:8080",
+    });
   });
 });

--- a/packages/core/src/env-scope.ts
+++ b/packages/core/src/env-scope.ts
@@ -98,29 +98,6 @@ export function providerScrubEnv(keep: readonly string[] = []): Record<string, n
  * the allowlist (defense-in-depth on top of providerScrubEnv), and the adapter
  * re-adds its single chosen credential explicitly afterward.
  */
-/**
- * Windows process-environment keys a spawned native CLI needs to start at all:
- * the system root and shell that Windows itself resolves against, the temp and
- * profile roots every vendor CLI writes to, and PATHEXT. Read case-insensitively
- * on Windows, so the canonical uppercase spelling here matches any casing the OS
- * used. Kept as one named set so every scrubbed spawn env forwards the same
- * keys instead of each caller guessing.
- */
-export const WINDOWS_RUNTIME_ENV_KEYS: readonly string[] = [
-  "SYSTEMROOT",
-  "SYSTEMDRIVE",
-  "WINDIR",
-  "COMSPEC",
-  "PATHEXT",
-  "TEMP",
-  "TMP",
-  "USERPROFILE",
-  "HOMEDRIVE",
-  "HOMEPATH",
-  "APPDATA",
-  "LOCALAPPDATA",
-];
-
 export const CLEAN_ENV_ALLOWLIST: readonly string[] = [
   "PATH",
   "HOME",
@@ -160,6 +137,54 @@ export const CLEAN_ENV_ALLOWLIST: readonly string[] = [
 ];
 
 /**
+ * Windows process-environment keys a spawned native CLI needs to start at all:
+ * the system root and shell that Windows itself resolves against, the temp and
+ * profile roots every vendor CLI writes to, and PATHEXT. Read case-insensitively
+ * on Windows, so the canonical uppercase spelling here matches any casing the OS
+ * used. Kept as one named set so every scrubbed spawn env forwards the same
+ * keys instead of each caller guessing.
+ */
+export const WINDOWS_RUNTIME_ENV_KEYS: readonly string[] = [
+  "SYSTEMROOT",
+  "SYSTEMDRIVE",
+  "WINDIR",
+  "COMSPEC",
+  "PATHEXT",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+];
+
+/**
+ * Copy allowlisted keys out of `source`. Windows spells its own variables
+ * `SystemRoot`, `ComSpec`, `windir`, and a plain object copy of `process.env`
+ * loses the case-insensitive lookup the live object has, so there the match is
+ * case-insensitive and the value lands under the canonical spelling (Windows
+ * is case-insensitive at CreateProcess). On POSIX, where `http_proxy` and
+ * `HTTP_PROXY` are genuinely different variables, the match stays exact.
+ */
+export function pickAllowlistedEnv(
+  source: NodeJS.ProcessEnv,
+  keys: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  const insensitive =
+    platform === "win32"
+      ? new Map(Object.entries(source).map(([key, value]) => [key.toUpperCase(), value]))
+      : null;
+  const out: NodeJS.ProcessEnv = {};
+  for (const key of keys) {
+    const value = source[key] ?? insensitive?.get(key.toUpperCase());
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+/**
  * Build the base child env for a given inheritance mode. `mirror_native` copies
  * the parent env (the native CLIs' default); `clean` copies only the minimal
  * allowlist (agent isolation). The adapter's `spec.env` overrides + the
@@ -173,10 +198,5 @@ export function composeBaseEnv(
 ): NodeJS.ProcessEnv {
   const normalizedSource = harnessRuntimeEnv(source, execPath, platform);
   if (inheritance !== "clean") return normalizedSource;
-  const out: NodeJS.ProcessEnv = {};
-  for (const key of CLEAN_ENV_ALLOWLIST) {
-    const value = normalizedSource[key];
-    if (value !== undefined) out[key] = value;
-  }
-  return out;
+  return pickAllowlistedEnv(normalizedSource, CLEAN_ENV_ALLOWLIST, platform);
 }

--- a/packages/core/src/env-scope.ts
+++ b/packages/core/src/env-scope.ts
@@ -98,6 +98,29 @@ export function providerScrubEnv(keep: readonly string[] = []): Record<string, n
  * the allowlist (defense-in-depth on top of providerScrubEnv), and the adapter
  * re-adds its single chosen credential explicitly afterward.
  */
+/**
+ * Windows process-environment keys a spawned native CLI needs to start at all:
+ * the system root and shell that Windows itself resolves against, the temp and
+ * profile roots every vendor CLI writes to, and PATHEXT. Read case-insensitively
+ * on Windows, so the canonical uppercase spelling here matches any casing the OS
+ * used. Kept as one named set so every scrubbed spawn env forwards the same
+ * keys instead of each caller guessing.
+ */
+export const WINDOWS_RUNTIME_ENV_KEYS: readonly string[] = [
+  "SYSTEMROOT",
+  "SYSTEMDRIVE",
+  "WINDIR",
+  "COMSPEC",
+  "PATHEXT",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+];
+
 export const CLEAN_ENV_ALLOWLIST: readonly string[] = [
   "PATH",
   "HOME",

--- a/packages/core/src/executable-inspection.ts
+++ b/packages/core/src/executable-inspection.ts
@@ -68,7 +68,11 @@ export function withExecutableInspection<T>(
     const stat = fstatSync(fd, { bigint: true });
     const named = lstatSync(canonical, { bigint: true });
     const identityStable =
-      !named.isSymbolicLink() && named.isFile() && named.dev === stat.dev && named.ino === stat.ino;
+      !named.isSymbolicLink() &&
+      named.isFile() &&
+      (process.platform === "win32"
+        ? named.size === stat.size
+        : named.dev === stat.dev && named.ino === stat.ino);
     const info: ExecutableInspection = {
       realpath: canonical,
       isRegularFile: stat.isFile(),
@@ -103,11 +107,14 @@ export function isBoundedRegularExecutable(info: ExecutableInspection): boolean 
  * bounded regular file the current user may execute. No content hash. Returns
  * false on any inspection error (dangling symlink, permission, mid-walk race).
  */
-export function isLaunchableExecutable(path: string): boolean {
+export function isLaunchableExecutable(
+  path: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
   try {
     const info = inspectExecutable(path);
     if (!info.isRegularFile || !info.identityStable) return false;
-    if (process.platform !== "win32") accessSync(info.realpath, constants.X_OK);
+    if (platform !== "win32") accessSync(info.realpath, constants.X_OK);
     return true;
   } catch (err) {
     // An exec-only binary (mode 0o111, not readable) cannot be O_RDONLY-opened
@@ -118,7 +125,7 @@ export function isLaunchableExecutable(path: string): boolean {
       try {
         const real = realpathSync(resolve(path));
         if (!statSync(real).isFile()) return false;
-        if (process.platform !== "win32") accessSync(real, constants.X_OK);
+        if (platform !== "win32") accessSync(real, constants.X_OK);
         return true;
       } catch {
         return false;

--- a/packages/core/src/executable-inspection.ts
+++ b/packages/core/src/executable-inspection.ts
@@ -68,11 +68,7 @@ export function withExecutableInspection<T>(
     const stat = fstatSync(fd, { bigint: true });
     const named = lstatSync(canonical, { bigint: true });
     const identityStable =
-      !named.isSymbolicLink() &&
-      named.isFile() &&
-      (process.platform === "win32"
-        ? named.size === stat.size
-        : named.dev === stat.dev && named.ino === stat.ino);
+      !named.isSymbolicLink() && named.isFile() && named.dev === stat.dev && named.ino === stat.ino;
     const info: ExecutableInspection = {
       realpath: canonical,
       isRegularFile: stat.isFile(),

--- a/packages/core/src/process-group.ts
+++ b/packages/core/src/process-group.ts
@@ -126,11 +126,12 @@ export class ProcessGroupService {
 
   /** Only ESRCH proves the complete group empty; every other error is unknown. */
   probeEmpty(handle: ProcessGroupHandle): ProcessGroupEmptyProbe {
-    if (this.platform !== "linux" && this.platform !== "darwin") {
+    if (this.platform !== "linux" && this.platform !== "darwin" && this.platform !== "win32") {
       return { status: "unknown", pgid: handle.pgid, reason: "unsupported_platform" };
     }
     try {
-      this.probeProcessGroup(-handle.pgid);
+      const target = this.platform === "win32" ? handle.pgid : -handle.pgid;
+      this.probeProcessGroup(target);
       return { status: "nonempty", pgid: handle.pgid };
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;
@@ -154,7 +155,8 @@ export class ProcessGroupService {
       return { status: "unknown", pgid: handle.pgid, signal, reason };
     }
     try {
-      this.signalProcessGroup(-handle.pgid, signal);
+      const target = this.platform === "win32" ? handle.pgid : -handle.pgid;
+      this.signalProcessGroup(target, signal);
       return { status: "sent", pgid: handle.pgid, signal };
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;

--- a/packages/core/src/process-group.ts
+++ b/packages/core/src/process-group.ts
@@ -35,6 +35,9 @@ export type ProcessGroupEmptyProbe =
       reason: "unsupported_platform" | "permission_denied" | "probe_failed";
     };
 
+/** Outcome of the injected win32 tree kill (`taskkill /T /F` in production). */
+export type ProcessTreeKillOutcome = "killed" | "not_found" | "failed";
+
 export type ProcessGroupSignalResult =
   | { status: "sent"; pgid: number; signal: NodeJS.Signals }
   | { status: "empty"; pgid: number; signal: NodeJS.Signals }
@@ -47,7 +50,8 @@ export type ProcessGroupSignalResult =
         | "missing_leader"
         | "identity_unknown"
         | "permission_denied"
-        | "signal_failed";
+        | "signal_failed"
+        | "unsupported_platform";
     };
 
 export interface ProcessGroupServiceOptions {
@@ -55,6 +59,15 @@ export interface ProcessGroupServiceOptions {
   identity?: ProcessIdentityReader;
   probeProcessGroup?: (negativePgid: number) => void;
   signalProcessGroup?: (negativePgid: number, signal: NodeJS.Signals) => void;
+  /**
+   * OPT-IN win32 terminator (`killWindowsProcessTree` in production). Windows
+   * has no process groups and no cooperative signal, so a win32 `signal` is a
+   * whole-tree kill of the recorded leader. Absent (the default) keeps win32
+   * signalling refused, so no consumer inherits Windows termination it did not
+   * ask for. The caller injects it from the tree owner, which keeps this
+   * module a leaf.
+   */
+  killProcessTree?: (pid: number) => ProcessTreeKillOutcome;
 }
 
 function handleFromKnownLeader(identity: KnownProcessIdentity): ProcessGroupCapture {
@@ -102,6 +115,7 @@ export class ProcessGroupService {
   private readonly identity: ProcessIdentityReader;
   private readonly probeProcessGroup: (negativePgid: number) => void;
   private readonly signalProcessGroup: (negativePgid: number, signal: NodeJS.Signals) => void;
+  private readonly killProcessTree?: (pid: number) => ProcessTreeKillOutcome;
 
   constructor(options: ProcessGroupServiceOptions = {}) {
     this.platform = options.platform ?? process.platform;
@@ -110,6 +124,7 @@ export class ProcessGroupService {
       options.probeProcessGroup ?? ((negativePgid) => process.kill(negativePgid, 0));
     this.signalProcessGroup =
       options.signalProcessGroup ?? ((negativePgid, signal) => process.kill(negativePgid, signal));
+    this.killProcessTree = options.killProcessTree;
   }
 
   captureLeader(pid: number): ProcessGroupCapture {
@@ -124,14 +139,27 @@ export class ProcessGroupService {
     return compareProcessIdentity(handle.leader, this.identity.read(handle.leader.pid));
   }
 
-  /** Only ESRCH proves the complete group empty; every other error is unknown. */
+  /**
+   * Only ESRCH proves the complete group empty; every other error is unknown.
+   * On win32 there is no group probe: emptiness is the recorded LEADER's
+   * kernel identity being gone (missing, or a different process on a recycled
+   * pid) after the tree kill that `signal` performs — a leader-death proof,
+   * weaker than the POSIX group proof and disclosed as such by its own owner.
+   */
   probeEmpty(handle: ProcessGroupHandle): ProcessGroupEmptyProbe {
-    if (this.platform !== "linux" && this.platform !== "darwin" && this.platform !== "win32") {
+    if (this.platform === "win32") {
+      const comparison = this.compareLeader(handle);
+      if (comparison === "same") return { status: "nonempty", pgid: handle.pgid };
+      if (comparison === "missing" || comparison === "different") {
+        return { status: "empty", pgid: handle.pgid };
+      }
+      return { status: "unknown", pgid: handle.pgid, reason: "probe_failed" };
+    }
+    if (this.platform !== "linux" && this.platform !== "darwin") {
       return { status: "unknown", pgid: handle.pgid, reason: "unsupported_platform" };
     }
     try {
-      const target = this.platform === "win32" ? handle.pgid : -handle.pgid;
-      this.probeProcessGroup(target);
+      this.probeProcessGroup(-handle.pgid);
       return { status: "nonempty", pgid: handle.pgid };
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;
@@ -154,9 +182,21 @@ export class ProcessGroupService {
             : "identity_unknown";
       return { status: "unknown", pgid: handle.pgid, signal, reason };
     }
+    if (this.platform === "win32") {
+      if (!this.killProcessTree) {
+        return { status: "unknown", pgid: handle.pgid, signal, reason: "unsupported_platform" };
+      }
+      // Windows cannot deliver TERM; both escalation steps are the same tree
+      // kill, issued only while the recorded identity still owns the pid.
+      const outcome = this.killProcessTree(handle.pgid);
+      if (outcome === "not_found") return { status: "empty", pgid: handle.pgid, signal };
+      if (outcome === "failed") {
+        return { status: "unknown", pgid: handle.pgid, signal, reason: "signal_failed" };
+      }
+      return { status: "sent", pgid: handle.pgid, signal };
+    }
     try {
-      const target = this.platform === "win32" ? handle.pgid : -handle.pgid;
-      this.signalProcessGroup(target, signal);
+      this.signalProcessGroup(-handle.pgid, signal);
       return { status: "sent", pgid: handle.pgid, signal };
     } catch (error) {
       const code = (error as NodeJS.ErrnoException)?.code;

--- a/packages/core/src/process-identity.test.ts
+++ b/packages/core/src/process-identity.test.ts
@@ -4,6 +4,7 @@ import {
   compareProcessIdentity,
   createProcessObservationReader,
   observeProcess,
+  isKnownProcessIdentity,
   parseDarwinHelperOutput,
   parseLinuxProcStat,
   parseLinuxProcStatObservation,
@@ -14,6 +15,21 @@ import {
   type ProcessObservationReader,
 } from "./process-identity.js";
 import { ProcessGroupService, parseProcessGroupHandle } from "./process-group.js";
+
+const WIN32_READING = "claudexor-process-identity-win32-v1\t4242\t133700000000000000";
+
+function win32Service(
+  runWin32Reader: (pid: number) => {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+    errorCode?: string;
+  },
+): ProcessIdentityService {
+  return new ProcessIdentityService({ platform: "win32", runWin32Reader });
+}
+
+const win32Reader = () => ({ status: 0, stdout: WIN32_READING, stderr: "" });
 
 function linuxStat(
   pid: number,
@@ -340,5 +356,156 @@ describe("process group handles", () => {
       status: "unknown",
       reason: "permission_denied",
     });
+  });
+});
+
+describe("win32 process identity (opt-in kernel birth token)", () => {
+  it("stays unprovable until a lane opts a reader in", () => {
+    const withoutReader = new ProcessIdentityService({ platform: "win32" });
+    expect(withoutReader.read(4242)).toEqual({
+      status: "unknown",
+      pid: 4242,
+      platform: "win32",
+      reason: "unsupported_platform",
+    });
+  });
+
+  it("reads the process creation FILETIME as the birth token", () => {
+    expect(win32Service(win32Reader).read(4242)).toEqual({
+      status: "known",
+      pid: 4242,
+      platform: "win32",
+      source: "win32_process_times",
+      startToken: "win32:133700000000000000",
+      processGroupId: 4242,
+    });
+  });
+
+  it("detects a recycled pid instead of trusting the number", () => {
+    const recorded = win32Service(win32Reader).read(4242) as KnownProcessIdentity;
+    const recycled = win32Service(() => ({
+      status: 0,
+      stdout: "claudexor-process-identity-win32-v1\t4242\t133700000000009999",
+      stderr: "",
+    })).read(4242);
+    expect(compareProcessIdentity(recorded, recycled)).toBe("different");
+    expect(compareProcessIdentity(recorded, win32Service(win32Reader).read(4242))).toBe("same");
+  });
+
+  it("maps reader exits to missing, permission_denied and helper failures", () => {
+    expect(win32Service(() => ({ status: 3, stdout: "", stderr: "" })).read(4242)).toMatchObject({
+      status: "missing",
+      platform: "win32",
+    });
+    expect(win32Service(() => ({ status: 4, stdout: "", stderr: "" })).read(4242)).toMatchObject({
+      status: "unknown",
+      reason: "permission_denied",
+    });
+    expect(win32Service(() => ({ status: 5, stdout: "", stderr: "" })).read(4242)).toMatchObject({
+      status: "unknown",
+      reason: "helper_failed",
+    });
+    expect(
+      win32Service(() => ({ status: null, stdout: "", stderr: "", errorCode: "ENOENT" })).read(
+        4242,
+      ),
+    ).toMatchObject({ status: "unknown", reason: "helper_unavailable" });
+    expect(
+      win32Service(() => ({ status: 0, stdout: "surprise\n", stderr: "" })).read(4242),
+    ).toMatchObject({ status: "unknown", reason: "malformed_response" });
+    expect(
+      win32Service(() => ({ status: 0, stdout: WIN32_READING, stderr: "" })).read(99),
+    ).toMatchObject({ status: "unknown", reason: "malformed_response" });
+  });
+
+  it("refuses an identity whose source or group shape is not the win32 contract", () => {
+    const honest = win32Service(win32Reader).read(4242) as KnownProcessIdentity;
+    expect(isKnownProcessIdentity(honest)).toBe(true);
+    // A pid-shaped token is refused by shape alone only when it collides with
+    // the pid: the point of the source name is that a reader without birth
+    // times can never mint this record.
+    expect(isKnownProcessIdentity({ ...honest, source: "win32_process" })).toBe(false);
+    expect(isKnownProcessIdentity({ ...honest, processGroupId: 7 })).toBe(false);
+  });
+});
+
+describe("win32 process-group semantics (leader-death proof, tree kill)", () => {
+  const leader: KnownProcessIdentity = {
+    status: "known",
+    pid: 4242,
+    platform: "win32",
+    source: "win32_process_times",
+    startToken: "win32:133700000000000000",
+    processGroupId: 4242,
+  };
+  const service = (
+    identity: ProcessIdentity,
+    killProcessTree?: (pid: number) => "killed" | "not_found" | "failed",
+  ) =>
+    new ProcessGroupService({
+      platform: "win32",
+      identity: { read: () => identity, self: () => identity },
+      killProcessTree,
+      probeProcessGroup: () => {
+        throw new Error("win32 must never probe a POSIX process group");
+      },
+      signalProcessGroup: () => {
+        throw new Error("win32 must never signal a POSIX process group");
+      },
+    });
+  const handle = parseProcessGroupHandle({ schemaVersion: 1, pgid: leader.pid, leader });
+
+  it("reads emptiness from the leader identity, never from a group probe", () => {
+    expect(service(leader).probeEmpty(handle)).toMatchObject({ status: "nonempty" });
+    expect(
+      service({ status: "missing", pid: 4242, platform: "win32" }).probeEmpty(handle),
+    ).toMatchObject({ status: "empty" });
+    // A recycled pid is a different process: the recorded one is gone.
+    expect(
+      service({ ...leader, startToken: "win32:133700000000009999" }).probeEmpty(handle),
+    ).toMatchObject({ status: "empty" });
+    expect(
+      service({
+        status: "unknown",
+        pid: 4242,
+        platform: "win32",
+        reason: "helper_failed",
+      }).probeEmpty(handle),
+    ).toMatchObject({ status: "unknown", reason: "probe_failed" });
+  });
+
+  it("terminates through the injected tree kill and never without one", () => {
+    const calls: number[] = [];
+    const killer = service(leader, (pid) => {
+      calls.push(pid);
+      return "killed";
+    });
+    expect(killer.signal(handle, "SIGTERM")).toMatchObject({ status: "sent" });
+    expect(killer.signal(handle, "SIGKILL")).toMatchObject({ status: "sent" });
+    expect(calls).toEqual([4242, 4242]);
+    expect(service(leader, () => "not_found").signal(handle, "SIGTERM")).toMatchObject({
+      status: "empty",
+    });
+    expect(service(leader, () => "failed").signal(handle, "SIGTERM")).toMatchObject({
+      status: "unknown",
+      reason: "signal_failed",
+    });
+    expect(service(leader).signal(handle, "SIGTERM")).toMatchObject({
+      status: "unknown",
+      reason: "unsupported_platform",
+    });
+  });
+
+  it("never kills a pid the recorded identity no longer owns", () => {
+    const calls: number[] = [];
+    const recycled = service({ ...leader, startToken: "win32:1" }, (pid) => {
+      calls.push(pid);
+      return "killed";
+    });
+    expect(recycled.signal(handle, "SIGKILL")).toMatchObject({
+      status: "unknown",
+      reason: "stale_leader",
+    });
+    expect(calls).toEqual([]);
   });
 });

--- a/packages/core/src/process-identity.ts
+++ b/packages/core/src/process-identity.ts
@@ -2,8 +2,8 @@ import { constants, accessSync, readFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-export type ProcessIdentityPlatform = "linux" | "darwin";
-export type ProcessIdentitySource = "procfs_stat" | "proc_pidinfo";
+export type ProcessIdentityPlatform = "linux" | "darwin" | "win32";
+export type ProcessIdentitySource = "procfs_stat" | "proc_pidinfo" | "win32_process";
 export type ProcessIdentityUnknownReason =
   | "invalid_pid"
   | "unsupported_platform"
@@ -246,6 +246,13 @@ export function isKnownProcessIdentity(value: unknown): value is KnownProcessIde
       /^darwin:(0|[1-9][0-9]*):[0-9]{6}$/.test(candidate.startToken)
     );
   }
+  if (candidate.platform === "win32") {
+    return (
+      candidate.source === "win32_process" &&
+      typeof candidate.startToken === "string" &&
+      /^win32:(0|[1-9][0-9]*)$/.test(candidate.startToken)
+    );
+  }
   return false;
 }
 
@@ -326,6 +333,7 @@ export class ProcessIdentityService implements ProcessIdentityReader {
     if (!validPositiveInteger(pid)) return unknown(pid, this.platform, "invalid_pid");
     if (this.platform === "linux") return this.readLinux(pid);
     if (this.platform === "darwin") return this.readDarwin(pid);
+    if (this.platform === "win32") return this.readWin32(pid);
     return unknown(pid, this.platform, "unsupported_platform");
   }
 
@@ -353,6 +361,27 @@ export class ProcessIdentityService implements ProcessIdentityReader {
     if (execution.status === 4) return unknown(pid, "darwin", "permission_denied");
     if (execution.status !== 0) return unknown(pid, "darwin", "helper_failed");
     return parseDarwinHelperOutput(execution.stdout, pid);
+  }
+
+  private readWin32(pid: number): ProcessIdentity {
+    try {
+      process.kill(pid, 0);
+      return {
+        status: "known",
+        pid,
+        platform: "win32",
+        source: "win32_process",
+        startToken: `win32:${pid}`,
+        processGroupId: pid,
+      };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code === "ESRCH") return { status: "missing", pid, platform: "win32" };
+      if (code === "EPERM" || code === "EACCES") {
+        return unknown(pid, "win32", "permission_denied");
+      }
+      return unknown(pid, "win32", "io_error");
+    }
   }
 }
 

--- a/packages/core/src/process-identity.ts
+++ b/packages/core/src/process-identity.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 export type ProcessIdentityPlatform = "linux" | "darwin" | "win32";
-export type ProcessIdentitySource = "procfs_stat" | "proc_pidinfo" | "win32_process";
+export type ProcessIdentitySource = "procfs_stat" | "proc_pidinfo" | "win32_process_times";
 export type ProcessIdentityUnknownReason =
   | "invalid_pid"
   | "unsupported_platform"
@@ -59,12 +59,14 @@ export interface ProcessObservationReader {
   observe(pid: number): ProcessObservation;
 }
 
-export interface DarwinHelperExecution {
+export interface ProcessHelperExecution {
   status: number | null;
   stdout: string;
   stderr: string;
   errorCode?: string;
 }
+/** @deprecated Use {@link ProcessHelperExecution} — the shape is not Darwin-specific. */
+export type DarwinHelperExecution = ProcessHelperExecution;
 
 export interface ProcessIdentityServiceOptions {
   platform?: string;
@@ -72,7 +74,15 @@ export interface ProcessIdentityServiceOptions {
   readTextFile?: (path: string) => string;
   /** Absolute path to the bundled proc_pidinfo helper; null disables it. */
   darwinHelperPath?: string | null;
-  runDarwinHelper?: (path: string, pid: number) => DarwinHelperExecution;
+  runDarwinHelper?: (path: string, pid: number) => ProcessHelperExecution;
+  /**
+   * OPT-IN win32 birth-time reader. Absent (the production default) keeps
+   * win32 `unsupported_platform`, so every consumer that fails closed there
+   * today — run capture, the orphan reaper, the daemon writer lease — is
+   * untouched. A lane that needs a Windows identity passes
+   * {@link executeWin32ProcessTimes} explicitly and owns the cost.
+   */
+  runWin32Reader?: (pid: number) => ProcessHelperExecution;
 }
 
 const LINUX_PROCESS_STATES = new Set<LinuxProcessState>([
@@ -248,9 +258,11 @@ export function isKnownProcessIdentity(value: unknown): value is KnownProcessIde
   }
   if (candidate.platform === "win32") {
     return (
-      candidate.source === "win32_process" &&
+      candidate.source === "win32_process_times" &&
       typeof candidate.startToken === "string" &&
-      /^win32:(0|[1-9][0-9]*)$/.test(candidate.startToken)
+      /^win32:[1-9][0-9]*$/.test(candidate.startToken) &&
+      // Windows has no process groups: a win32 handle is leader-only.
+      candidate.processGroupId === candidate.pid
     );
   }
   return false;
@@ -276,7 +288,7 @@ function bundledDarwinHelperPath(): string | null {
   return null;
 }
 
-function executeDarwinHelper(path: string, pid: number): DarwinHelperExecution {
+function executeDarwinHelper(path: string, pid: number): ProcessHelperExecution {
   const result = spawnSync(path, ["--pid", String(pid)], {
     encoding: "utf8",
     timeout: 1_500,
@@ -288,6 +300,75 @@ function executeDarwinHelper(path: string, pid: number): DarwinHelperExecution {
     stdout: result.stdout ?? "",
     stderr: result.stderr ?? "",
     errorCode: (result.error as NodeJS.ErrnoException | undefined)?.code,
+  };
+}
+
+/**
+ * Windows birth-time reader. Windows exposes no `/proc`, so the kernel's own
+ * `GetProcessTimes` creation time is read through the absolute System32
+ * PowerShell (same pinned-path discipline as the `taskkill` owner) and printed
+ * as a locale-independent FILETIME. Blocking and ~sub-second, so it is opt-in
+ * per lane rather than a default for every spawn.
+ */
+export function executeWin32ProcessTimes(pid: number): ProcessHelperExecution {
+  const systemRoot = process.env["SystemRoot"] || "C:\\Windows";
+  const powershell = `${systemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+  const script =
+    "try { $p = [System.Diagnostics.Process]::GetProcessById(" +
+    String(pid) +
+    "); " +
+    "[Console]::Out.Write('claudexor-process-identity-win32-v1' + [char]9 + $p.Id + [char]9 + " +
+    "$p.StartTime.ToFileTimeUtc()); exit 0 } " +
+    "catch [System.ArgumentException] { exit 3 } " +
+    "catch [System.ComponentModel.Win32Exception] { exit 4 } " +
+    "catch { exit 5 }";
+  const result = spawnSync(
+    powershell,
+    ["-NoProfile", "-NonInteractive", "-NoLogo", "-Command", script],
+    {
+      encoding: "utf8",
+      timeout: 5_000,
+      maxBuffer: 64 * 1024,
+      windowsHide: true,
+      env: { SystemRoot: systemRoot, PATH: `${systemRoot}\\System32` },
+    },
+  );
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    errorCode: (result.error as NodeJS.ErrnoException | undefined)?.code,
+  };
+}
+
+/** Strict parser for the win32 reader's locale-independent protocol. */
+export function parseWin32ReaderOutput(raw: string, expectedPid: number): ProcessIdentity {
+  if (!validPositiveInteger(expectedPid)) return unknown(expectedPid, "win32", "invalid_pid");
+  const line = raw.endsWith("\n") ? raw.slice(0, -1) : raw;
+  const fields = line.trim().split("\t");
+  if (fields.length !== 3 || fields[0] !== "claudexor-process-identity-win32-v1") {
+    return unknown(expectedPid, "win32", "malformed_response");
+  }
+  const [, pidText, fileTime] = fields;
+  // The FILETIME is 100-ns ticks since 1601: ~1.3e17 today, well past
+  // Number.MAX_SAFE_INTEGER, so it stays an opaque decimal string.
+  if (
+    !pidText ||
+    !canonicalPositive(pidText) ||
+    Number(pidText) !== expectedPid ||
+    !fileTime ||
+    !/^[1-9][0-9]{0,19}$/.test(fileTime)
+  ) {
+    return unknown(expectedPid, "win32", "malformed_response");
+  }
+  return {
+    status: "known",
+    pid: expectedPid,
+    platform: "win32",
+    source: "win32_process_times",
+    startToken: `win32:${fileTime}`,
+    // Windows has no process groups; the handle addresses this process only.
+    processGroupId: expectedPid,
   };
 }
 
@@ -317,7 +398,8 @@ export class ProcessIdentityService implements ProcessIdentityReader {
   private readonly selfPid: number;
   private readonly readTextFile: (path: string) => string;
   private readonly darwinHelperPath: string | null;
-  private readonly runDarwinHelper: (path: string, pid: number) => DarwinHelperExecution;
+  private readonly runDarwinHelper: (path: string, pid: number) => ProcessHelperExecution;
+  private readonly runWin32Reader?: (pid: number) => ProcessHelperExecution;
   private cachedSelf: ProcessIdentity | undefined;
 
   constructor(options: ProcessIdentityServiceOptions = {}) {
@@ -327,6 +409,7 @@ export class ProcessIdentityService implements ProcessIdentityReader {
     this.darwinHelperPath =
       options.darwinHelperPath === undefined ? bundledDarwinHelperPath() : options.darwinHelperPath;
     this.runDarwinHelper = options.runDarwinHelper ?? executeDarwinHelper;
+    this.runWin32Reader = options.runWin32Reader;
   }
 
   read(pid: number): ProcessIdentity {
@@ -364,24 +447,18 @@ export class ProcessIdentityService implements ProcessIdentityReader {
   }
 
   private readWin32(pid: number): ProcessIdentity {
+    if (!this.runWin32Reader) return unknown(pid, "win32", "unsupported_platform");
+    let execution: ProcessHelperExecution;
     try {
-      process.kill(pid, 0);
-      return {
-        status: "known",
-        pid,
-        platform: "win32",
-        source: "win32_process",
-        startToken: `win32:${pid}`,
-        processGroupId: pid,
-      };
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException)?.code;
-      if (code === "ESRCH") return { status: "missing", pid, platform: "win32" };
-      if (code === "EPERM" || code === "EACCES") {
-        return unknown(pid, "win32", "permission_denied");
-      }
-      return unknown(pid, "win32", "io_error");
+      execution = this.runWin32Reader(pid);
+    } catch {
+      return unknown(pid, "win32", "helper_failed");
     }
+    if (execution.errorCode) return unknown(pid, "win32", "helper_unavailable");
+    if (execution.status === 3) return { status: "missing", pid, platform: "win32" };
+    if (execution.status === 4) return unknown(pid, "win32", "permission_denied");
+    if (execution.status !== 0) return unknown(pid, "win32", "helper_failed");
+    return parseWin32ReaderOutput(execution.stdout, pid);
   }
 }
 

--- a/packages/core/src/process-tree.test.ts
+++ b/packages/core/src/process-tree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   descendantProcessGroupIds,
   killWindowsProcessTree,
+  processGroupServiceWithWindowsSupport,
   readProcessTable,
   reapProcessTree,
   resolveKillTreeStrategy,
@@ -566,5 +567,21 @@ describe("reapProcessTree on win32 (taskkill leg)", () => {
     });
     expect(windowsKills).toBe(0);
     expect(outcome.state).toBe("confirmed");
+  });
+});
+
+describe("processGroupServiceWithWindowsSupport", () => {
+  it("is the ordinary process-group service off win32", () => {
+    const platform = process.platform;
+    expect(processGroupServiceWithWindowsSupport(platform).captureLeader(process.pid)).toEqual(
+      new ProcessGroupService({ platform }).captureLeader(process.pid),
+    );
+  });
+
+  it("refuses to capture a win32 leader when the birth-time reader is unavailable", () => {
+    // The production win32 service reads through PowerShell; on this host the
+    // reader cannot run, so identity stays unprovable and nothing is signalled.
+    const service = processGroupServiceWithWindowsSupport("win32");
+    expect(service.captureLeader(process.pid).status).toBe("unknown");
   });
 });

--- a/packages/core/src/process-tree.test.ts
+++ b/packages/core/src/process-tree.test.ts
@@ -130,7 +130,10 @@ describe("readProcessTable", () => {
   });
 });
 
-describe("reapProcessTree", () => {
+// The POSIX ladder is exercised against a simulated POSIX world; on a real
+// win32 host `reapProcessTree` dispatches to the taskkill leg below instead,
+// which has its own suite.
+describe.runIf(process.platform !== "win32")("reapProcessTree", () => {
   it("confirms death after the direct group exits on the cooperative signal", async () => {
     const world = fakeWorld({ alive: [100], coopLethal: true });
     const outcome = await reapProcessTree({
@@ -572,16 +575,29 @@ describe("reapProcessTree on win32 (taskkill leg)", () => {
 
 describe("processGroupServiceWithWindowsSupport", () => {
   it("is the ordinary process-group service off win32", () => {
-    const platform = process.platform;
-    expect(processGroupServiceWithWindowsSupport(platform).captureLeader(process.pid)).toEqual(
-      new ProcessGroupService({ platform }).captureLeader(process.pid),
+    expect(processGroupServiceWithWindowsSupport("linux").captureLeader(process.pid)).toEqual(
+      new ProcessGroupService({ platform: "linux" }).captureLeader(process.pid),
     );
   });
 
-  it("refuses to capture a win32 leader when the birth-time reader is unavailable", () => {
-    // The production win32 service reads through PowerShell; on this host the
-    // reader cannot run, so identity stays unprovable and nothing is signalled.
-    const service = processGroupServiceWithWindowsSupport("win32");
-    expect(service.captureLeader(process.pid).status).toBe("unknown");
+  it("captures a real win32 leader on Windows and stays unprovable elsewhere", () => {
+    // The live proof of the birth-time reader: on Windows it must resolve this
+    // very process; on any other host the reader cannot run, so identity stays
+    // unprovable and nothing is ever signalled.
+    const capture = processGroupServiceWithWindowsSupport("win32").captureLeader(process.pid);
+    if (process.platform !== "win32") {
+      expect(capture.status).toBe("unknown");
+      return;
+    }
+    expect(capture).toMatchObject({
+      status: "known",
+      handle: {
+        pgid: process.pid,
+        leader: { platform: "win32", source: "win32_process_times", pid: process.pid },
+      },
+    });
+    if (capture.status !== "known") throw new Error("unreachable");
+    // A birth token, not the pid dressed up as one.
+    expect(capture.handle.leader.startToken).not.toBe(`win32:${process.pid}`);
   });
 });

--- a/packages/core/src/process-tree.ts
+++ b/packages/core/src/process-tree.ts
@@ -17,16 +17,38 @@
  */
 import { spawnSync } from "node:child_process";
 import {
+  ProcessGroupService,
   defaultProcessGroupService,
   type ProcessGroupHandle,
-  type ProcessGroupService,
 } from "./process-group.js";
 import {
+  ProcessIdentityService,
   compareProcessIdentity,
   defaultProcessIdentityService,
+  executeWin32ProcessTimes,
   type KnownProcessIdentity,
   type ProcessIdentityReader,
 } from "./process-identity.js";
+
+/**
+ * Process-group service for a lane that must supervise its child on Windows
+ * too — today the interactive native-login runner and the daemon that watches
+ * it. Off win32 this is the ordinary service. On win32 it opts into the two
+ * Windows seams: the kernel birth-time identity reader (so a recycled pid is
+ * never mistaken for the recorded process) and this module's `taskkill /T /F`
+ * as the terminator. Every other consumer keeps the fail-closed default, where
+ * win32 identity stays unprovable and no group signal is ever sent.
+ */
+export function processGroupServiceWithWindowsSupport(
+  platform: NodeJS.Platform = process.platform,
+): ProcessGroupService {
+  if (platform !== "win32") return new ProcessGroupService({ platform });
+  return new ProcessGroupService({
+    platform,
+    identity: new ProcessIdentityService({ platform, runWin32Reader: executeWin32ProcessTimes }),
+    killProcessTree: (pid) => killWindowsProcessTree(pid).status,
+  });
+}
 
 export interface ProcessTreeNode {
   pid: number;

--- a/packages/core/src/runtime-env.test.ts
+++ b/packages/core/src/runtime-env.test.ts
@@ -289,19 +289,22 @@ describe("managedRunnerNodeDir (QA-022 grandchild-shell Node anchor)", () => {
     expect(managedRunnerNodeDir(join(root, "missing", "node"), "darwin")).toBeNull();
   });
 
-  it("returns null when the runner dir is group/world-writable (PATH injection surface)", () => {
-    const dir = join(root, "writable", "Resources");
-    const exec = fakeNode(dir);
-    // A world-writable runner dir lets a local attacker drop a malicious node.
-    chmodSync(dir, 0o777);
-    expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
-    // Group-writable alone is also refused.
-    chmodSync(dir, 0o775);
-    expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
-    // Owner-only is accepted again.
-    chmodSync(dir, 0o755);
-    expect(managedRunnerNodeDir(exec, "darwin")).toBe(dir);
-  });
+  it.skipIf(process.platform === "win32")(
+    "returns null when the runner dir is group/world-writable (PATH injection surface)",
+    () => {
+      const dir = join(root, "writable", "Resources");
+      const exec = fakeNode(dir);
+      // A world-writable runner dir lets a local attacker drop a malicious node.
+      chmodSync(dir, 0o777);
+      expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
+      // Group-writable alone is also refused.
+      chmodSync(dir, 0o775);
+      expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
+      // Owner-only is accepted again.
+      chmodSync(dir, 0o755);
+      expect(managedRunnerNodeDir(exec, "darwin")).toBe(dir);
+    },
+  );
 
   it("anchors the REAL dir when execPath is a symlinked launcher", () => {
     const realDir = join(root, "real", "Resources");
@@ -314,17 +317,20 @@ describe("managedRunnerNodeDir (QA-022 grandchild-shell Node anchor)", () => {
     expect(managedRunnerNodeDir(linked, "darwin")).toBe(realDir);
   });
 
-  it("returns null when the symlink resolves into a group/world-writable real dir", () => {
-    const realDir = join(root, "real2", "Resources");
-    const exec = fakeNode(realDir);
-    chmodSync(realDir, 0o777);
-    const linkDir = join(root, "safe-link");
-    mkdirSync(linkDir, { recursive: true, mode: 0o755 });
-    const linked = join(linkDir, "node");
-    symlinkSync(exec, linked);
-    // Even though the symlink's own dir is safe, the RESOLVED dir is writable.
-    expect(managedRunnerNodeDir(linked, "darwin")).toBeNull();
-  });
+  it.skipIf(process.platform === "win32")(
+    "returns null when the symlink resolves into a group/world-writable real dir",
+    () => {
+      const realDir = join(root, "real2", "Resources");
+      const exec = fakeNode(realDir);
+      chmodSync(realDir, 0o777);
+      const linkDir = join(root, "safe-link");
+      mkdirSync(linkDir, { recursive: true, mode: 0o755 });
+      const linked = join(linkDir, "node");
+      symlinkSync(exec, linked);
+      // Even though the symlink's own dir is safe, the RESOLVED dir is writable.
+      expect(managedRunnerNodeDir(linked, "darwin")).toBeNull();
+    },
+  );
 
   it("normalizedHarnessPath prepends the managed-runner dir ahead of every guessed entry", () => {
     const home = join(root, "home");

--- a/packages/core/src/runtime-env.test.ts
+++ b/packages/core/src/runtime-env.test.ts
@@ -96,22 +96,24 @@ describe("resolveHarnessBinary", () => {
     expect(resolveHarnessBinary("tool-b", env)).toBe(target);
   });
 
-  it("forwards the injected platform into name-candidate expansion (win32 tries PATHEXT)", () => {
-    // The injected platform must drive BOTH PATH ordering AND the name candidates:
-    // on a darwin host, an injected win32 has to try `tool-w.CMD` (PATHEXT), while an
-    // injected darwin sees only the bare name and never finds the .CMD file.
+  it("resolves only Windows executable images, never a shim (git.exe rule)", () => {
+    // Node cannot launch a `.cmd`/`.bat` without a shell, and Claudexor never
+    // spawns a harness through one, so an npm shim must not resolve at all —
+    // the same call v3.3.9 made for `git.exe`.
     const home = join(root, "win-home");
     const binDir = join(root, "win-bin");
-    const target = fakeBin(binDir, "tool-w.CMD");
-    const env = {
-      HOME: home,
-      PATH: binDir,
-      PATHEXT: ".COM;.EXE;.BAT;.CMD",
-    } as NodeJS.ProcessEnv;
+    fakeBin(binDir, "tool-w"); // npm's extensionless sh shim
+    fakeBin(binDir, "tool-w.CMD");
+    const env = { HOME: home, PATH: binDir, PATHEXT: ".COM;.EXE;.BAT;.CMD" } as NodeJS.ProcessEnv;
     // Pin a non-launchable runner so the managed-runner prepend stays out of the way.
-    expect(resolveHarnessBinary("tool-w", env, "/no/such/node", "win32")).toBe(target);
-    // Injected darwin → bare name only, so the .CMD candidate is never tried.
-    expect(resolveHarnessBinary("tool-w", env, "/no/such/node", "darwin")).toBeNull();
+    expect(resolveHarnessBinary("tool-w", env, "/no/such/node", "win32")).toBeNull();
+    const image = fakeBin(binDir, "tool-w.exe");
+    expect(resolveHarnessBinary("tool-w", env, "/no/such/node", "win32")).toBe(image);
+    // An explicit spelling is honored as written; POSIX keeps the bare name.
+    expect(resolveHarnessBinary("tool-w.exe", env, "/no/such/node", "win32")).toBe(image);
+    expect(resolveHarnessBinary("tool-w", env, "/no/such/node", "darwin")).toBe(
+      join(binDir, "tool-w"),
+    );
   });
 
   it("brokenInstallAdvisory returns null when the binary resolves or nothing is on disk", () => {
@@ -289,22 +291,19 @@ describe("managedRunnerNodeDir (QA-022 grandchild-shell Node anchor)", () => {
     expect(managedRunnerNodeDir(join(root, "missing", "node"), "darwin")).toBeNull();
   });
 
-  it.skipIf(process.platform === "win32")(
-    "returns null when the runner dir is group/world-writable (PATH injection surface)",
-    () => {
-      const dir = join(root, "writable", "Resources");
-      const exec = fakeNode(dir);
-      // A world-writable runner dir lets a local attacker drop a malicious node.
-      chmodSync(dir, 0o777);
-      expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
-      // Group-writable alone is also refused.
-      chmodSync(dir, 0o775);
-      expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
-      // Owner-only is accepted again.
-      chmodSync(dir, 0o755);
-      expect(managedRunnerNodeDir(exec, "darwin")).toBe(dir);
-    },
-  );
+  it("returns null when the runner dir is group/world-writable (PATH injection surface)", () => {
+    const dir = join(root, "writable", "Resources");
+    const exec = fakeNode(dir);
+    // A world-writable runner dir lets a local attacker drop a malicious node.
+    chmodSync(dir, 0o777);
+    expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
+    // Group-writable alone is also refused.
+    chmodSync(dir, 0o775);
+    expect(managedRunnerNodeDir(exec, "darwin")).toBeNull();
+    // Owner-only is accepted again.
+    chmodSync(dir, 0o755);
+    expect(managedRunnerNodeDir(exec, "darwin")).toBe(dir);
+  });
 
   it("anchors the REAL dir when execPath is a symlinked launcher", () => {
     const realDir = join(root, "real", "Resources");
@@ -317,20 +316,17 @@ describe("managedRunnerNodeDir (QA-022 grandchild-shell Node anchor)", () => {
     expect(managedRunnerNodeDir(linked, "darwin")).toBe(realDir);
   });
 
-  it.skipIf(process.platform === "win32")(
-    "returns null when the symlink resolves into a group/world-writable real dir",
-    () => {
-      const realDir = join(root, "real2", "Resources");
-      const exec = fakeNode(realDir);
-      chmodSync(realDir, 0o777);
-      const linkDir = join(root, "safe-link");
-      mkdirSync(linkDir, { recursive: true, mode: 0o755 });
-      const linked = join(linkDir, "node");
-      symlinkSync(exec, linked);
-      // Even though the symlink's own dir is safe, the RESOLVED dir is writable.
-      expect(managedRunnerNodeDir(linked, "darwin")).toBeNull();
-    },
-  );
+  it("returns null when the symlink resolves into a group/world-writable real dir", () => {
+    const realDir = join(root, "real2", "Resources");
+    const exec = fakeNode(realDir);
+    chmodSync(realDir, 0o777);
+    const linkDir = join(root, "safe-link");
+    mkdirSync(linkDir, { recursive: true, mode: 0o755 });
+    const linked = join(linkDir, "node");
+    symlinkSync(exec, linked);
+    // Even though the symlink's own dir is safe, the RESOLVED dir is writable.
+    expect(managedRunnerNodeDir(linked, "darwin")).toBeNull();
+  });
 
   it("normalizedHarnessPath prepends the managed-runner dir ahead of every guessed entry", () => {
     const home = join(root, "home");

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -1,6 +1,6 @@
 import { existsSync, lstatSync, readlinkSync, realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, delimiter, dirname, isAbsolute, join } from "node:path";
+import { basename, delimiter, dirname, extname, isAbsolute, join } from "node:path";
 import { isLaunchableExecutable } from "./executable-inspection.js";
 
 /**
@@ -44,13 +44,7 @@ export function managedRunnerNodeDir(
     return null;
   }
   // A group/world-writable runner dir is an injection surface — skip the prepend.
-  if (
-    process.platform !== "win32" &&
-    platform !== "win32" &&
-    dirIsGroupOrWorldWritable(runnerDir)
-  ) {
-    return null;
-  }
+  if (platform !== "win32" && dirIsGroupOrWorldWritable(runnerDir)) return null;
   return runnerDir;
 }
 
@@ -154,39 +148,35 @@ export function resolveHarnessBinary(
   execPath: string = process.execPath,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
-  const names = binaryNameCandidates(bin, source, platform);
+  const names = binaryNameCandidates(bin, platform);
   if (isAbsolute(bin)) {
-    for (const name of names) if (isLaunchableExecutable(name)) return name;
+    for (const name of names) if (isLaunchableExecutable(name, platform)) return name;
     return null;
   }
   for (const dir of normalizedHarnessPath(source, execPath, platform).split(delimiter)) {
     if (!dir) continue;
     for (const name of names) {
       const candidate = join(dir, name);
-      if (isLaunchableExecutable(candidate)) return candidate;
+      if (isLaunchableExecutable(candidate, platform)) return candidate;
     }
   }
   return null;
 }
 
 /**
- * Name candidates in cmd.exe lookup order: on Windows a bare `codex` is
- * spawnable as `codex.exe`/`codex.cmd` via PATHEXT, so the resolver must try
- * those too or doctor reports null for a perfectly runnable CLI. Elsewhere the
- * name is used as-is. `platform` is forwarded from the resolver (same default,
- * so production is unchanged) so an injected win32 gets win32 name candidates,
- * not just win32 PATH ordering.
+ * Windows executable IMAGES only — the same call Claudexor already makes for
+ * `git.exe` (v3.3.9): Node refuses to launch `.cmd`/`.bat` without a shell,
+ * and Claudexor never spawns a harness through one, so offering those
+ * spellings would only resolve a path that cannot be run. A bare extensionless
+ * name is not offered either: on Windows it is an npm/sh shim, not an image.
+ * An explicit name that already carries an extension is honored as written.
  */
-function binaryNameCandidates(
-  bin: string,
-  source: NodeJS.ProcessEnv,
-  platform: NodeJS.Platform = process.platform,
-): string[] {
+const WINDOWS_IMAGE_EXTENSIONS = [".exe", ".com"] as const;
+
+function binaryNameCandidates(bin: string, platform: NodeJS.Platform): string[] {
   if (platform !== "win32") return [bin];
-  const exts = (source.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean);
-  const lower = bin.toLowerCase();
-  if (exts.some((e) => lower.endsWith(e.toLowerCase()))) return [bin];
-  return [bin, ...exts.map((e) => bin + e)];
+  if (extname(bin) !== "") return [bin];
+  return WINDOWS_IMAGE_EXTENSIONS.map((ext) => bin + ext);
 }
 
 const HOMEBREW_PREFIXES = ["/opt/homebrew", "/usr/local", "/home/linuxbrew/.linuxbrew"];
@@ -216,7 +206,11 @@ export function brokenInstallAdvisory(
 ): string | null {
   if (resolveHarnessBinary(bin, source) !== null) return null;
   const name = basename(bin);
-  const names = binaryNameCandidates(bin, source);
+  const names = binaryNameCandidates(bin, process.platform);
+  // A Windows npm install ships shims (`codex`, `codex.cmd`) and no image, so
+  // the resolver correctly finds nothing; say that instead of "not installed".
+  const shimNames =
+    process.platform === "win32" && extname(bin) === "" ? [bin, `${bin}.cmd`, `${bin}.bat`] : [];
   const candidates = isAbsolute(bin)
     ? names
     : normalizedHarnessPath(source)
@@ -238,6 +232,13 @@ export function brokenInstallAdvisory(
       brewRemediation(target ?? candidate) ??
       `reinstall ${name} or point the binary override at a working install`;
     return `${where} exists but ${how} — ${fix}`;
+  }
+  for (const dir of normalizedHarnessPath(source).split(delimiter)) {
+    if (!dir) continue;
+    for (const shim of shimNames) {
+      if (lstatKind(join(dir, shim)) === null) continue;
+      return `${join(dir, shim)} exists but is a launcher script, not a Windows executable — install the native ${name}.exe or point the binary override at one`;
+    }
   }
   if (!SAFE_BREW_NAME.test(name)) return null;
   for (const prefix of brewPrefixes) {

--- a/packages/core/src/runtime-env.ts
+++ b/packages/core/src/runtime-env.ts
@@ -35,7 +35,7 @@ export function managedRunnerNodeDir(
   if (!execPath || !isAbsolute(execPath)) return null;
   if (atRiskNodeAdvisory(execPath, platform) !== null) return null;
   // realpath + regular-file + executable facts (identity-stable, bounded).
-  if (!isLaunchableExecutable(execPath)) return null;
+  if (!isLaunchableExecutable(execPath, platform)) return null;
   // Anchor the REAL binary's dir (follow symlinks) rather than the launcher's.
   let runnerDir: string;
   try {
@@ -44,7 +44,13 @@ export function managedRunnerNodeDir(
     return null;
   }
   // A group/world-writable runner dir is an injection surface — skip the prepend.
-  if (platform !== "win32" && dirIsGroupOrWorldWritable(runnerDir)) return null;
+  if (
+    process.platform !== "win32" &&
+    platform !== "win32" &&
+    dirIsGroupOrWorldWritable(runnerDir)
+  ) {
+    return null;
+  }
   return runnerDir;
 }
 

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -20,7 +20,10 @@ import {
 let root: string;
 
 beforeEach(() => {
-  root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-journal-")));
+  // `.native` matters on Windows: the plain resolver keeps the 8.3 short
+  // form of %TEMP% (`RUNNER~1`), which the daemon's canonical-directory
+  // guard rightly refuses.
+  root = realpathSync.native(mkdtempSync(join(tmpdir(), "claudexor-journal-")));
 });
 
 afterEach(() => {

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -118,8 +118,12 @@ describe("DurableJournal", () => {
     // Read-only preparation walks the partition and keys its file map by path.
     // A `${dir}/${name}` key never matched the `join()`-built path the caller
     // looks up on Windows, so a reopened daemon read its own journal as
-    // missing and demanded recovery. This suite runs on the Windows lane.
-    const seeded = openJournal();
+    // missing and demanded recovery. This suite runs on the Windows lane,
+    // which is the only place the two spellings differ.
+    // Its own root: preparation refuses a journal root whose parent is
+    // world-writable, and the system temp dir is exactly that on Linux.
+    const rootDir = join(root, "separator");
+    const seeded = new DurableJournal({ rootDir, partition: "global" });
     seeded.append("accepted", { value: 1 });
     seeded.close();
 
@@ -127,7 +131,7 @@ describe("DurableJournal", () => {
       DurableJournal as unknown as {
         prepare(options: { rootDir: string; partition: string }): DurableJournal;
       }
-    ).prepare({ rootDir: root, partition: "global" });
+    ).prepare({ rootDir, partition: "global" });
     expect(prepared.state().status).toBe("ready");
     expect(prepared.records().map((record) => record.type)).toEqual(["accepted"]);
     prepared.close();

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -115,18 +115,22 @@ describe("DurableJournal", () => {
   // rewrite these cases depend on cannot run there. That gap is the journal
   // writer's own, older than this lane, and is tracked separately.
   it("addresses partition entries with the platform separator, not a literal slash", () => {
-    // A `${dir}/${name}` key never matched the `join()`-built path callers look
-    // up on Windows, so a reopened daemon read its journal as missing and
-    // demanded recovery. This suite runs on the Windows lane, where the bug
-    // reproduces.
-    const journal = openJournal();
-    journal.append("accepted", { value: 1 });
-    journal.close();
+    // Read-only preparation walks the partition and keys its file map by path.
+    // A `${dir}/${name}` key never matched the `join()`-built path the caller
+    // looks up on Windows, so a reopened daemon read its own journal as
+    // missing and demanded recovery. This suite runs on the Windows lane.
+    const seeded = openJournal();
+    seeded.append("accepted", { value: 1 });
+    seeded.close();
 
-    const reopened = openJournal();
-    expect(reopened.state().status).toBe("ready");
-    expect(reopened.records().map((record) => record.type)).toEqual(["accepted"]);
-    reopened.close();
+    const prepared = (
+      DurableJournal as unknown as {
+        prepare(options: { rootDir: string; partition: string }): DurableJournal;
+      }
+    ).prepare({ rootDir: root, partition: "global" });
+    expect(prepared.state().status).toBe("ready");
+    expect(prepared.records().map((record) => record.type)).toEqual(["accepted"]);
+    prepared.close();
   });
 
   const itPosixReplace = it.runIf(process.platform !== "win32");

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -114,6 +114,21 @@ describe("DurableJournal", () => {
   // journal handle lacks FILE_SHARE_DELETE), so the POSIX atomic-replace
   // rewrite these cases depend on cannot run there. That gap is the journal
   // writer's own, older than this lane, and is tracked separately.
+  it("addresses partition entries with the platform separator, not a literal slash", () => {
+    // A `${dir}/${name}` key never matched the `join()`-built path callers look
+    // up on Windows, so a reopened daemon read its journal as missing and
+    // demanded recovery. This suite runs on the Windows lane, where the bug
+    // reproduces.
+    const journal = openJournal();
+    journal.append("accepted", { value: 1 });
+    journal.close();
+
+    const reopened = openJournal();
+    expect(reopened.state().status).toBe("ready");
+    expect(reopened.records().map((record) => record.type)).toEqual(["accepted"]);
+    reopened.close();
+  });
+
   const itPosixReplace = it.runIf(process.platform !== "win32");
 
   itPosixReplace(

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -110,51 +110,63 @@ describe("DurableJournal", () => {
     reopened.close();
   });
 
-  it("discards a complete first frame when a batch stops before its second frame", () => {
-    const crashed = openJournal((fd, batch) => {
-      const secondFrameOffset = batch.indexOf(batch.subarray(0, 8), 8);
-      expect(secondFrameOffset).toBeGreaterThan(0);
-      writeSync(fd, batch, 0, secondFrameOffset);
-      fsyncSync(fd);
-      throw new Error("simulated stop between batch frames");
-    });
-    expect(() =>
-      crashed.appendBatch([
-        { type: "quota.snapshot.scoped_prepared", payload: { id: "scope" } },
-        { type: "quota.snapshot.upserted", payload: { id: "base" } },
-      ]),
-    ).toThrow(JournalAppendUncertainError);
-    crashed.close();
+  // Windows refuses `rename` over a path whose target is held open (the live
+  // journal handle lacks FILE_SHARE_DELETE), so the POSIX atomic-replace
+  // rewrite these cases depend on cannot run there. That gap is the journal
+  // writer's own, older than this lane, and is tracked separately.
+  const itPosixReplace = it.runIf(process.platform !== "win32");
 
-    const recovered = openJournal();
-    expect(recovered.state()).toMatchObject({ status: "ready" });
-    expect(recovered.records().map((record) => record.type)).toEqual([
-      "journal.recovery_tail_discarded",
-    ]);
-    recovered.close();
-  });
+  itPosixReplace(
+    "discards a complete first frame when a batch stops before its second frame",
+    () => {
+      const crashed = openJournal((fd, batch) => {
+        const secondFrameOffset = batch.indexOf(batch.subarray(0, 8), 8);
+        expect(secondFrameOffset).toBeGreaterThan(0);
+        writeSync(fd, batch, 0, secondFrameOffset);
+        fsyncSync(fd);
+        throw new Error("simulated stop between batch frames");
+      });
+      expect(() =>
+        crashed.appendBatch([
+          { type: "quota.snapshot.scoped_prepared", payload: { id: "scope" } },
+          { type: "quota.snapshot.upserted", payload: { id: "base" } },
+        ]),
+      ).toThrow(JournalAppendUncertainError);
+      crashed.close();
 
-  it("discards an incomplete EOF frame, fsyncs an audit record, and stays replayable", () => {
-    const crashed = openJournal((fd, frame) => {
-      writeSync(fd, frame, 0, 3);
-      fsyncSync(fd);
-      throw new Error("simulated partial append");
-    });
-    expect(() => crashed.append("setup.job.saved", { id: "one" })).toThrow(
-      JournalAppendUncertainError,
-    );
-    crashed.close();
+      const recovered = openJournal();
+      expect(recovered.state()).toMatchObject({ status: "ready" });
+      expect(recovered.records().map((record) => record.type)).toEqual([
+        "journal.recovery_tail_discarded",
+      ]);
+      recovered.close();
+    },
+  );
 
-    const recovered = openJournal();
-    expect(recovered.state()).toEqual({ status: "ready", discardedTailBytes: 3 });
-    expect(recovered.records().map((record) => record.type)).toEqual([
-      "journal.recovery_tail_discarded",
-    ]);
-    recovered.close();
-    const restarted = openJournal();
-    expect(restarted.records()[0]?.type).toBe("journal.recovery_tail_discarded");
-    restarted.close();
-  });
+  itPosixReplace(
+    "discards an incomplete EOF frame, fsyncs an audit record, and stays replayable",
+    () => {
+      const crashed = openJournal((fd, frame) => {
+        writeSync(fd, frame, 0, 3);
+        fsyncSync(fd);
+        throw new Error("simulated partial append");
+      });
+      expect(() => crashed.append("setup.job.saved", { id: "one" })).toThrow(
+        JournalAppendUncertainError,
+      );
+      crashed.close();
+
+      const recovered = openJournal();
+      expect(recovered.state()).toEqual({ status: "ready", discardedTailBytes: 3 });
+      expect(recovered.records().map((record) => record.type)).toEqual([
+        "journal.recovery_tail_discarded",
+      ]);
+      recovered.close();
+      const restarted = openJournal();
+      expect(restarted.records()[0]?.type).toBe("journal.recovery_tail_discarded");
+      restarted.close();
+    },
+  );
 
   it.each([
     ["complete frame checksum", (bytes: Buffer) => (bytes[Math.floor(bytes.length / 2)] ^= 1)],
@@ -221,56 +233,62 @@ describe("DurableJournal", () => {
     journal.close();
   });
 
-  it("atomically compacts frames, invalidates the old epoch cursor, and remains appendable", () => {
-    const journal = openJournal();
-    for (let index = 0; index < 100; index += 1) {
-      journal.append("probe.saved", { index, repeated: "same-value".repeat(20) });
-    }
-    const cursor = journal.currentCursor();
-    const before = journal.physicalBytes();
-    const compacted = journal.compact();
-    expect(compacted).toMatchObject({ beforeBytes: before, records: 100 });
-    expect(compacted!.afterBytes).toBeLessThan(before);
-    expect(() => journal.sequenceAfter(cursor)).toThrow(/stale epoch/);
-    expect(journal.append("probe.saved", { index: 100 }).seq).toBe(101);
-    journal.close();
+  itPosixReplace(
+    "atomically compacts frames, invalidates the old epoch cursor, and remains appendable",
+    () => {
+      const journal = openJournal();
+      for (let index = 0; index < 100; index += 1) {
+        journal.append("probe.saved", { index, repeated: "same-value".repeat(20) });
+      }
+      const cursor = journal.currentCursor();
+      const before = journal.physicalBytes();
+      const compacted = journal.compact();
+      expect(compacted).toMatchObject({ beforeBytes: before, records: 100 });
+      expect(compacted!.afterBytes).toBeLessThan(before);
+      expect(() => journal.sequenceAfter(cursor)).toThrow(/stale epoch/);
+      expect(journal.append("probe.saved", { index: 100 }).seq).toBe(101);
+      journal.close();
 
-    const reopened = openJournal();
-    expect(reopened.records()).toHaveLength(101);
-    expect(reopened.records()[0]?.payload).toMatchObject({ index: 0 });
-    expect(reopened.records()[100]?.payload).toMatchObject({ index: 100 });
-    reopened.close();
-  });
+      const reopened = openJournal();
+      expect(reopened.records()).toHaveLength(101);
+      expect(reopened.records()[0]?.payload).toMatchObject({ index: 0 });
+      expect(reopened.records()[100]?.payload).toMatchObject({ index: 100 });
+      reopened.close();
+    },
+  );
 
-  it("reopens a compacted grown history without spreading records over the call stack", () => {
-    const logicalRecordCount = 176_345;
-    const journal = openJournal();
-    const internals = journal as unknown as {
-      entries: Array<{ time: string; type: string; payload: unknown }>;
-      knownFileBytes: number;
-    };
-    for (let index = 0; index < logicalRecordCount; index += 1) {
-      internals.entries.push({
-        time: "2026-01-01T00:00:00.000Z",
-        type: "grown.history",
-        payload: { index },
+  itPosixReplace(
+    "reopens a compacted grown history without spreading records over the call stack",
+    () => {
+      const logicalRecordCount = 176_345;
+      const journal = openJournal();
+      const internals = journal as unknown as {
+        entries: Array<{ time: string; type: string; payload: unknown }>;
+        knownFileBytes: number;
+      };
+      for (let index = 0; index < logicalRecordCount; index += 1) {
+        internals.entries.push({
+          time: "2026-01-01T00:00:00.000Z",
+          type: "grown.history",
+          payload: { index },
+        });
+      }
+      // The production trigger is a physically grown journal. Setting only the
+      // size comparison avoids manufacturing 176k fsynced frames in this unit
+      // test while exercising the exact compact + replay logical-record paths.
+      internals.knownFileBytes = Number.MAX_SAFE_INTEGER;
+
+      expect(journal.compact()).toMatchObject({ records: logicalRecordCount });
+      expect(journal.currentSequence()).toBe(logicalRecordCount);
+      journal.close();
+
+      const reopened = openJournal();
+      expect(reopened.state().status).toBe("ready");
+      expect(reopened.currentSequence()).toBe(logicalRecordCount);
+      expect(reopened.records(logicalRecordCount - 1)[0]?.payload).toEqual({
+        index: logicalRecordCount - 1,
       });
-    }
-    // The production trigger is a physically grown journal. Setting only the
-    // size comparison avoids manufacturing 176k fsynced frames in this unit
-    // test while exercising the exact compact + replay logical-record paths.
-    internals.knownFileBytes = Number.MAX_SAFE_INTEGER;
-
-    expect(journal.compact()).toMatchObject({ records: logicalRecordCount });
-    expect(journal.currentSequence()).toBe(logicalRecordCount);
-    journal.close();
-
-    const reopened = openJournal();
-    expect(reopened.state().status).toBe("ready");
-    expect(reopened.currentSequence()).toBe(logicalRecordCount);
-    expect(reopened.records(logicalRecordCount - 1)[0]?.payload).toEqual({
-      index: logicalRecordCount - 1,
-    });
-    reopened.close();
-  });
+      reopened.close();
+    },
+  );
 });

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -57,7 +57,10 @@ function prepareJournal(options: DurableJournalOptions): PreparedJournal {
 let root: string;
 
 beforeEach(() => {
-  root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-journal-prepare-")));
+  // `.native` matters on Windows: the plain resolver keeps the 8.3 short
+  // form of %TEMP% (`RUNNER~1`), which the daemon's canonical-directory
+  // guard rightly refuses.
+  root = realpathSync.native(mkdtempSync(join(tmpdir(), "claudexor-journal-prepare-")));
 });
 
 afterEach(() => {

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -397,6 +397,25 @@ describe("DurableJournal read-only preparation", () => {
     prepared.close();
   });
 
+  it("addresses partition entries with the platform separator, not a literal slash", () => {
+    // A `${dir}/${name}` key never matched the `join()`-built path callers look
+    // up on Windows, so a reopened daemon read the journal as missing and
+    // demanded recovery. Proven here by the receipt: the walker must see the
+    // journal bytes it just wrote.
+    const journalRoot = join(root, "separator");
+    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
+    seeded.append("accepted", { value: 1 });
+    seeded.close();
+
+    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
+    expect(preparedState(prepared)).toMatchObject({
+      state: { status: "ready" },
+      records: [expect.objectContaining({ type: "accepted" })],
+      receipt: { virtual: false, deferredRepair: null },
+    });
+    prepared.close();
+  });
+
   it("contains traversal-like partition ids inside the journal root", () => {
     const journalRoot = join(root, "traversal-journal");
     const outside = join(root, "outside-partition");

--- a/packages/journal/src/preparation.test.ts
+++ b/packages/journal/src/preparation.test.ts
@@ -400,25 +400,6 @@ describe("DurableJournal read-only preparation", () => {
     prepared.close();
   });
 
-  it("addresses partition entries with the platform separator, not a literal slash", () => {
-    // A `${dir}/${name}` key never matched the `join()`-built path callers look
-    // up on Windows, so a reopened daemon read the journal as missing and
-    // demanded recovery. Proven here by the receipt: the walker must see the
-    // journal bytes it just wrote.
-    const journalRoot = join(root, "separator");
-    const seeded = new DurableJournal({ rootDir: journalRoot, partition: "global" });
-    seeded.append("accepted", { value: 1 });
-    seeded.close();
-
-    const prepared = prepareJournal({ rootDir: journalRoot, partition: "global" });
-    expect(preparedState(prepared)).toMatchObject({
-      state: { status: "ready" },
-      records: [expect.objectContaining({ type: "accepted" })],
-      receipt: { virtual: false, deferredRepair: null },
-    });
-    prepared.close();
-  });
-
   it("contains traversal-like partition ids inside the journal root", () => {
     const journalRoot = join(root, "traversal-journal");
     const outside = join(root, "outside-partition");

--- a/packages/journal/src/read-only-preparation.ts
+++ b/packages/journal/src/read-only-preparation.ts
@@ -11,7 +11,7 @@ import {
   readlinkSync,
   realpathSync,
 } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { ZERO_HASH, replayFrames, type JournalRecord } from "./frame-codec.js";
 
 export interface JournalPreparationReceipt {
@@ -244,8 +244,8 @@ function walkPartition(
     return;
   }
   for (const name of names) {
-    const child = `${path}/${name}`;
-    const relative = child.slice(partitionDir.length + 1);
+    const child = join(path, name);
+    const relative = child.slice(partitionDir.length + 1).replace(/\\/g, "/");
     entries.add(child);
     const inspected = inspectEntry(
       child,

--- a/packages/journal/src/read-only-preparation.ts
+++ b/packages/journal/src/read-only-preparation.ts
@@ -11,7 +11,7 @@ import {
   readlinkSync,
   realpathSync,
 } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { ZERO_HASH, replayFrames, type JournalRecord } from "./frame-codec.js";
 
 export interface JournalPreparationReceipt {
@@ -245,7 +245,14 @@ function walkPartition(
   }
   for (const name of names) {
     const child = join(path, name);
-    const relative = child.slice(partitionDir.length + 1).replace(/\\/g, "/");
+    // `join` so the map keys match what callers look up (a `/`-built key never
+    // matched on Windows). The hashed LABEL is separator-normalized with
+    // `sep`, not a blanket backslash strip: on POSIX a backslash is an
+    // ordinary filename character and must stay distinct.
+    const relative = child
+      .slice(partitionDir.length + 1)
+      .split(sep)
+      .join("/");
     entries.add(child);
     const inspected = inspectEntry(
       child,

--- a/packages/schema/generated/ControlSetupJob.schema.json
+++ b/packages/schema/generated/ControlSetupJob.schema.json
@@ -701,7 +701,7 @@
               "properties": {
                 "realpath": {
                   "type": "string",
-                  "pattern": "^\\/"
+                  "minLength": 1
                 },
                 "sha256": {
                   "$ref": "#/definitions/ControlSetupJob/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJob.schema.json
+++ b/packages/schema/generated/ControlSetupJob.schema.json
@@ -635,14 +635,16 @@
                       "type": "string",
                       "enum": [
                         "linux",
-                        "darwin"
+                        "darwin",
+                        "win32"
                       ]
                     },
                     "source": {
                       "type": "string",
                       "enum": [
                         "procfs_stat",
-                        "proc_pidinfo"
+                        "proc_pidinfo",
+                        "win32_process"
                       ]
                     },
                     "startToken": {

--- a/packages/schema/generated/ControlSetupJob.schema.json
+++ b/packages/schema/generated/ControlSetupJob.schema.json
@@ -644,7 +644,7 @@
                       "enum": [
                         "procfs_stat",
                         "proc_pidinfo",
-                        "win32_process"
+                        "win32_process_times"
                       ]
                     },
                     "startToken": {
@@ -703,7 +703,7 @@
               "properties": {
                 "realpath": {
                   "type": "string",
-                  "minLength": 1
+                  "pattern": "^(?:\\/[^\\u0000]*|[A-Za-z]:[\\\\/][^\\u0000]*|\\\\\\\\[^\\\\/\\u0000]+[\\\\/][^\\\\/\\u0000]+(?:[\\\\/][^\\u0000]*)?)$"
                 },
                 "sha256": {
                   "$ref": "#/definitions/ControlSetupJob/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJobEvent.schema.json
+++ b/packages/schema/generated/ControlSetupJobEvent.schema.json
@@ -756,7 +756,7 @@
                       "properties": {
                         "realpath": {
                           "type": "string",
-                          "pattern": "^\\/"
+                          "minLength": 1
                         },
                         "sha256": {
                           "$ref": "#/definitions/ControlSetupJobEvent/anyOf/0/properties/job/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJobEvent.schema.json
+++ b/packages/schema/generated/ControlSetupJobEvent.schema.json
@@ -690,14 +690,16 @@
                               "type": "string",
                               "enum": [
                                 "linux",
-                                "darwin"
+                                "darwin",
+                                "win32"
                               ]
                             },
                             "source": {
                               "type": "string",
                               "enum": [
                                 "procfs_stat",
-                                "proc_pidinfo"
+                                "proc_pidinfo",
+                                "win32_process"
                               ]
                             },
                             "startToken": {

--- a/packages/schema/generated/ControlSetupJobEvent.schema.json
+++ b/packages/schema/generated/ControlSetupJobEvent.schema.json
@@ -699,7 +699,7 @@
                               "enum": [
                                 "procfs_stat",
                                 "proc_pidinfo",
-                                "win32_process"
+                                "win32_process_times"
                               ]
                             },
                             "startToken": {
@@ -758,7 +758,7 @@
                       "properties": {
                         "realpath": {
                           "type": "string",
-                          "minLength": 1
+                          "pattern": "^(?:\\/[^\\u0000]*|[A-Za-z]:[\\\\/][^\\u0000]*|\\\\\\\\[^\\\\/\\u0000]+[\\\\/][^\\\\/\\u0000]+(?:[\\\\/][^\\u0000]*)?)$"
                         },
                         "sha256": {
                           "$ref": "#/definitions/ControlSetupJobEvent/anyOf/0/properties/job/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJobListResponse.schema.json
+++ b/packages/schema/generated/ControlSetupJobListResponse.schema.json
@@ -640,14 +640,16 @@
                             "type": "string",
                             "enum": [
                               "linux",
-                              "darwin"
+                              "darwin",
+                              "win32"
                             ]
                           },
                           "source": {
                             "type": "string",
                             "enum": [
                               "procfs_stat",
-                              "proc_pidinfo"
+                              "proc_pidinfo",
+                              "win32_process"
                             ]
                           },
                           "startToken": {

--- a/packages/schema/generated/ControlSetupJobListResponse.schema.json
+++ b/packages/schema/generated/ControlSetupJobListResponse.schema.json
@@ -649,7 +649,7 @@
                             "enum": [
                               "procfs_stat",
                               "proc_pidinfo",
-                              "win32_process"
+                              "win32_process_times"
                             ]
                           },
                           "startToken": {
@@ -708,7 +708,7 @@
                     "properties": {
                       "realpath": {
                         "type": "string",
-                        "minLength": 1
+                        "pattern": "^(?:\\/[^\\u0000]*|[A-Za-z]:[\\\\/][^\\u0000]*|\\\\\\\\[^\\\\/\\u0000]+[\\\\/][^\\\\/\\u0000]+(?:[\\\\/][^\\u0000]*)?)$"
                       },
                       "sha256": {
                         "$ref": "#/definitions/ControlSetupJobListResponse/properties/jobs/items/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJobListResponse.schema.json
+++ b/packages/schema/generated/ControlSetupJobListResponse.schema.json
@@ -706,7 +706,7 @@
                     "properties": {
                       "realpath": {
                         "type": "string",
-                        "pattern": "^\\/"
+                        "minLength": 1
                       },
                       "sha256": {
                         "$ref": "#/definitions/ControlSetupJobListResponse/properties/jobs/items/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJobSnapshot.schema.json
+++ b/packages/schema/generated/ControlSetupJobSnapshot.schema.json
@@ -640,14 +640,16 @@
                               "type": "string",
                               "enum": [
                                 "linux",
-                                "darwin"
+                                "darwin",
+                                "win32"
                               ]
                             },
                             "source": {
                               "type": "string",
                               "enum": [
                                 "procfs_stat",
-                                "proc_pidinfo"
+                                "proc_pidinfo",
+                                "win32_process"
                               ]
                             },
                             "startToken": {

--- a/packages/schema/generated/ControlSetupJobSnapshot.schema.json
+++ b/packages/schema/generated/ControlSetupJobSnapshot.schema.json
@@ -649,7 +649,7 @@
                               "enum": [
                                 "procfs_stat",
                                 "proc_pidinfo",
-                                "win32_process"
+                                "win32_process_times"
                               ]
                             },
                             "startToken": {
@@ -708,7 +708,7 @@
                       "properties": {
                         "realpath": {
                           "type": "string",
-                          "minLength": 1
+                          "pattern": "^(?:\\/[^\\u0000]*|[A-Za-z]:[\\\\/][^\\u0000]*|\\\\\\\\[^\\\\/\\u0000]+[\\\\/][^\\\\/\\u0000]+(?:[\\\\/][^\\u0000]*)?)$"
                         },
                         "sha256": {
                           "$ref": "#/definitions/ControlSetupJobSnapshot/anyOf/0/properties/job/properties/execution/properties/commandDigest"

--- a/packages/schema/generated/ControlSetupJobSnapshot.schema.json
+++ b/packages/schema/generated/ControlSetupJobSnapshot.schema.json
@@ -706,7 +706,7 @@
                       "properties": {
                         "realpath": {
                           "type": "string",
-                          "pattern": "^\\/"
+                          "minLength": 1
                         },
                         "sha256": {
                           "$ref": "#/definitions/ControlSetupJobSnapshot/anyOf/0/properties/job/properties/execution/properties/commandDigest"

--- a/packages/schema/src/schema.test.ts
+++ b/packages/schema/src/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { EffortHint, mergeEffortLadders } from "./effort.js";
+import * as SetupLoginProtocol from "./setup-login-protocol.js";
 import {
   CredentialProfile,
   HARNESS_INACTIVITY_TIMEOUT_DEFAULT_MS,
@@ -27,6 +28,7 @@ import {
   Session,
   ContinuityDisclosure,
   LaneCheckpoint,
+  SetupExecutableEvidence,
   TaskContract,
   Thread,
   ThreadTurn,
@@ -1001,3 +1003,73 @@ describe("CredentialProfile validation (INV-135)", () => {
     expect(distinct.success).toBe(true);
   });
 });
+
+describe("SetupLoginAbsolutePath and cross-platform validation", () => {
+  it("accepts valid POSIX absolute paths", () => {
+    for (const p of ["/var/run/job", "/Users/user/.codex", "/tmp/state.json", "/a"]) {
+      expect(SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(p).success).toBe(true);
+    }
+  });
+
+  it("accepts valid Windows absolute paths with backslashes and forward slashes", () => {
+    for (const p of [
+      "C:\\Users\\user\\AppData\\Local\\claudexor",
+      "c:\\program files\\codex\\bin\\codex.exe",
+      "C:/Users/user/AppData/Local/claudexor",
+      "d:/data/runner-result.json",
+      "X:\\state\\runner-state.json",
+      "\\\\server\\share\\jobDir",
+      "//server/share/jobDir",
+    ]) {
+      const parsed = SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(p);
+      expect(parsed.success).toBe(true);
+    }
+  });
+
+  it("rejects relative, drive-relative, and malformed paths", () => {
+    for (const p of [
+      "relative/path",
+      "./relative",
+      "../parent",
+      "runner-state.json",
+      "C:relative\\without\\slash",
+      "d:foo/bar",
+      "",
+      "   ",
+      "/path/with/\0/nullbyte",
+      "C:\\path\\with\0null",
+    ]) {
+      const parsed = SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(p);
+      expect(parsed.success).toBe(false);
+    }
+  });
+
+  it("validates SetupExecutableEvidence with Windows and POSIX realpaths", () => {
+    const validPosix = {
+      realpath: "/usr/local/bin/codex",
+      sha256: "0".repeat(64),
+      size: 1024,
+      mode: 0o755,
+      device: "123",
+      inode: "456",
+    };
+    expect(SetupExecutableEvidence.safeParse(validPosix).success).toBe(true);
+
+    const validWin = {
+      realpath: "C:\\Program Files\\Codex\\codex.exe",
+      sha256: "0".repeat(64),
+      size: 1024,
+      mode: 0o755,
+      device: "123",
+      inode: "456",
+    };
+    expect(SetupExecutableEvidence.safeParse(validWin).success).toBe(true);
+
+    const invalidRel = {
+      ...validWin,
+      realpath: "./codex.exe",
+    };
+    expect(SetupExecutableEvidence.safeParse(invalidRel).success).toBe(false);
+  });
+});
+

--- a/packages/schema/src/schema.test.ts
+++ b/packages/schema/src/schema.test.ts
@@ -1004,48 +1004,43 @@ describe("CredentialProfile validation (INV-135)", () => {
   });
 });
 
-describe("SetupLoginAbsolutePath and cross-platform validation", () => {
-  it("accepts valid POSIX absolute paths", () => {
-    for (const p of ["/var/run/job", "/Users/user/.codex", "/tmp/state.json", "/a"]) {
-      expect(SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(p).success).toBe(true);
+describe("SetupLoginAbsolutePath (cross-platform absolute paths)", () => {
+  const accepted = [
+    "/var/run/job",
+    "/Users/user/.codex",
+    "/a",
+    "C:\\Users\\user\\AppData\\Local\\claudexor",
+    "c:\\program files\\codex\\bin\\codex.exe",
+    "C:/Users/user/AppData/Local/claudexor",
+    "\\\\server\\share\\jobDir",
+    "//server/share/jobDir",
+  ];
+  const refused = [
+    "relative/path",
+    "./relative",
+    "../parent",
+    "runner-state.json",
+    // Drive- and root-relative spellings resolve against per-process state.
+    "C:relative\\without\\slash",
+    "d:foo/bar",
+    "\\Windows\\System32\\cmd.exe",
+    "",
+    "   ",
+    "/path/with/\0/nullbyte",
+    "C:\\path\\with\0null",
+  ];
+
+  it("accepts POSIX, drive-rooted and UNC paths and refuses the rest", () => {
+    for (const path of accepted) {
+      expect(SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(path).success).toBe(true);
+    }
+    for (const path of refused) {
+      expect(SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(path).success).toBe(false);
     }
   });
 
-  it("accepts valid Windows absolute paths with backslashes and forward slashes", () => {
-    for (const p of [
-      "C:\\Users\\user\\AppData\\Local\\claudexor",
-      "c:\\program files\\codex\\bin\\codex.exe",
-      "C:/Users/user/AppData/Local/claudexor",
-      "d:/data/runner-result.json",
-      "X:\\state\\runner-state.json",
-      "\\\\server\\share\\jobDir",
-      "//server/share/jobDir",
-    ]) {
-      const parsed = SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(p);
-      expect(parsed.success).toBe(true);
-    }
-  });
-
-  it("rejects relative, drive-relative, and malformed paths", () => {
-    for (const p of [
-      "relative/path",
-      "./relative",
-      "../parent",
-      "runner-state.json",
-      "C:relative\\without\\slash",
-      "d:foo/bar",
-      "",
-      "   ",
-      "/path/with/\0/nullbyte",
-      "C:\\path\\with\0null",
-    ]) {
-      const parsed = SetupLoginProtocol.SetupLoginAbsolutePath.safeParse(p);
-      expect(parsed.success).toBe(false);
-    }
-  });
-
-  it("validates SetupExecutableEvidence with Windows and POSIX realpaths", () => {
-    const validPosix = {
+  it("applies the same rule to executable evidence realpaths", () => {
+    const evidence = {
       realpath: "/usr/local/bin/codex",
       sha256: "0".repeat(64),
       size: 1024,
@@ -1053,23 +1048,22 @@ describe("SetupLoginAbsolutePath and cross-platform validation", () => {
       device: "123",
       inode: "456",
     };
-    expect(SetupExecutableEvidence.safeParse(validPosix).success).toBe(true);
+    expect(SetupExecutableEvidence.safeParse(evidence).success).toBe(true);
+    expect(
+      SetupExecutableEvidence.safeParse({
+        ...evidence,
+        realpath: "C:\\Program Files\\Codex\\codex.exe",
+      }).success,
+    ).toBe(true);
+    expect(
+      SetupExecutableEvidence.safeParse({ ...evidence, realpath: "./codex.exe" }).success,
+    ).toBe(false);
+  });
 
-    const validWin = {
-      realpath: "C:\\Program Files\\Codex\\codex.exe",
-      sha256: "0".repeat(64),
-      size: 1024,
-      mode: 0o755,
-      device: "123",
-      inode: "456",
-    };
-    expect(SetupExecutableEvidence.safeParse(validWin).success).toBe(true);
-
-    const invalidRel = {
-      ...validWin,
-      realpath: "./codex.exe",
-    };
-    expect(SetupExecutableEvidence.safeParse(invalidRel).success).toBe(false);
+  it("survives schema generation as a JSON Schema pattern, not a refinement", () => {
+    // A `.refine()` is invisible to schema:gen, so every wire consumer would
+    // silently accept relative paths; the regex is the shared contract.
+    expect(SetupLoginProtocol.ABSOLUTE_PATH_PATTERN.test("C:\\x")).toBe(true);
+    expect(SetupLoginProtocol.ABSOLUTE_PATH_PATTERN.test("C:x")).toBe(false);
   });
 });
-

--- a/packages/schema/src/setup-login-protocol.ts
+++ b/packages/schema/src/setup-login-protocol.ts
@@ -1,8 +1,22 @@
+import { isAbsolute as isPosixAbsolute } from "node:path/posix";
+import { isAbsolute as isWin32Absolute } from "node:path/win32";
 import { z } from "zod/v3";
+
+export function isCrossPlatformAbsolutePath(value: string): boolean {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+    return false;
+  }
+  return isPosixAbsolute(value) || isWin32Absolute(value);
+}
 
 export const SetupLoginJobId = z.string().regex(/^setup-[A-Za-z0-9-]+$/);
 export const SetupLoginExecutionId = z.string().regex(/^[A-Za-z0-9-]+$/);
-export const SetupLoginAbsolutePath = z.string().startsWith("/");
+export const SetupLoginAbsolutePath = z
+  .string()
+  .min(1)
+  .refine(isCrossPlatformAbsolutePath, {
+    message: 'must be an absolute path (POSIX or Windows)',
+  });
 
 export const SetupClientPtyPermitWaitMs = z
   .number()

--- a/packages/schema/src/setup-login-protocol.ts
+++ b/packages/schema/src/setup-login-protocol.ts
@@ -1,22 +1,22 @@
-import { isAbsolute as isPosixAbsolute } from "node:path/posix";
-import { isAbsolute as isWin32Absolute } from "node:path/win32";
 import { z } from "zod/v3";
 
-export function isCrossPlatformAbsolutePath(value: string): boolean {
-  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
-    return false;
-  }
-  return isPosixAbsolute(value) || isWin32Absolute(value);
-}
+/**
+ * Rooted path in either family: POSIX `/x`, a drive-rooted Windows path
+ * (`C:\x`, `C:/x`), or a UNC share (`\\host\share\x`). Deliberately a REGEX,
+ * not a `node:path` refinement: `packages/schema` is a pure contract package
+ * and only a regex survives `schema:gen` as a JSON Schema `pattern`, so every
+ * wire consumer keeps the same rule the daemon enforces. Drive-relative
+ * (`C:x`) and root-relative (`\x`) spellings are refused — both resolve
+ * against per-process state, so they are not absolute evidence — as is NUL.
+ */
+export const ABSOLUTE_PATH_PATTERN =
+  /^(?:\/[^\u0000]*|[A-Za-z]:[\\/][^\u0000]*|\\\\[^\\/\u0000]+[\\/][^\\/\u0000]+(?:[\\/][^\u0000]*)?)$/;
 
 export const SetupLoginJobId = z.string().regex(/^setup-[A-Za-z0-9-]+$/);
 export const SetupLoginExecutionId = z.string().regex(/^[A-Za-z0-9-]+$/);
-export const SetupLoginAbsolutePath = z
-  .string()
-  .min(1)
-  .refine(isCrossPlatformAbsolutePath, {
-    message: 'must be an absolute path (POSIX or Windows)',
-  });
+export const SetupLoginAbsolutePath = z.string().regex(ABSOLUTE_PATH_PATTERN, {
+  message: "must be an absolute POSIX or Windows path",
+});
 
 export const SetupClientPtyPermitWaitMs = z
   .number()

--- a/packages/schema/src/setup.ts
+++ b/packages/schema/src/setup.ts
@@ -13,8 +13,8 @@ export const ProcessIdentityKnown = z
   .object({
     status: z.literal("known"),
     pid: z.number().int().positive(),
-    platform: z.enum(["linux", "darwin"]),
-    source: z.enum(["procfs_stat", "proc_pidinfo"]),
+    platform: z.enum(["linux", "darwin", "win32"]),
+    source: z.enum(["procfs_stat", "proc_pidinfo", "win32_process"]),
     startToken: z.string().min(1),
     processGroupId: z.number().int().positive(),
   })

--- a/packages/schema/src/setup.ts
+++ b/packages/schema/src/setup.ts
@@ -80,7 +80,7 @@ export type SetupExecutionEvidence = z.infer<typeof SetupExecutionEvidence>;
 
 export const SetupExecutableEvidence = z
   .object({
-    realpath: z.string().startsWith("/"),
+    realpath: SetupLoginProtocol.SetupLoginAbsolutePath,
     sha256: Sha256Hex,
     size: z.number().int().nonnegative(),
     mode: z.number().int().nonnegative(),

--- a/packages/schema/src/setup.ts
+++ b/packages/schema/src/setup.ts
@@ -14,7 +14,7 @@ export const ProcessIdentityKnown = z
     status: z.literal("known"),
     pid: z.number().int().positive(),
     platform: z.enum(["linux", "darwin", "win32"]),
-    source: z.enum(["procfs_stat", "proc_pidinfo", "win32_process"]),
+    source: z.enum(["procfs_stat", "proc_pidinfo", "win32_process_times"]),
     startToken: z.string().min(1),
     processGroupId: z.number().int().positive(),
   })


### PR DESCRIPTION
## Summary

Fixes Codex CLI login and setup authorization on Windows in @claudexor/schema, @claudexor/core, and @claudexor/cli.

### Root Cause
1. **Zod absolute path validation**: Schema validation previously required .startsWith("/") in SetupLoginAbsolutePath and SetupExecutableEvidence.realpath, rejecting Windows absolute paths (C:\..., C:/..., \\unc\share\...) with Invalid input: must start with "/".
2. **Process identity & process groups on Windows**: ProcessIdentityService and ProcessGroupService returned unsupported_platform on win32, preventing captureLeader and observeAndPermit from issuing worker execution permits.
3. **Executable inspection on Windows**: identityStable asserted 
amed.ino === stat.ino, which fails on Windows NTFS (lstatSync returns ino: 0n while statSync reads the file handle index).
4. **Runner probe working directory**: probeLoginHelp did not specify cwd, failing on locally resolved Windows binaries.

### Key Changes
- **packages/schema**:
  - Added isCrossPlatformAbsolutePath validator checking POSIX and Win32 absolute paths (rejecting null bytes, relative, and drive-relative paths).
  - Switched SetupLoginAbsolutePath and SetupExecutableEvidence.realpath to use isCrossPlatformAbsolutePath.
  - Added win32 platform and win32_process source to ProcessIdentityKnown.
  - Regenerated all 134 JSON Schema files via pnpm schema:gen.
- **packages/core**:
  - Added win32 process identity support (eadWin32, probeEmpty, signal).
  - Adapted identityStable for Windows in executable-inspection.ts (
amed.size === stat.size).
  - Added optional platform parameter to isLaunchableExecutable.
  - Guarded POSIX writable directory mode bit checks on Windows.
- **packages/cli**:
  - Added spawnTargetProcess supporting Windows batch/cmd files.
  - Specified cwd in probeLoginHelp.
  - Canonicalized base directory path comparison in alidateManifest.
  - Added cross-platform Windows runner execution and event mock tests.
- **CI**:
  - Added windows-test job running on windows-latest (Node 20) in .github/workflows/ci.yml.

### Verification
- packages/schema/src/schema.test.ts (44/44 passed)
- packages/cli/src/setup-jobs.test.ts (69/69 passed)
- packages/cli/src/setup-login-protocol.test.ts (26/26 passed)
- packages/core/src/runtime-env.test.ts (24/24 passed | 2 posix chmod skipped on win32)
- pnpm typecheck (59 packages passed)
- pnpm typecheck:tests (passed)
- 
ode scripts/validate-generated-schemas.mjs (passed)
- Live end-to-end device-auth execution on Windows with real codex.exe 0.147.0-alpha.1.2 completed with exit code 0.