### PR TITLE
fix(daemon): raise the default run concurrency limit to 12

### DIFF
--- a/.changeset/raise-daemon-run-cap.md
+++ b/.changeset/raise-daemon-run-cap.md
@@ -1,0 +1,5 @@
+---
+"@claudexor/daemon": patch
+---
+
+Run up to twelve regular daemon jobs concurrently before queueing additional work.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -883,6 +883,10 @@ interactive REPL enters through the managed daemon and `/v2`; the CLI starts it
 when needed and fails loudly if it cannot. There is no second in-process CLI
 run/thread authority. The daemon remains the single scheduler and journal
 writer while the mode pipelines below retain their distinct mutability.
+By default, the daemon admits up to twelve regular jobs globally per data root.
+Same-thread turns remain serialized, while one already validated Delegate child
+may use the scheduler's single overflow lane to prevent a waiting parent from
+deadlocking.
 `claudexor doctor`, `models`, and `auth status` are also thin projections of the
 daemon's typed `/v2/harnesses` and `/v2/harnesses/:id/models` readiness services;
 requested harness filters reach the producer instead of probing unrelated adapters.

--- a/packages/daemon/src/daemon.test.ts
+++ b/packages/daemon/src/daemon.test.ts
@@ -1444,6 +1444,62 @@ describe("DaemonServer", () => {
     expect(() => commandAuthority(dir)).toThrow(/duplicate|multiple terminal events/);
   });
 
+  it("defaults to twelve regular concurrent jobs and queues the thirteenth", async () => {
+    const dir = tempDir("c12");
+    const authority = commandAuthority(dir);
+    const socketPath = join(dir, "daemon.sock");
+    let active = 0;
+    let maxActive = 0;
+    let started = 0;
+    let releaseRuns!: () => void;
+    const runBarrier = new Promise<void>((resolve) => {
+      releaseRuns = resolve;
+    });
+    const server = new DaemonServer({
+      socketPath,
+      token: "token",
+      commands: authority.slot,
+      runner: async (params, ctx) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        started += 1;
+        ctx.onRunStart({
+          runId: `run-${(params as { id: number }).id}`,
+          taskId: "task",
+          runDir: dir,
+        });
+        try {
+          await runBarrier;
+          return { lifecycle: "succeeded" };
+        } finally {
+          active -= 1;
+        }
+      },
+    });
+    await server.start();
+    const client = new DaemonClient(socketPath, "token");
+    let jobs: Array<{ id: string }> = [];
+    try {
+      jobs = await Promise.all(
+        Array.from({ length: 13 }, (_, index) => client.enqueue({ id: index + 1 })),
+      );
+      expect(started).toBe(12);
+      await expect(client.health()).resolves.toMatchObject({ active: 12, queue: 1 });
+
+      releaseRuns();
+      const records = await Promise.all(jobs.map((job) => terminal(client, job.id)));
+      expect(records.map((record) => record.state)).toEqual(Array(13).fill("succeeded"));
+      expect(maxActive).toBe(12);
+    } finally {
+      releaseRuns();
+      if (jobs.length > 0) {
+        await Promise.all(jobs.map((job) => terminal(client, job.id))).catch(() => {});
+      }
+      await server.stop();
+      authority.journal.close();
+    }
+  });
+
   it("bounds concurrency and cancellation while exposing run identity", async () => {
     const dir = tempDir("concurrency");
     const authority = commandAuthority(dir);

--- a/packages/daemon/src/server.ts
+++ b/packages/daemon/src/server.ts
@@ -385,7 +385,7 @@ export class DaemonServer {
   }
 
   private get maxConcurrent(): number {
-    return this.opts.maxConcurrent ?? 4;
+    return this.opts.maxConcurrent ?? 12;
   }
 
   /** Daemon-owned cancellation primitive used by RPC and the Delegate drain


### PR DESCRIPTION
The shared Claudexor daemon currently admits four ordinary top-level jobs at once, so unrelated runs from different tasks can queue behind each other. This raises the bounded default to twelve while preserving explicit maxConcurrent overrides, one-active-run-per-thread serialization, and the single Delegate-child overflow lane.

A focused daemon regression omits the override, starts twelve ordinary jobs, and proves the thirteenth remains queued until a slot is released. The scheduler map and patch changeset are updated with the same behavior.

Verified with the focused daemon suite and the complete pnpm release:verify:node gate, including 4357 unit and integration tests plus 42 canary tests. No schema, control API, settings, or concept invariant changed. The shared local daemon was not restarted or disturbed.