### PR TITLE
Final-review fixes for #197: rotation evidence, pool-member gate, route-scoped block, per-try markers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -679,7 +679,9 @@ selected profile's freshest quota window applicable to the effective model
 at/over the threshold, or its own OBSERVED live block (a reactive rate-limit
 cooldown or spent window judged by the schema's availability projection —
 stale-but-live evidence included, since a cooldown instant is absolute clock
-truth), emits typed
+truth, and matched by the FULL subject key including `credential_route`, so
+the api-key default and the native-session default of one harness never
+conflate on their shared `subject_id=null`), emits typed
 `route.profile.headroom_exceeded` evidence, and `rotate` swaps to the next
 eligible profile with `route.profile.rotated` provenance; and
 `vendor_limit_rejected` — a TYPED vendor rate-limit that terminated a
@@ -695,7 +697,10 @@ retryable deaths stay with the same-profile retry machinery, and an observed
 mutation (workspace diff or any `file_change` event) blocks every branch.
 Adapters keep a failed result's prose out of answer material entirely: a
 non-success terminal result rides a `status` event, never a `message`, and an
-errored attempt with no typed final has no deliverable (`acceptedTryOutput`).
+errored attempt with no typed final has no deliverable (`acceptedTryOutput`) —
+the in-loop rotation evidence reads this same policy owner, so refusal prose
+that legitimately flows as mid-stream `message` events (the claude
+org-disabled incident shape) can never suppress failover on any adapter.
 Credentials never change inside a running spawn; a
 rotation INTO a spent or still-cooling profile is refused by the same
 headroom-plus-cooldown check. When no
@@ -705,7 +710,11 @@ headroom or cooldown evidence (with its earliest known release instant); the
 UI surfaces the exhaustion instead of implying a switch. Exhaustion is also a
 TYPED terminal: a reactive rotation-eligible failure with nowhere to go
 terminalizes the attempt on `credential_pool_exhausted` (category
-`harness_unavailable` — nothing malfunctioned) through NORMAL attempt
+`harness_unavailable` — nothing malfunctioned) only when the triggering
+subject or a POOL-MEMBER row carries limit/unusable evidence — rows for
+identities rotation could never select (wrong kind, outside policy, not
+ready) never count, and an evidence-free structural death keeps its TRUE
+failure — through NORMAL attempt
 finalization, BEFORE the transient gate could burn same-profile retries on the
 already-refused subject, and the run terminal lifts `code` + `resetsAt` onto
 `final/failure.yaml` in every lane (race unanimity, convergence last-result,

--- a/packages/orchestrator/src/credential-cooldown.test.ts
+++ b/packages/orchestrator/src/credential-cooldown.test.ts
@@ -66,7 +66,7 @@ const policy: ProfilePolicy = {
 
 describe("profileQuotaBlock (A4 cooldown reader)", () => {
   it("a STALE snapshot with a live cooldown blocks, with typed evidence", () => {
-    expect(profileQuotaBlock([cooldownSnapshot("a")], "cursor", "a")).toEqual({
+    expect(profileQuotaBlock([cooldownSnapshot("a")], "cursor", "a", "local_session")).toEqual({
       blocked: true,
       constraint_id: "cooldown",
       resets_at: FUTURE,
@@ -76,7 +76,12 @@ describe("profileQuotaBlock (A4 cooldown reader)", () => {
 
   it("an expired cooldown never blocks", () => {
     expect(
-      profileQuotaBlock([cooldownSnapshot("a", { cooldown_until: PAST })], "cursor", "a"),
+      profileQuotaBlock(
+        [cooldownSnapshot("a", { cooldown_until: PAST })],
+        "cursor",
+        "a",
+        "local_session",
+      ),
     ).toBeNull();
   });
 
@@ -86,6 +91,7 @@ describe("profileQuotaBlock (A4 cooldown reader)", () => {
         [cooldownSnapshot("a", { cooldown_until: null, used_ratio: 1, resets_at: FUTURE })],
         "cursor",
         "a",
+        "local_session",
       ),
     ).toMatchObject({ kind: "exhausted", resets_at: FUTURE });
     expect(
@@ -93,22 +99,44 @@ describe("profileQuotaBlock (A4 cooldown reader)", () => {
         [cooldownSnapshot("a", { cooldown_until: null, used_ratio: 1, resets_at: null })],
         "cursor",
         "a",
+        "local_session",
       ),
     ).toBeNull();
   });
 
   it("blocks only the snapshot's own subject — never a sibling or the default", () => {
     const snapshots = [cooldownSnapshot("a")];
-    expect(profileQuotaBlock(snapshots, "cursor", "a")).not.toBeNull();
-    expect(profileQuotaBlock(snapshots, "cursor", "b")).toBeNull();
-    expect(profileQuotaBlock(snapshots, "cursor", null)).toBeNull();
-    expect(profileQuotaBlock(snapshots, "codex", "a")).toBeNull();
+    expect(profileQuotaBlock(snapshots, "cursor", "a", "local_session")).not.toBeNull();
+    expect(profileQuotaBlock(snapshots, "cursor", "b", "local_session")).toBeNull();
+    expect(profileQuotaBlock(snapshots, "cursor", null, "local_session")).toBeNull();
+    expect(profileQuotaBlock(snapshots, "codex", "a", "local_session")).toBeNull();
+  });
+
+  it("route-scoped: an api_key-route cooldown never blocks the subscription-session default of the same harness (and vice versa)", () => {
+    // Both defaults carry subject_id=null — the credential_route is the only
+    // thing separating the managed-api-key subject from the native session.
+    const apiKeyDefault: QuotaSnapshot = {
+      ...cooldownSnapshot(null),
+      subject: {
+        harness: "cursor",
+        credential_route: "managed_api_key",
+        plan_label: null,
+        subject_id: null,
+      },
+    };
+    expect(profileQuotaBlock([apiKeyDefault], "cursor", null, "local_session")).toBeNull();
+    expect(profileQuotaBlock([apiKeyDefault], "cursor", null, "api_key")).not.toBeNull();
+    const nativeDefault = cooldownSnapshot(null); // vendor_native subject
+    expect(profileQuotaBlock([nativeDefault], "cursor", null, "api_key")).toBeNull();
+    expect(profileQuotaBlock([nativeDefault], "cursor", null, "local_session")).not.toBeNull();
   });
 
   it("a Gemini-scoped cooldown never cools the grok lane on the same account", () => {
     const scoped = [cooldownSnapshot("a", { applies_to_models: ["Gemini 3.7 Flash High"] })];
-    expect(profileQuotaBlock(scoped, "cursor", "a", "grok-4.6")).toBeNull();
-    expect(profileQuotaBlock(scoped, "cursor", "a", "Gemini 3.7 Flash High")).not.toBeNull();
+    expect(profileQuotaBlock(scoped, "cursor", "a", "local_session", "grok-4.6")).toBeNull();
+    expect(
+      profileQuotaBlock(scoped, "cursor", "a", "local_session", "Gemini 3.7 Flash High"),
+    ).not.toBeNull();
   });
 
   it("fails OPEN when a display label cannot be proven to cover the routed slug", () => {
@@ -116,22 +144,26 @@ describe("profileQuotaBlock (A4 cooldown reader)", () => {
     // slug. Unprovable coverage must leave the subject spendable, never cool
     // every model on the account.
     const scoped = [cooldownSnapshot("a", { applies_to_models: ["Gemini 3.7 Flash High"] })];
-    expect(profileQuotaBlock(scoped, "cursor", "a", "gemini-3.7-flash")).toBeNull();
+    expect(
+      profileQuotaBlock(scoped, "cursor", "a", "local_session", "gemini-3.7-flash"),
+    ).toBeNull();
     // Provable containment still blocks (alias ⊂ slug).
     const alias = [cooldownSnapshot("a", { applies_to_models: ["gemini"] })];
-    expect(profileQuotaBlock(alias, "cursor", "a", "gemini-3.7-flash")).not.toBeNull();
+    expect(
+      profileQuotaBlock(alias, "cursor", "a", "local_session", "gemini-3.7-flash"),
+    ).not.toBeNull();
   });
 
   it("with no model context a scoped window blocks only when it governs the unspecified route", () => {
     const scoped = [cooldownSnapshot("a", { applies_to_models: ["Gemini 3.7 Flash High"] })];
-    expect(profileQuotaBlock(scoped, "cursor", "a", null)).toBeNull();
+    expect(profileQuotaBlock(scoped, "cursor", "a", "local_session", null)).toBeNull();
     const governing = [
       cooldownSnapshot("a", {
         applies_to_models: ["Gemini 3.7 Flash High"],
         applies_to_unspecified_model: true,
       }),
     ];
-    expect(profileQuotaBlock(governing, "cursor", "a", null)).not.toBeNull();
+    expect(profileQuotaBlock(governing, "cursor", "a", "local_session", null)).not.toBeNull();
   });
 });
 

--- a/packages/orchestrator/src/credential-cooldown.ts
+++ b/packages/orchestrator/src/credential-cooldown.ts
@@ -66,17 +66,33 @@ export interface QuotaBlock {
  * spendable rather than cooling every model on the account. A scoped window
  * with NO model context blocks only when it declares it governs the
  * unspecified-model route.
+ *
+ * The subject KEY includes `credential_route` (final-review fix): the
+ * native-session default and the managed-api-key default of one harness BOTH
+ * carry subject_id=null, so without the route an api_key cooldown would cool
+ * the subscription session (and vice versa). `subjectRoute` speaks the
+ * callers' vocabulary (`limitSubjectRoute`); `null` = honestly unknown route —
+ * fail open to the legacy any-route match rather than unblocking on a
+ * technicality (no current caller passes null).
  */
 export function profileQuotaBlock(
   snapshots: readonly QuotaSnapshot[],
   harnessId: string,
   profileId: string | null,
+  subjectRoute: "local_session" | "api_key" | null,
   model?: string | null,
   now?: Date,
 ): QuotaBlock | null {
+  const wantRoute =
+    subjectRoute === "local_session"
+      ? "vendor_native"
+      : subjectRoute === "api_key"
+        ? "managed_api_key"
+        : null;
   for (const snapshot of snapshots) {
     if (snapshot.subject.harness !== harnessId) continue;
     if ((snapshot.subject.subject_id ?? null) !== profileId) continue;
+    if (wantRoute !== null && snapshot.subject.credential_route !== wantRoute) continue;
     const availability = quotaSnapshotAvailability(snapshot, { now, model: model ?? null });
     if (availability.state === "available") continue;
     return {
@@ -117,6 +133,29 @@ const POOL_MEMBER_REJECTIONS = new Set([
   "cooldown",
   "not_selected",
 ]);
+
+/**
+ * Whether one exhaustion row is CREDENTIAL-LAYER EVIDENCE for the pool
+ * terminal's claim (final-review fix): the fold's member labels plus
+ * `credential_unusable` — a dead credential IS a pool member whose typed
+ * verdict is evidence, even though the reset fold excludes its windows (they
+ * promise no reopen). Rows naming identities rotation could never select
+ * (`not_ready`, `not_in_rotation_policy`, `credential_kind_mismatch`) never
+ * count: an api_key sibling's stale cooldown must not let a subscription
+ * subject's structural death terminalize as "the credential pool refused".
+ */
+export function poolMemberEvidence(candidate: PoolExhaustionCandidate): boolean {
+  if (
+    !POOL_MEMBER_REJECTIONS.has(candidate.rejected) &&
+    candidate.rejected !== "credential_unusable"
+  )
+    return false;
+  return (
+    candidate.headroom !== null ||
+    candidate.cooldown !== null ||
+    (candidate.unusable ?? null) !== null
+  );
+}
 
 /**
  * The WHOLE pool refused, MACHINE-READABLY (A5).

--- a/packages/orchestrator/src/credential-preflight.ts
+++ b/packages/orchestrator/src/credential-preflight.ts
@@ -106,7 +106,7 @@ function rotationProbeNeeded(args: {
   const subjectId = profile?.profile_id ?? null;
   return (
     profileHeadroomBreach(snapshots, harnessId, subjectId, policy.headroom_threshold, model) !==
-      null || profileQuotaBlock(snapshots, harnessId, subjectId, model) !== null
+      null || profileQuotaBlock(snapshots, harnessId, subjectId, route, model) !== null
   );
 }
 
@@ -196,7 +196,8 @@ export function preflightCredentialProfile(args: {
   const { profile, harnessId, policy, registry, snapshots, readyProfileIds, model, emit } = args;
   // The RESOLVED action for THIS subject (A6): `auto` decides by the pinned
   // profile's own credential kind — rotate for subscription, fail for metered.
-  const action = effectiveLimitAction(policy, limitSubjectRoute(profile));
+  const subjectRoute = limitSubjectRoute(profile);
+  const action = effectiveLimitAction(policy, subjectRoute);
   const breach = profileHeadroomBreach(
     snapshots,
     harnessId,
@@ -207,7 +208,9 @@ export function preflightCredentialProfile(args: {
   // The cooldown reader (A4) sees what the fresh-only headroom check cannot:
   // an OBSERVED live block — a reactive vendor-limit cooldown (stale-but-live
   // included) or a spent window with a known future reset.
-  const block = breach ? null : profileQuotaBlock(snapshots, harnessId, profile.profile_id, model);
+  const block = breach
+    ? null
+    : profileQuotaBlock(snapshots, harnessId, profile.profile_id, subjectRoute, model);
   if (!breach && !block) return profile;
   emit("route.profile.headroom_exceeded", {
     harness_id: harnessId,
@@ -254,7 +257,8 @@ export function preflightCredentialProfile(args: {
     // cooldown) with an exhausted pool is hard evidence — refuse typed BEFORE
     // spawn. A bare headroom breach is proximity, not proof the window is
     // spent: proceed on the selected profile and let the vendor be the truth.
-    const hard = block ?? profileQuotaBlock(snapshots, harnessId, profile.profile_id, model);
+    const hard =
+      block ?? profileQuotaBlock(snapshots, harnessId, profile.profile_id, subjectRoute, model);
     if (hard) {
       throw credentialPoolExhausted({
         harnessId,
@@ -314,8 +318,10 @@ export function preflightDefaultSubject(args: {
     model,
   );
   // Same A4 cooldown reader as the pinned lane: the default subject's own
-  // observed live block (reactive cooldown / spent window) rotates too.
-  const block = breach ? null : profileQuotaBlock(snapshots, harnessId, null, model);
+  // observed live block (reactive cooldown / spent window) rotates too. The
+  // guard above pins `defaultRoute === "local_session"`, so the block is read
+  // for the SUBSCRIPTION default subject only.
+  const block = breach ? null : profileQuotaBlock(snapshots, harnessId, null, defaultRoute, model);
   if (!breach && !block) return null;
   emit("route.profile.headroom_exceeded", {
     harness_id: harnessId,
@@ -352,7 +358,7 @@ export function preflightDefaultSubject(args: {
     // Same A5 preflight split as the pinned lane: the DEFAULT subject's own
     // observed live block with no eligible alternative refuses typed before
     // spawn; a bare headroom breach proceeds (not proven spent).
-    const hard = block ?? profileQuotaBlock(snapshots, harnessId, null, model);
+    const hard = block ?? profileQuotaBlock(snapshots, harnessId, null, defaultRoute, model);
     if (hard) {
       throw credentialPoolExhausted({
         harnessId,

--- a/packages/orchestrator/src/credential-profile-rotation.ts
+++ b/packages/orchestrator/src/credential-profile-rotation.ts
@@ -12,6 +12,7 @@ import { quotaConstraintAppliesToModel } from "@claudexor/budget";
 import {
   credentialPoolExhausted,
   liveUnusableFor,
+  poolMemberEvidence,
   profileQuotaBlock,
   type PoolExhaustionCandidate,
   type QuotaBlock,
@@ -185,7 +186,16 @@ export function nextEligibleProfile(
     // Rotating INTO a subject whose own observed windows are still cooling or
     // spent (A4) is not a failover — it burns an attempt to rediscover the
     // limit the registry already holds, stale-but-live evidence included.
-    if (profileQuotaBlock(snapshots, harnessId, candidate.profile_id, model)) continue;
+    if (
+      profileQuotaBlock(
+        snapshots,
+        harnessId,
+        candidate.profile_id,
+        limitSubjectRoute(candidate),
+        model,
+      )
+    )
+      continue;
     return candidate;
   }
   return null;
@@ -234,6 +244,7 @@ function rotationExhaustionCandidates(args: {
         args.snapshots,
         args.harnessId,
         profile.profile_id,
+        limitSubjectRoute(profile),
         args.model,
       );
       // A7: a candidate refused because ITS CREDENTIAL was observed dead says
@@ -494,27 +505,35 @@ export async function rotateSpecOnTypedLimit(args: {
       unusable: args.liveUnusable,
       model: args.spec.model_hint,
     });
+    // The default subject reached here only via the vendor-native eligibility
+    // gate above, so its registry row is the SUBSCRIPTION default — never the
+    // managed-api-key default that shares subject_id=null.
     const subjectBlock =
       current === null
-        ? profileQuotaBlock(args.snapshots, args.harnessId, null, args.spec.model_hint)
+        ? profileQuotaBlock(
+            args.snapshots,
+            args.harnessId,
+            null,
+            "local_session",
+            args.spec.model_hint,
+          )
         : null;
     const subjectLimit =
       subjectBlock ??
       (evidence.sawTypedLimit ? { resets_at: args.lastLimit?.resetsAt ?? null } : null);
     // The pool terminal REQUIRES evidence: "credential_pool_exhausted" claims
     // the credential layer refused the run, so either the triggering subject
-    // must carry limit/unusable evidence or some candidate row must carry
-    // headroom/cooldown/unusable evidence. A structural pre-progress death
+    // must carry limit/unusable evidence or some POOL-MEMBER row must carry
+    // headroom/cooldown/unusable evidence (`poolMemberEvidence` — rows for
+    // identities rotation could never select, e.g. an api_key sibling under a
+    // subscription subject, never count). A structural pre-progress death
     // over an empty (or evidence-free) pool proves nothing about credentials —
     // fail as-is and keep the TRUE failure (a vanilla user's crashed run must
     // never terminalize as a pool refusal). The already-emitted
     // `route.profile.rotation_exhausted` event stays: rotation WAS consulted
     // and had nowhere to go; only the terminal's claim is evidence-gated.
     const subjectEvidence = subjectLimit !== null || subjectUnusable !== null;
-    const poolEvidence = candidates.some(
-      (candidate) =>
-        candidate.headroom !== null || candidate.cooldown !== null || candidate.unusable !== null,
-    );
+    const poolEvidence = candidates.some(poolMemberEvidence);
     if (!subjectEvidence && !poolEvidence) return null;
     return {
       poolExhausted: credentialPoolExhausted({

--- a/packages/orchestrator/src/credential-profiles.ts
+++ b/packages/orchestrator/src/credential-profiles.ts
@@ -340,7 +340,7 @@ export function nextUpIdentity(args: {
       policy.headroom_threshold,
       model,
     );
-    if (breach || profileQuotaBlock(snapshots, harnessId, null, model)) {
+    if (breach || profileQuotaBlock(snapshots, harnessId, null, defaultRoute, model)) {
       const next = nextEligibleProfile(
         registry,
         harnessId,

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -11,6 +11,7 @@ import {
 } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
 import { repoHash } from "@claudexor/config";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,6 +32,7 @@ import { createFakeHarness } from "@claudexor/harness-fake";
 import type {
   AccessProfile,
   ControlReviewerPanelEntry,
+  HarnessEvent,
   HarnessRunSpec,
   ProviderFamily,
 } from "@claudexor/schema";
@@ -4615,6 +4617,281 @@ describe("Orchestrator", () => {
       expect(legacyOutcome(res)).toBe("failed");
       expect(profilesSeen).toEqual(["a"]);
       expect(events).not.toContain("route.profile.rotated");
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.CLAUDEXOR_CONFIG_DIR;
+      else process.env.CLAUDEXOR_CONFIG_DIR = previousConfigDir;
+    }
+  });
+
+  it("REGRESSION (final-review fix): the claude org-disabled incident — message-first prose — rotates STRUCTURALLY to a sibling subscription profile; answer.md never carries the prose", async () => {
+    const repo = await initRepo();
+    const configDir = reapMk(join(tmpdir(), "claudexor-org-disabled-config-"));
+    const previousConfigDir = process.env.CLAUDEXOR_CONFIG_DIR;
+    process.env.CLAUDEXOR_CONFIG_DIR = configDir;
+    writeFileSync(
+      join(configDir, "config.yaml"),
+      [
+        "credential_profiles:",
+        "  - profile_id: a",
+        "    harness_id: limited",
+        "    display_name: A",
+        "    credential_kind: config_dir_login",
+        `    isolation_locator: '${join(configDir, "profile-a")}'`,
+        "  - profile_id: b",
+        "    harness_id: limited",
+        "    display_name: B",
+        "    credential_kind: config_dir_login",
+        `    isolation_locator: '${join(configDir, "profile-b")}'`,
+        "harnesses:",
+        "  limited:",
+        "    profile_policy:",
+        "      limit_action: rotate",
+        "",
+      ].join("\n"),
+    );
+    // Replay the COMMITTED incident fixture (live 2026-08-17, run-ea06645118d7):
+    // the entitlement prose arrives as a mid-stream ASSISTANT MESSAGE, again on
+    // the is_error result, then exit 1 — no api_retry frame, no typed
+    // rate_limit. Frames map onto the claude parser's pinned contract
+    // (harness-claude signals.test.ts): init → started; the assistant message
+    // KEEPS flowing as a `message` event (it is model output); the non-success
+    // result rides STATUS events (typed oauth_org_not_allowed + the prose as
+    // non_success_result, never a message); the shared runloop folds exit 1
+    // into a terminal error event.
+    const fixtureFrames = readFileSync(
+      fileURLToPath(
+        new URL(
+          "../../harness-claude/fixtures/signals/org-disabled-subscription.jsonl",
+          import.meta.url,
+        ),
+      ),
+      "utf8",
+    )
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    const orgDisabledEvents = (sessionId: string): Array<Record<string, unknown>> => {
+      const ts = new Date().toISOString();
+      const out: Array<Record<string, unknown>> = [];
+      for (const frame of fixtureFrames) {
+        if (frame["type"] === "system") out.push({ type: "started", session_id: sessionId, ts });
+        if (frame["type"] === "assistant") {
+          const content = (frame["message"] as { content: Array<{ text?: string }> }).content;
+          out.push({ type: "message", session_id: sessionId, ts, text: content[0]?.text ?? "" });
+        }
+        if (frame["type"] === "result") {
+          const prose = String(frame["result"] ?? "");
+          out.push({
+            type: "status",
+            session_id: sessionId,
+            ts,
+            text: `entitlement: ${prose}`,
+            status: { kind: "api_retry", error_category: "oauth_org_not_allowed" },
+            payload: { entitlement_denied: true },
+          });
+          out.push({
+            type: "status",
+            session_id: sessionId,
+            ts,
+            text: prose,
+            payload: { non_success_result: true },
+          });
+        }
+      }
+      out.push({ type: "error", session_id: sessionId, ts, error: "claude exited with code 1" });
+      return out;
+    };
+    // Guard against fixture drift: the replay must still be the incident shape.
+    expect(fixtureFrames.some((f) => f["type"] === "assistant")).toBe(true);
+    try {
+      const profilesSeen: Array<string | null> = [];
+      const adapter: HarnessAdapter = {
+        id: "limited",
+        async discover() {
+          return HarnessManifest.parse({
+            id: "limited",
+            display_name: "limited",
+            kind: "local_cli",
+            provider_family: "local",
+            capabilities: { implement: true },
+            access_profiles_supported: ["workspace_write"],
+          });
+        },
+        async doctor() {
+          return ConformanceReport.parse({
+            harness_id: "limited",
+            status: "ok",
+            enabled_intents: ["implement"],
+          });
+        },
+        async probeCredentialProfile(profile) {
+          return {
+            profile_id: profile.profile_id,
+            harness_id: "limited",
+            availability: "available",
+            verification: "passed",
+            verification_source: "local_store",
+            detail: "fixture profile verified",
+            last_verified_at: new Date().toISOString(),
+          };
+        },
+        async *run(spec) {
+          const ts = new Date().toISOString();
+          profilesSeen.push(spec.credential_profile?.profile_id ?? null);
+          if (profilesSeen.length === 1) {
+            for (const ev of orgDisabledEvents(spec.session_id)) yield ev as HarnessEvent;
+            yield { type: "completed", session_id: spec.session_id, ts };
+            return;
+          }
+          yield { type: "started", session_id: spec.session_id, ts };
+          writeFileSync(join(spec.cwd, "CHANGED.txt"), "made it\n");
+          yield { type: "message", session_id: spec.session_id, ts, text: "Implemented." };
+          yield { type: "completed", session_id: spec.session_id, ts };
+        },
+      };
+      const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+      const res = await new Orchestrator({
+        registry: new Map([["limited", adapter]]),
+        reviewers: [],
+      }).run({
+        repoRoot: repo,
+        prompt: "do it",
+        mode: "agent",
+        harnesses: ["limited"],
+        n: 1,
+        credentialProfileId: "a",
+        onEvent: (event) =>
+          events.push({ type: event.type, payload: event.payload as Record<string, unknown> }),
+      });
+      // The incident class is CLOSED only when the sibling actually spawns:
+      // before this fix the mid-stream prose filled the assembly, the raw
+      // in-loop emptiness read "deliverable present", and the structural
+      // branch never fired.
+      expect(legacyOutcome(res)).not.toBe("failed");
+      expect(profilesSeen).toEqual(["a", "b"]);
+      const rotated = events.find((e) => e.type === "route.profile.rotated");
+      expect(rotated?.payload["reason"]).toBe("structural_pre_progress_failure");
+      const answer = readFileSync(join(res.runDir, "final", "answer.md"), "utf8");
+      expect(answer).toContain("Implemented.");
+      expect(answer).not.toContain("organization has disabled");
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.CLAUDEXOR_CONFIG_DIR;
+      else process.env.CLAUDEXOR_CONFIG_DIR = previousConfigDir;
+    }
+  });
+
+  it("per-try markers (final-review fix): try-A progress never suppresses try-B's structural rotation", async () => {
+    const repo = await initRepo();
+    const configDir = reapMk(join(tmpdir(), "claudexor-per-try-markers-config-"));
+    const previousConfigDir = process.env.CLAUDEXOR_CONFIG_DIR;
+    process.env.CLAUDEXOR_CONFIG_DIR = configDir;
+    writeFileSync(
+      join(configDir, "config.yaml"),
+      [
+        "credential_profiles:",
+        ...["a", "b", "c"].flatMap((id) => [
+          `  - profile_id: ${id}`,
+          "    harness_id: limited",
+          `    display_name: ${id.toUpperCase()}`,
+          "    credential_kind: api_key",
+          `    secret_ref: 'openai:${id}'`,
+        ]),
+        "harnesses:",
+        "  limited:",
+        "    profile_policy:",
+        "      limit_action: rotate",
+        "",
+      ].join("\n"),
+    );
+    try {
+      const profilesSeen: Array<string | null> = [];
+      const adapter: HarnessAdapter = {
+        id: "limited",
+        async discover() {
+          return HarnessManifest.parse({
+            id: "limited",
+            display_name: "limited",
+            kind: "local_cli",
+            provider_family: "local",
+            capabilities: { implement: true },
+            access_profiles_supported: ["workspace_write"],
+          });
+        },
+        async doctor() {
+          return ConformanceReport.parse({
+            harness_id: "limited",
+            status: "ok",
+            enabled_intents: ["implement"],
+          });
+        },
+        async probeCredentialProfile(profile) {
+          return {
+            profile_id: profile.profile_id,
+            harness_id: "limited",
+            availability: "available",
+            verification: "passed",
+            verification_source: "local_store",
+            detail: "fixture profile verified",
+            last_verified_at: new Date().toISOString(),
+          };
+        },
+        async *run(spec) {
+          const ts = new Date().toISOString();
+          profilesSeen.push(spec.credential_profile?.profile_id ?? null);
+          yield { type: "started", session_id: spec.session_id, ts };
+          if (profilesSeen.length === 1) {
+            // Try A: the agent demonstrably THINKS, then hits a TYPED limit —
+            // the typed branch rotates regardless of progress (W5.4 canon).
+            yield { type: "thinking", session_id: spec.session_id, ts, text: "assessing repo" };
+            yield {
+              type: "status",
+              session_id: spec.session_id,
+              ts,
+              text: "api_retry: rate limited",
+              status: { kind: "api_retry", error_category: "rate_limit" },
+              rate_limit: { resets_at: null, retry_delay_ms: 60_000 },
+            };
+            yield {
+              type: "error",
+              session_id: spec.session_id,
+              ts,
+              error: "vendor rate limit exhausted",
+            };
+            yield { type: "completed", session_id: spec.session_id, ts };
+            return;
+          }
+          if (profilesSeen.length === 2) {
+            // Try B: untyped pre-progress terminal death. Cumulative markers
+            // would still carry try-A's thinking and suppress the structural
+            // branch — per-try markers must let B rotate to C.
+            yield { type: "error", session_id: spec.session_id, ts, error: "untyped death" };
+            yield { type: "completed", session_id: spec.session_id, ts };
+            return;
+          }
+          writeFileSync(join(spec.cwd, "CHANGED.txt"), "made it\n");
+          yield { type: "message", session_id: spec.session_id, ts, text: "Implemented." };
+          yield { type: "completed", session_id: spec.session_id, ts };
+        },
+      };
+      const events: Array<{ type: string; payload: Record<string, unknown> }> = [];
+      const res = await new Orchestrator({
+        registry: new Map([["limited", adapter]]),
+        reviewers: [],
+      }).run({
+        repoRoot: repo,
+        prompt: "do it",
+        mode: "agent",
+        harnesses: ["limited"],
+        n: 1,
+        credentialProfileId: "a",
+        onEvent: (event) =>
+          events.push({ type: event.type, payload: event.payload as Record<string, unknown> }),
+      });
+      expect(legacyOutcome(res)).not.toBe("failed");
+      expect(profilesSeen).toEqual(["a", "b", "c"]);
+      expect(
+        events.filter((e) => e.type === "route.profile.rotated").map((e) => e.payload["reason"]),
+      ).toEqual(["vendor_limit_rejected", "structural_pre_progress_failure"]);
     } finally {
       if (previousConfigDir === undefined) delete process.env.CLAUDEXOR_CONFIG_DIR;
       else process.env.CLAUDEXOR_CONFIG_DIR = previousConfigDir;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -205,6 +205,7 @@ import {
   unrecoveredToolErrors,
   webUnsatisfied,
 } from "./attemptTelemetry.js";
+import { newAttemptOutputMarkers } from "./attemptOutputMarkers.js";
 import * as delegateFailure from "./delegationFailure.js";
 import * as secretDiff from "./secretDiff.js";
 import { dominantHarnessFailureCategory, harnessFailureNextActions } from "./harnessFailure.js";
@@ -2506,8 +2507,11 @@ export class Orchestrator {
     }
     try {
       for (let nativeTry = 0; !signal?.aborted; nativeTry += 1) {
-        // A3 per-try isolation: a failed try's output never seeds the next try.
-        if (nativeTry > 0) answer = new AnswerAssembly();
+        // A3 per-try isolation: neither output nor progress markers leak across tries.
+        if (nativeTry > 0) {
+          answer = new AnswerAssembly();
+          telemetry.outputMarkers = newAttemptOutputMarkers();
+        }
         const clearFileBackedContext = stageFileBackedContext(
           envelope.worktree_path,
           fileBackedContext,
@@ -2648,8 +2652,7 @@ export class Orchestrator {
         const sawRetryable = newTransients.some((f) => f.retryable);
         const sawTypedLimit = telemetry.rateLimits.length > rateLimitStart;
         const currentDiff = await wsm.diff(envelope);
-        const currentAnswer = answer.text();
-        const deliverableEmpty = currentDiff.trim().length === 0 && currentAnswer.length === 0;
+        const deliverableEmpty = currentDiff.trim().length === 0 && answer.text().length === 0;
         // W5.4 + A2 failover: a typed-limit hit OR a structural pre-progress
         // death rebuilds the spec on a NEW session under the next profile.
         if (harnessErrored && runInput && !signal?.aborted) {
@@ -2674,7 +2677,12 @@ export class Orchestrator {
             sawTypedLimit,
             sawRetryable,
             attemptErrored: harnessErrored,
-            deliverableEmpty,
+            // Rotation evidence reads the POLICY-accepted try output: refusal
+            // prose arriving as mid-stream MESSAGE events (claude org-disabled)
+            // is no deliverable; the transient gate keeps RAW deliverableEmpty.
+            deliverableEmpty:
+              currentDiff.trim().length === 0 &&
+              acceptedTryOutput(answer, harnessErrored).length === 0,
             workspaceDiffNonEmpty: currentDiff.trim().length > 0,
             lastLimit: telemetry.rateLimits.at(-1) ?? null,
             emit: (type, payload) => log?.emit(type, payload),
@@ -6743,8 +6751,12 @@ export class Orchestrator {
       try {
         const triedProfiles = new Set<string>(); // W5.4 failover: each profile at most once
         for (let nativeTry = 0; !input.signal?.aborted; nativeTry += 1) {
-          // A3 per-try isolation: a failed try's output never seeds the next try.
-          if (nativeTry > 0) answer = new AnswerAssembly();
+          // A3 per-try isolation (candidate-lane parity): neither a failed try's
+          // output nor its progress markers leak into the next try's evidence.
+          if (nativeTry > 0) {
+            answer = new AnswerAssembly();
+            telemetry.outputMarkers = newAttemptOutputMarkers();
+          }
           const runSpec =
             nativeTry === 0
               ? spec
@@ -6848,7 +6860,9 @@ export class Orchestrator {
               sawTypedLimit,
               sawRetryable,
               attemptErrored: harnessError !== null,
-              deliverableEmpty: reportSoFar.length === 0,
+              // Same policy owner as the candidate lane: an errored try's
+              // narration is not a report; the transient gate keeps reportSoFar.
+              deliverableEmpty: acceptedTryOutput(answer, harnessError !== null).length === 0,
               lastLimit: telemetry.rateLimits.at(-1) ?? null,
               emit: (type, payload) => log.emit(type, payload),
               newSessionId: () => newId("ses"),

--- a/packages/orchestrator/src/quotaRefusal.test.ts
+++ b/packages/orchestrator/src/quotaRefusal.test.ts
@@ -274,6 +274,40 @@ describe("credential pool exhaustion (A5)", () => {
     });
   });
 
+  it("an api_key sibling's stale cooldown is NEVER pool evidence for a subscription subject (member-only gate)", async () => {
+    // A subscription (native-session) subject dies structurally; the only
+    // registered identity is a METERED api_key sibling — a row rotation could
+    // never select (`credential_kind_mismatch`). Its own cooldown evidence
+    // must not let the terminal claim "the credential pool refused": the
+    // attempt keeps its TRUE failure (fail-as-is → null).
+    const metered: CredentialProfile = {
+      ...profile,
+      profile_id: "metered",
+      display_name: "metered",
+      credential_kind: "api_key",
+      isolation_locator: null,
+      secret_ref: "anthropic_key:metered",
+    };
+    const meteredCooldown: QuotaSnapshot = {
+      ...snapshotFor("metered", { cooldown_until: MID }),
+      subject: {
+        harness: "claude",
+        credential_route: "managed_api_key",
+        plan_label: null,
+        subject_id: "metered",
+      },
+    };
+    const result = await rotateSpecOnTypedLimit({
+      ...rotateArgs([meteredCooldown], null),
+      registry: [metered],
+      probeReadyProfiles: async () => new Set<string>(),
+      // STRUCTURAL death: no typed limit, so the subject carries no evidence.
+      sawTypedLimit: false,
+      sawRetryable: false,
+    });
+    expect(result).toBeNull();
+  });
+
   it("lands in failure.yaml with its code and folded reset intact", async () => {
     const result = await rotateSpecOnTypedLimit(
       rotateArgs(

--- a/packages/orchestrator/src/rotation-predicate.ts
+++ b/packages/orchestrator/src/rotation-predicate.ts
@@ -27,7 +27,9 @@ import type { AttemptOutputMarkers } from "./attemptOutputMarkers.js";
 export interface RotationEvidence {
   /** A TYPED vendor rate-limit signal was observed this try (W5.4). */
   sawTypedLimit: boolean;
-  /** No answer material and (candidate lane) no workspace diff so far. */
+  /** No POLICY-ACCEPTED answer material (`acceptedTryOutput`: an errored try's
+   * mid-stream narration — e.g. a vendor refusal arriving as MESSAGE prose —
+   * never counts, for ANY adapter) and (candidate lane) no workspace diff. */
   deliverableEmpty: boolean;
   /** A workspace mutation was OBSERVED: a non-empty diff (candidate lane) or
    * any typed file_change event (both lanes — the read-only lane has no


### PR DESCRIPTION
## What this is

PR #197 was merged at 02:48 UTC while the final-review fix round was still being pushed — this PR carries the one commit that missed the merge window (`a3a8989b`, already reviewed: each fix has a discriminator proof, full vitest 4154+1 green, all gates green; see the round summary in the #197 comment).

### The four fixes (final code-review findings on #197)
1. **The flagship incident now actually rotates.** Rotation evidence reads `acceptedTryOutput` in both lanes: claude org-disabled prose arriving as a mid-stream assistant message no longer suppresses structural failover. End-to-end regression test replays the committed incident fixture — the sibling profile is spawned, `answer.md` never carries the prose. (Without this commit, the merged main still fails the sprint's original incident.)
2. Pool-exhausted terminal counts evidence from pool MEMBERS only — a wrong-kind sibling's stale cooldown cannot relabel a true harness failure.
3. `profileQuotaBlock` is route-scoped — api-key-route cooldowns no longer block the native-session subject of the same harness (and vice versa).
4. Output markers reset per native try — one try's progress cannot suppress the next try's structural rotation.

No history rewritten; this is the same reviewed branch, one commit ahead of the merged state.
