### PR TITLE
Keep Claude auth probes from becoming false logouts

### DIFF
--- a/.changeset/steady-claude-auth-probe.md
+++ b/.changeset/steady-claude-auth-probe.md
@@ -1,0 +1,7 @@
+---
+"@claudexor/harness-claude": patch
+"@claudexor/cli": patch
+---
+
+Keep transient Claude native auth-status transport failures typed as unknown,
+with bounded retry and last-known-good disclosure instead of a false logout.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -547,9 +547,11 @@ typed, process-local stale observation for at most one minute. Claudexor-handled
 logout, login, profile, or secret mutations clear that observation (including
 an in-flight probe); an external vendor login/logout may remain visible for the
 bounded grace window. Stale evidence is never reported as a fresh passed login
-and does not alter the selected profile or paid-route policy. This absorbs a
-probe failure only; it does not claim to serialize the vendor's OAuth refresh
-or to repair a revoked credential.
+and does not alter profile selection or paid-route policy: an already explicit
+pin or durable thread binding may keep its exact config-dir route alive for
+this bounded grace, while unpinned pool/rotation selection remains fresh-only.
+This absorbs a probe failure only; it does not claim to serialize the vendor's
+OAuth refresh or to repair a revoked credential.
 Adapters declare the physical credential transport they support (`config_file`,
 `env_var`, `oauth_token_env`, `os_keychain`, `http_header`, or `none`) plus the
 containment strategy that keeps it honest. A transport may be platform-scoped;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -539,6 +539,17 @@ adapter/doctor caches without clearing or replacing shared cached reports.
 An absent/logged-out source is `unavailable + not_run`; a probe failure that
 cannot decide source presence is `unknown + not_run`; present but wrong or
 unusable source material is `available + failed`.
+Claude's native `auth status` probe keeps that distinction under transient
+child-process or Keychain transport failure: concurrent reads of one exact
+`(binary, config-dir)` store share one bounded probe, a retry stays inside the
+original ten-second budget, and a positive result may be reused only as a
+typed, process-local stale observation for at most one minute. Claudexor-handled
+logout, login, profile, or secret mutations clear that observation (including
+an in-flight probe); an external vendor login/logout may remain visible for the
+bounded grace window. Stale evidence is never reported as a fresh passed login
+and does not alter the selected profile or paid-route policy. This absorbs a
+probe failure only; it does not claim to serialize the vendor's OAuth refresh
+or to repair a revoked credential.
 Adapters declare the physical credential transport they support (`config_file`,
 `env_var`, `oauth_token_env`, `os_keychain`, `http_header`, or `none`) plus the
 containment strategy that keeps it honest. A transport may be platform-scoped;

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -42,7 +42,7 @@ import {
   recoveryBlockedPartitions,
 } from "./daemon-startup.js";
 import { assertPlanImplementReady } from "./plan-implement-readiness.js";
-import { buildRunOrchestrator, credentialUnusableLedger } from "./run-orchestrator.js";
+import { buildRunOrchestrator } from "./run-orchestrator.js";
 import { delegationBeltForRun } from "./delegation-belt-descriptor.js";
 import { loadConfig } from "@claudexor/config";
 import { engineBuildIdentity, noProjectRepoRoot, redactSecrets } from "@claudexor/util";
@@ -50,10 +50,9 @@ import { type ResourceAttachmentRef } from "@claudexor/schema";
 import { scheduleStartupRetention } from "./retention-service.js";
 import { controlServices } from "./control-services.js";
 import { AuthReadinessService } from "@claudexor/gateway";
-import { clearClaudeAuthStatusCache } from "@claudexor/harness-claude";
 import { buildGateway } from "./registry.js";
 import { createSetupJobManager } from "./setup-jobs.js";
-import { invalidateStatusProjections } from "./status-projection-cache.js";
+import { bustGlobalCredentialStatusCaches } from "./credential-status-invalidation.js";
 import { SetupJobStore } from "./setup-job-store.js";
 import { SetupLifecycleBinding } from "./setup-lifecycle-binding.js";
 import { DaemonRuntimeShutdown } from "./daemon-runtime-shutdown.js";
@@ -449,16 +448,8 @@ export async function main(): Promise<void> {
         rootDir: daemonDir(),
         store,
         onCredentialStateMayHaveChanged: (harness) => {
-          clearClaudeAuthStatusCache();
+          bustGlobalCredentialStatusCaches(() => quotaStoreSlot.current());
           authReadiness.invalidate(harness);
-          // The poll-surface projections embed harness/profile status; a
-          // login/logout makes them stale NOW, not a TTL from now.
-          invalidateStatusProjections();
-          // Drop the quota absence backoff too (wave-1): a fresh login must
-          // not wait out up to 15 minutes of logged-out pacing. The unusable-
-          // credential ledger clears with it (A7 generation-change contract).
-          quotaStoreSlot.current().noteCredentialChange();
-          credentialUnusableLedger.noteCredentialChange();
         },
       }),
     );

--- a/packages/cli/src/claudexord.ts
+++ b/packages/cli/src/claudexord.ts
@@ -50,6 +50,7 @@ import { type ResourceAttachmentRef } from "@claudexor/schema";
 import { scheduleStartupRetention } from "./retention-service.js";
 import { controlServices } from "./control-services.js";
 import { AuthReadinessService } from "@claudexor/gateway";
+import { clearClaudeAuthStatusCache } from "@claudexor/harness-claude";
 import { buildGateway } from "./registry.js";
 import { createSetupJobManager } from "./setup-jobs.js";
 import { invalidateStatusProjections } from "./status-projection-cache.js";
@@ -448,6 +449,7 @@ export async function main(): Promise<void> {
         rootDir: daemonDir(),
         store,
         onCredentialStateMayHaveChanged: (harness) => {
+          clearClaudeAuthStatusCache();
           authReadiness.invalidate(harness);
           // The poll-surface projections embed harness/profile status; a
           // login/logout makes them stale NOW, not a TTL from now.

--- a/packages/cli/src/credential-status-invalidation.ts
+++ b/packages/cli/src/credential-status-invalidation.ts
@@ -10,6 +10,7 @@
  */
 import { loadConfig } from "@claudexor/config";
 import { invalidateDoctorCache } from "@claudexor/core";
+import { clearClaudeAuthStatusCache } from "@claudexor/harness-claude";
 import type { QuotaRegistry } from "@claudexor/daemon";
 import { noProjectRepoRoot } from "@claudexor/util";
 import { invalidateStatusProjections } from "./status-projection-cache.js";
@@ -24,6 +25,10 @@ export function bustCredentialStatusCaches(
   quotaRegistry: () => QuotaRegistry,
   subject?: CredentialMutationSubject,
 ): void {
+  // Auth-status keeps a short process-local LKG only to survive a transient
+  // probe transport error. Any explicit credential mutation must invalidate it
+  // before status/probe consumers can observe the changed store.
+  clearClaudeAuthStatusCache();
   invalidateDoctorCache();
   invalidateStatusProjections();
   quotaRegistry().noteCredentialChange();

--- a/packages/cli/src/credential-status-invalidation.ts
+++ b/packages/cli/src/credential-status-invalidation.ts
@@ -46,3 +46,9 @@ export function bustCredentialStatusCaches(
   }
   if (!subject.secretName.includes(":")) credentialUnusableLedger.clearDefaultSubjects();
 }
+
+/** Clear the process-wide observations after a daemon login/logout lifecycle. */
+export function bustGlobalCredentialStatusCaches(quotaRegistry: () => QuotaRegistry): void {
+  bustCredentialStatusCaches(quotaRegistry);
+  credentialUnusableLedger.noteCredentialChange();
+}

--- a/packages/harness-claude/src/auth-status.test.ts
+++ b/packages/harness-claude/src/auth-status.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpawnOptions } from "@claudexor/core";
+import {
+  CLAUDE_AUTH_STATUS_CACHE_TTL_MS,
+  CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS,
+  clearClaudeAuthStatusCache,
+  probeClaudeAuthStatus,
+} from "./auth-status.js";
+
+function result(
+  stdout: string,
+  over: Partial<{ code: number | null; signal: NodeJS.Signals | null; stderr: string }> = {},
+) {
+  return {
+    code: 0,
+    signal: null,
+    stdout,
+    stderr: "",
+    ...over,
+  };
+}
+
+const options = (runCapture: Parameters<typeof probeClaudeAuthStatus>[1]["runCapture"]) => ({
+  env: {},
+  configDir: "/owned/profiles/work",
+  runCapture,
+});
+
+describe("Claude auth-status resilience", () => {
+  beforeEach(() => clearClaudeAuthStatusCache());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("coalesces concurrent probes for one exact store", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      await gate;
+      return result('{"loggedIn":true,"authMethod":"claude.ai"}');
+    };
+
+    const first = probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    const second = probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(calls).toBe(1);
+    release();
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { loggedIn: true, authed: true, authMethod: "claude.ai", probeError: null },
+      { loggedIn: true, authed: true, authMethod: "claude.ai", probeError: null },
+    ]);
+  });
+
+  it("does not coalesce different exact profile stores", async () => {
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return result('{"loggedIn":true,"authMethod":"claude.ai"}');
+    };
+    const first = probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    const second = probeClaudeAuthStatus("/bin/claude", {
+      ...options(runCapture),
+      configDir: "/owned/profiles/other",
+    });
+    await Promise.all([first, second]);
+    expect(calls).toBe(2);
+  });
+
+  it("retries once for a transport failure, then accepts a typed verdict", async () => {
+    let calls = 0;
+    const timeouts: number[] = [];
+    const runCapture = async () => {
+      calls += 1;
+      return calls === 1
+        ? result("", { code: null, signal: "SIGKILL" })
+        : result('{"loggedIn":true,"authMethod":"claude.ai"}');
+    };
+    const captureWithTimeout = async (_bin: string, _args: string[], opts?: SpawnOptions) => {
+      timeouts.push(opts?.timeoutMs ?? -1);
+      return runCapture();
+    };
+    const probe = await probeClaudeAuthStatus("/bin/claude", options(captureWithTimeout));
+    expect(probe).toEqual({
+      loggedIn: true,
+      authed: true,
+      authMethod: "claude.ai",
+      probeError: null,
+    });
+    expect(calls).toBe(2);
+    expect(timeouts[0]).toBe(CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS);
+    expect(timeouts[1]).toBeGreaterThan(0);
+    expect(timeouts[1]).toBeLessThan(CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS);
+  });
+
+  it("does not retry or mask a parseable vendor/config error", async () => {
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return result("", { code: 1, stderr: "Error: authentication rejected (401)" });
+    };
+    const probe = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(calls).toBe(1);
+    expect(probe.authed).toBe(false);
+    expect(probe.stale).toBeUndefined();
+    expect(probe.probeError).toContain("authentication rejected (401)");
+  });
+
+  it("uses the bounded last-known-good verdict only after transport retry fails", async () => {
+    let clock = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return calls === 1
+        ? result('{"loggedIn":true,"authMethod":"claude.ai"}')
+        : result("", { code: null, signal: "SIGKILL" });
+    };
+    await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    const stale = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(calls).toBe(3);
+    expect(stale).toMatchObject({ loggedIn: true, authed: true, stale: true, probeError: null });
+    expect(stale.staleAgeMs).toEqual(expect.any(Number));
+  });
+
+  it("expires the last-known-good grace window", async () => {
+    let clock = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return calls === 1
+        ? result('{"loggedIn":true,"authMethod":"claude.ai"}')
+        : result("", { code: null, signal: "SIGKILL" });
+    };
+    await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    clock += CLAUDE_AUTH_STATUS_CACHE_TTL_MS + 1;
+    const expired = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(expired.stale).toBeUndefined();
+    expect(expired.probeError).toBeTruthy();
+  });
+
+  it("clears LKG on a clean logout, so a later transport error cannot resurrect it", async () => {
+    let clock = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      if (calls === 1) return result('{"loggedIn":true,"authMethod":"claude.ai"}');
+      if (calls === 2) return result('{"loggedIn":false,"authMethod":"none"}', { code: 1 });
+      return result("", { code: null, signal: "SIGKILL" });
+    };
+    await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    const loggedOut = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(loggedOut).toMatchObject({ loggedIn: false, authed: false, probeError: null });
+    const afterLogout = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(afterLogout.stale).toBeUndefined();
+    expect(afterLogout.probeError).toBeTruthy();
+  });
+
+  it("does not retry an already-aborted transport probe", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return result("", { code: null, signal: "SIGTERM" });
+    };
+    const probe = await probeClaudeAuthStatus("/bin/claude", {
+      ...options(runCapture),
+      abortSignal: controller.signal,
+    });
+    // An already-cancelled caller must not spawn a vendor process at all.
+    expect(calls).toBe(0);
+    expect(probe.stale).toBeUndefined();
+    expect(probe.probeError).toBeTruthy();
+  });
+
+  it("does not let the first caller's abort cancel a shared probe", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    const firstAbort = new AbortController();
+    const secondAbort = new AbortController();
+    const runCapture = async () => {
+      calls += 1;
+      await gate;
+      return result('{"loggedIn":true,"authMethod":"claude.ai"}');
+    };
+    const first = probeClaudeAuthStatus("/bin/claude", {
+      ...options(runCapture),
+      abortSignal: firstAbort.signal,
+    });
+    const second = probeClaudeAuthStatus("/bin/claude", {
+      ...options(runCapture),
+      abortSignal: secondAbort.signal,
+    });
+    firstAbort.abort();
+    await expect(first).resolves.toMatchObject({ probeError: "claude auth status probe aborted" });
+    expect(calls).toBe(1);
+    release();
+    await expect(second).resolves.toMatchObject({ authed: true, probeError: null });
+  });
+
+  it("does not return stale LKG to a caller that aborts during transport failure", async () => {
+    let clock = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      if (calls === 1) return result('{"loggedIn":true,"authMethod":"claude.ai"}');
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      return result("", { code: null, signal: "SIGKILL" });
+    };
+    await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    const controller = new AbortController();
+    const aborted = probeClaudeAuthStatus("/bin/claude", {
+      ...options(runCapture),
+      abortSignal: controller.signal,
+    });
+    controller.abort();
+    const probe = await aborted;
+    expect(probe.stale).toBeUndefined();
+    expect(probe.probeError).toBe("claude auth status probe aborted");
+  });
+
+  it("does not resurrect LKG after an explicit cache invalidation", async () => {
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return calls === 1
+        ? result('{"loggedIn":true,"authMethod":"claude.ai"}')
+        : result("", { code: null, signal: "SIGTERM" });
+    };
+    await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    clearClaudeAuthStatusCache();
+    const probe = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(probe.stale).toBeUndefined();
+    expect(probe.probeError).toBeTruthy();
+  });
+
+  it("does not let an invalidated in-flight probe repopulate the LKG", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const runCapture = async () => {
+      await gate;
+      return result('{"loggedIn":true,"authMethod":"claude.ai"}');
+    };
+    const pending = probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    clearClaudeAuthStatusCache();
+    release();
+    const invalidated = await pending;
+    expect(invalidated.stale).toBeUndefined();
+    expect(invalidated.probeError).toBeTruthy();
+  });
+});

--- a/packages/harness-claude/src/auth-status.test.ts
+++ b/packages/harness-claude/src/auth-status.test.ts
@@ -109,6 +109,25 @@ describe("Claude auth-status resilience", () => {
     expect(probe.probeError).toContain("authentication rejected (401)");
   });
 
+  it("does not accept a typed verdict flushed by a signaled child", async () => {
+    let calls = 0;
+    const runCapture = async () => {
+      calls += 1;
+      return result('{"loggedIn":true,"authMethod":"claude.ai"}', {
+        code: null,
+        signal: "SIGKILL",
+      });
+    };
+    const probe = await probeClaudeAuthStatus("/bin/claude", options(runCapture));
+    expect(calls).toBe(2);
+    expect(probe).toMatchObject({
+      loggedIn: false,
+      authed: false,
+      probeError: expect.stringContaining('"loggedIn":true'),
+    });
+    expect(probe.stale).toBeUndefined();
+  });
+
   it("uses the bounded last-known-good verdict only after transport retry fails", async () => {
     let clock = 1_000;
     vi.spyOn(Date, "now").mockImplementation(() => clock);

--- a/packages/harness-claude/src/auth-status.test.ts
+++ b/packages/harness-claude/src/auth-status.test.ts
@@ -68,10 +68,13 @@ describe("Claude auth-status resilience", () => {
   });
 
   it("retries once for a transport failure, then accepts a typed verdict", async () => {
+    let clock = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => clock);
     let calls = 0;
     const timeouts: number[] = [];
     const runCapture = async () => {
       calls += 1;
+      clock += 100;
       return calls === 1
         ? result("", { code: null, signal: "SIGKILL" })
         : result('{"loggedIn":true,"authMethod":"claude.ai"}');

--- a/packages/harness-claude/src/auth-status.ts
+++ b/packages/harness-claude/src/auth-status.ts
@@ -160,6 +160,12 @@ function thrownErrorDetail(err: unknown): string {
 }
 
 function typedVerdict(capture: CaptureResult): ClaudeAuthStatusProbe | null {
+  // A killed/timed-out child may have flushed a complete-looking JSON object
+  // before the signal arrived.  The bytes are not a fresh vendor verdict in
+  // that case.  Keep exit-code semantics separate: `claude auth status` uses
+  // code 1 for a clean logged-out JSON response, so code alone cannot reject
+  // an otherwise complete status result.
+  if (capture.signal !== null) return null;
   try {
     const verdict = JSON.parse(capture.stdout.trim()) as {
       loggedIn?: unknown;

--- a/packages/harness-claude/src/auth-status.ts
+++ b/packages/harness-claude/src/auth-status.ts
@@ -1,0 +1,269 @@
+import type { CaptureResult } from "@claudexor/core";
+import { labelStreams, runCapture } from "@claudexor/core";
+import { redactSecrets } from "@claudexor/util";
+import type { ClaudeAuthStatusProbe } from "./index.js";
+
+/**
+ * Auth-status is a read of one vendor-owned store.  A daemon can ask for the
+ * same store from several concurrent runs, so coalesce those reads and keep a
+ * short, process-local last-known-good value.  The cache is deliberately not
+ * persisted: it is only a grace window for a transient child-process failure,
+ * never an auth proof after a daemon restart.
+ */
+// A transient daemon/Keychain read may keep the last positive verdict alive
+// briefly, but this is deliberately much shorter than a login session.  It is
+// a recovery grace window, never durable auth proof.
+export const CLAUDE_AUTH_STATUS_CACHE_TTL_MS = 60_000;
+/** The two-attempt probe must fit the same 10s wall-clock budget as one run. */
+export const CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS = 10_000;
+const CLAUDE_AUTH_STATUS_RETRY_DELAY_MS = 50;
+
+export interface ClaudeAuthStatusProbeOptions {
+  env: Record<string, string | null | undefined>;
+  configDir: string;
+  abortSignal?: AbortSignal;
+  runCapture?: typeof runCapture;
+}
+
+interface CachedAuthStatus {
+  result: ClaudeAuthStatusProbe;
+  checkedAt: number;
+}
+
+interface ProbeAttempt {
+  result?: ClaudeAuthStatusProbe;
+  transportFailure: boolean;
+  detail: string;
+}
+
+const cache = new Map<string, CachedAuthStatus>();
+interface PendingProbe {
+  promise: Promise<ClaudeAuthStatusProbe>;
+  controller: AbortController;
+}
+const pending = new Map<string, PendingProbe>();
+
+/** Test seam for isolating the process-local cache between focused cases. */
+export function clearClaudeAuthStatusCache(): void {
+  cache.clear();
+  // An explicit credential mutation must also stop an in-flight probe from
+  // repopulating the just-invalidated LKG with a pre-mutation verdict.
+  for (const { controller } of pending.values()) controller.abort("credential state changed");
+  pending.clear();
+}
+
+function cacheKey(bin: string, configDir: string): string {
+  return JSON.stringify([bin, configDir]);
+}
+
+function probeErrorDetail(capture: CaptureResult): string {
+  return (
+    labelStreams(capture.stderr, capture.stdout, { transform: redactSecrets }) ??
+    `claude auth status exited with ${capture.code ?? capture.signal ?? "unknown result"}`
+  );
+}
+
+function thrownErrorDetail(err: unknown): string {
+  return [...redactSecrets(err instanceof Error ? err.message : String(err))]
+    .slice(0, 300)
+    .join("");
+}
+
+function typedVerdict(capture: CaptureResult): ClaudeAuthStatusProbe | null {
+  try {
+    const verdict = JSON.parse(capture.stdout.trim()) as {
+      loggedIn?: unknown;
+      authMethod?: unknown;
+    };
+    if (typeof verdict.loggedIn === "boolean" && typeof verdict.authMethod === "string") {
+      return {
+        loggedIn: verdict.loggedIn,
+        authed: verdict.loggedIn && verdict.authMethod === "claude.ai",
+        authMethod: verdict.authMethod,
+        probeError: null,
+      };
+    }
+  } catch {
+    // The caller turns an absent typed verdict into a probe error below.
+  }
+  return null;
+}
+
+async function waitBeforeRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (delayMs <= 0 || signal?.aborted) return;
+  await new Promise<void>((resolve) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, delayMs);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function attempt(
+  bin: string,
+  options: ClaudeAuthStatusProbeOptions,
+  timeoutMs: number,
+): Promise<ProbeAttempt> {
+  const capture = options.runCapture ?? runCapture;
+  try {
+    const result = await capture(bin, ["auth", "status"], {
+      env: options.env,
+      timeoutMs,
+      abortSignal: options.abortSignal,
+      cancelSignal: "SIGTERM",
+      cancelKillDelayMs: 0,
+    });
+    const verdict = typedVerdict(result);
+    if (verdict !== null) {
+      return { result: verdict, transportFailure: false, detail: "" };
+    }
+    return {
+      transportFailure: result.code === null || result.signal !== null,
+      detail: probeErrorDetail(result),
+    };
+  } catch (err) {
+    return { transportFailure: true, detail: thrownErrorDetail(err) };
+  }
+}
+
+async function probeUnshared(
+  bin: string,
+  options: ClaudeAuthStatusProbeOptions,
+  key: string,
+): Promise<ClaudeAuthStatusProbe> {
+  const deadline = Date.now() + CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS;
+  let latest = await attempt(bin, options, Math.max(1, deadline - Date.now()));
+  if (options.abortSignal?.aborted) return abortedProbe();
+  if (latest.result !== undefined) {
+    // A clean logged-out or wrong-method verdict is authoritative and must
+    // invalidate an older positive cache entry, so it cannot resurrect a
+    // session that the vendor explicitly says is gone.
+    if (!latest.result.authed) cache.delete(key);
+    else cache.set(key, { result: latest.result, checkedAt: Date.now() });
+    return latest.result;
+  }
+
+  if (latest.transportFailure && !options.abortSignal?.aborted) {
+    const remainingBeforeWait = deadline - Date.now();
+    if (remainingBeforeWait > 0) {
+      await waitBeforeRetry(
+        Math.min(CLAUDE_AUTH_STATUS_RETRY_DELAY_MS, remainingBeforeWait),
+        options.abortSignal,
+      );
+      const remaining = deadline - Date.now();
+      if (remaining > 0 && !options.abortSignal?.aborted)
+        latest = await attempt(bin, options, remaining);
+    }
+    if (options.abortSignal?.aborted) return abortedProbe();
+  }
+
+  if (latest.result !== undefined) {
+    if (!latest.result.authed) cache.delete(key);
+    else cache.set(key, { result: latest.result, checkedAt: Date.now() });
+    return latest.result;
+  }
+
+  // Only a transport failure can use LKG.  A parseable vendor error is a real
+  // negative signal and remains a probe error, preserving the tri-state caller
+  // contract instead of hiding configuration corruption behind stale data.
+  if (latest.transportFailure && !options.abortSignal?.aborted) {
+    const prior = cache.get(key);
+    if (prior !== undefined) {
+      const staleAgeMs = Math.max(0, Date.now() - prior.checkedAt);
+      if (staleAgeMs <= CLAUDE_AUTH_STATUS_CACHE_TTL_MS) {
+        return {
+          ...prior.result,
+          probeError: null,
+          stale: true,
+          staleAgeMs,
+        };
+      }
+      cache.delete(key);
+    }
+  }
+  return {
+    loggedIn: false,
+    authed: false,
+    authMethod: null,
+    probeError: latest.detail,
+  };
+}
+
+/**
+ * Probe one exact `(binary, config-dir)` store.  Concurrent callers share one
+ * child process.  The lock is intentionally process-local and auth-status-only;
+ * full Claude runs are not serialized, and no cross-process lock or new wire
+ * schema is required for this recovery path.
+ */
+export async function probeClaudeAuthStatus(
+  bin: string,
+  options: ClaudeAuthStatusProbeOptions,
+): Promise<ClaudeAuthStatusProbe> {
+  if (options.abortSignal?.aborted) {
+    return {
+      loggedIn: false,
+      authed: false,
+      authMethod: null,
+      probeError: "claude auth status probe aborted",
+    };
+  }
+  const key = cacheKey(bin, options.configDir);
+  const inFlight = pending.get(key);
+  if (inFlight !== undefined) return awaitProbe(inFlight.promise, options.abortSignal);
+  // The underlying operation uses its own signal.  A caller cancelling its
+  // wait must not cancel the child process shared with a second caller.
+  const operationAbort = new AbortController();
+  const operation = probeUnshared(bin, { ...options, abortSignal: operationAbort.signal }, key);
+  const promise = operation.finally(() => {
+    if (pending.get(key)?.promise === promise) pending.delete(key);
+  });
+  pending.set(key, { promise, controller: operationAbort });
+  return awaitProbe(promise, options.abortSignal);
+}
+
+function abortedProbe(): ClaudeAuthStatusProbe {
+  return {
+    loggedIn: false,
+    authed: false,
+    authMethod: null,
+    probeError: "claude auth status probe aborted",
+  };
+}
+
+async function awaitProbe(
+  promise: Promise<ClaudeAuthStatusProbe>,
+  signal?: AbortSignal,
+): Promise<ClaudeAuthStatusProbe> {
+  if (!signal) return promise;
+  if (signal.aborted) return abortedProbe();
+  return new Promise<ClaudeAuthStatusProbe>((resolve) => {
+    let settled = false;
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const finish = (result: ClaudeAuthStatusProbe) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(signal.aborted ? abortedProbe() : result);
+    };
+    const onAbort = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(abortedProbe());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(finish, (err) =>
+      finish({
+        loggedIn: false,
+        authed: false,
+        authMethod: null,
+        probeError: thrownErrorDetail(err),
+      }),
+    );
+  });
+}

--- a/packages/harness-claude/src/auth-status.ts
+++ b/packages/harness-claude/src/auth-status.ts
@@ -1,7 +1,24 @@
 import type { CaptureResult } from "@claudexor/core";
+import type { AuthSourceReadiness, HarnessEvent } from "@claudexor/schema";
 import { labelStreams, runCapture } from "@claudexor/core";
-import { redactSecrets } from "@claudexor/util";
-import type { ClaudeAuthStatusProbe } from "./index.js";
+import { nowIso, redactSecrets } from "@claudexor/util";
+
+/**
+ * Native-session probe with a distinct PROBE-FAILURE state (same contract as
+ * the codex adapter's probeLogin). `claude auth status` prints a typed JSON
+ * verdict; a probe that produces no parseable verdict is a probe error, never
+ * a silent "not logged in".
+ */
+export interface ClaudeAuthStatusProbe {
+  loggedIn: boolean;
+  authed: boolean;
+  authMethod: string | null;
+  probeError: string | null;
+  /** True only when the result came from the bounded LKG grace window. */
+  stale?: boolean;
+  /** Age of the LKG auth verdict in milliseconds, when `stale` is true. */
+  staleAgeMs?: number;
+}
 
 /**
  * Auth-status is a read of one vendor-owned store.  A daemon can ask for the
@@ -18,11 +35,84 @@ export const CLAUDE_AUTH_STATUS_CACHE_TTL_MS = 60_000;
 export const CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS = 10_000;
 const CLAUDE_AUTH_STATUS_RETRY_DELAY_MS = 50;
 
-export interface ClaudeAuthStatusProbeOptions {
+interface ClaudeAuthStatusCoordinatorOptions {
   env: Record<string, string | null | undefined>;
   configDir: string;
   abortSignal?: AbortSignal;
   runCapture?: typeof runCapture;
+}
+
+export function redactClaudeDoctorDetail(text: string): string {
+  return redactSecrets(text).slice(0, 500);
+}
+
+export function claudeAuthSourceReadiness(input: {
+  native: ClaudeAuthStatusProbe;
+  oauthAvailable: boolean;
+  oauthVerification: "passed" | "failed" | "not_run";
+  oauthDetail: string;
+  apiKeyAvailable: boolean;
+  apiKeyVerification: "passed" | "failed" | "not_run";
+  apiKeyDetail: string;
+}): AuthSourceReadiness[] {
+  const nativeReady =
+    input.native.authed && input.native.probeError === null && input.native.stale !== true;
+  const nativeAvailability =
+    input.native.probeError || input.native.stale
+      ? "unknown"
+      : input.native.loggedIn
+        ? "available"
+        : "unavailable";
+  const nativeVerification = nativeReady
+    ? "passed"
+    : input.native.probeError || input.native.stale || !input.native.loggedIn
+      ? "not_run"
+      : "failed";
+  return [
+    {
+      source: "native_session",
+      availability: nativeAvailability,
+      verification: nativeVerification,
+      detail: nativeReady
+        ? "vendor status confirmed authMethod=claude.ai in the exact run environment"
+        : input.native.stale
+          ? `auth-status probe is stale; using last-known-good native session${
+              input.native.staleAgeMs === undefined ? "" : ` (${input.native.staleAgeMs}ms old)`
+            }`
+          : input.native.probeError
+            ? `auth-status probe failed: ${redactClaudeDoctorDetail(input.native.probeError)}`
+            : input.native.loggedIn
+              ? `Claude is logged in via ${input.native.authMethod ?? "unknown"}, not claude.ai`
+              : "official native Claude session is not logged in",
+    },
+    {
+      source: "oauth_token_env",
+      availability: input.oauthAvailable ? "available" : "unavailable",
+      verification: input.oauthVerification,
+      detail: input.oauthDetail,
+    },
+    {
+      source: "api_key_env",
+      availability: input.apiKeyAvailable ? "available" : "unavailable",
+      verification: input.apiKeyVerification,
+      detail: input.apiKeyDetail,
+    },
+  ];
+}
+
+export function staleClaudeAuthStatusEvent(sessionId: string, ageMs?: number): HarnessEvent {
+  return {
+    type: "message",
+    session_id: sessionId,
+    ts: nowIso(),
+    text: `[auth] native auth-status probe stale; using last-known-good session${
+      ageMs === undefined ? "" : ` (${ageMs}ms old)`
+    }`,
+    payload: {
+      auth_status_stale: true,
+      ...(ageMs === undefined ? {} : { auth_status_stale_age_ms: ageMs }),
+    },
+  };
 }
 
 interface CachedAuthStatus {
@@ -106,7 +196,7 @@ async function waitBeforeRetry(delayMs: number, signal?: AbortSignal): Promise<v
 
 async function attempt(
   bin: string,
-  options: ClaudeAuthStatusProbeOptions,
+  options: ClaudeAuthStatusCoordinatorOptions,
   timeoutMs: number,
 ): Promise<ProbeAttempt> {
   const capture = options.runCapture ?? runCapture;
@@ -133,7 +223,7 @@ async function attempt(
 
 async function probeUnshared(
   bin: string,
-  options: ClaudeAuthStatusProbeOptions,
+  options: ClaudeAuthStatusCoordinatorOptions,
   key: string,
 ): Promise<ClaudeAuthStatusProbe> {
   const deadline = Date.now() + CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS;
@@ -202,7 +292,7 @@ async function probeUnshared(
  */
 export async function probeClaudeAuthStatus(
   bin: string,
-  options: ClaudeAuthStatusProbeOptions,
+  options: ClaudeAuthStatusCoordinatorOptions,
 ): Promise<ClaudeAuthStatusProbe> {
   if (options.abortSignal?.aborted) {
     return {

--- a/packages/harness-claude/src/auth.test.ts
+++ b/packages/harness-claude/src/auth.test.ts
@@ -228,6 +228,26 @@ describe("probeAuthStatus (JSON verdict beats exit code; probe failures are dist
     }
   });
 
+  it("returns a typed probe error when native-store normalization rejects the locator", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-probe-"));
+    try {
+      const result = await probeAuthStatus("/fake/claude", {
+        env: { CLAUDEXOR_CLAUDE_NATIVE_DIR: join(dir, "outside-owned-root") },
+        runCapture: async () => {
+          throw new Error("runCapture must not be reached after locator rejection");
+        },
+      });
+      expect(result).toEqual({
+        loggedIn: false,
+        authed: false,
+        authMethod: null,
+        probeError: expect.stringContaining("must stay inside"),
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("no typed JSON + exit 0 is a probe error, never native readiness", async () => {
     const dir = mkdtempSync(join(tmpdir(), "claude-probe-"));
     try {

--- a/packages/harness-claude/src/auth.test.ts
+++ b/packages/harness-claude/src/auth.test.ts
@@ -79,6 +79,31 @@ describe("Claude setup-token readiness", () => {
       verification: "passed",
     });
   });
+
+  it("projects a stale last-known-good native probe as unknown, not passed", () => {
+    const sources = claudeAuthSourceReadiness({
+      native: {
+        loggedIn: true,
+        authed: true,
+        authMethod: "claude.ai",
+        probeError: null,
+        stale: true,
+        staleAgeMs: 321,
+      },
+      oauthAvailable: false,
+      oauthVerification: "not_run",
+      oauthDetail: "none",
+      apiKeyAvailable: false,
+      apiKeyVerification: "not_run",
+      apiKeyDetail: "none",
+    });
+    expect(sources[0]).toMatchObject({
+      source: "native_session",
+      availability: "unknown",
+      verification: "not_run",
+      detail: "auth-status probe is stale; using last-known-good native session (321ms old)",
+    });
+  });
 });
 
 function spec(over: Partial<HarnessRunSpec> = {}): HarnessRunSpec {
@@ -240,7 +265,8 @@ describe("probeAuthStatus (JSON verdict beats exit code; probe failures are dist
     expect(env.HOME).toBe("/scoped/home");
     expect(env.CLAUDE_CONFIG_DIR).toBe(defaultNativeClaudeConfigDir());
     expect(env.ANTHROPIC_API_KEY).toBeNull();
-    expect(captured?.abortSignal).toBe(controller.signal);
+    expect(captured?.abortSignal).toBeInstanceOf(AbortSignal);
+    expect(captured?.abortSignal).not.toBe(controller.signal);
     expect(captured?.cancelSignal).toBe("SIGTERM");
     expect(captured?.cancelKillDelayMs).toBe(0);
   });
@@ -365,6 +391,46 @@ describe("Claude scoped-HOME doctor honesty (INV-067)", () => {
     expect(reason).toContain("Accounts → Claude → Login");
     expect(reason).not.toContain("claude auth login --claudeai");
     expect(reason).not.toContain("setup-token");
+  });
+
+  it("does not turn a stale native probe into a login remedy", async () => {
+    const adapter = createClaudeAdapter({
+      detectVersion: async () => "2.1.165",
+      probeReadonlyProfile: readonlySupported,
+      probeAuthStatus: async () => ({
+        loggedIn: true,
+        authed: true,
+        authMethod: "claude.ai",
+        probeError: null,
+        stale: true,
+        staleAgeMs: 55,
+      }),
+      anthropicApiKey: () => null,
+      claudeOAuthToken: () => null,
+    });
+    const report = await adapter.doctor({ cwd: "/repo", authPreference: "auto", fresh: true });
+    expect(report.status).toBe("degraded");
+    expect(report.reasons.join(" ")).toContain("auth-status probe is stale");
+    expect(report.reasons.join(" ")).not.toContain("Native setup");
+  });
+
+  it("does not turn an unknown native probe into a login remedy", async () => {
+    const adapter = createClaudeAdapter({
+      detectVersion: async () => "2.1.165",
+      probeReadonlyProfile: readonlySupported,
+      probeAuthStatus: async () => ({
+        loggedIn: false,
+        authed: false,
+        authMethod: null,
+        probeError: "auth status timed out",
+      }),
+      anthropicApiKey: () => null,
+      claudeOAuthToken: () => null,
+    });
+    const report = await adapter.doctor({ cwd: "/repo", authPreference: "auto", fresh: true });
+    expect(report.status).toBe("degraded");
+    expect(report.reasons.join(" ")).toContain("native-session probe failed");
+    expect(report.reasons.join(" ")).not.toContain("Native setup");
   });
 });
 

--- a/packages/harness-claude/src/auth.test.ts
+++ b/packages/harness-claude/src/auth.test.ts
@@ -538,6 +538,26 @@ describe("Claude transport-aware source selection", () => {
     });
   });
 
+  it("does not advertise a stale native verdict as the default discovery route", async () => {
+    const adapter = createClaudeAdapter({
+      detectVersion: async () => "2.1.165",
+      probeReadonlyProfile: readonlySupported,
+      probeAuthStatus: async () => ({
+        loggedIn: true,
+        authed: true,
+        authMethod: "claude.ai",
+        probeError: null,
+        stale: true,
+      }),
+      anthropicApiKey: () => null,
+      claudeOAuthToken: () => "oauth-token",
+    });
+    await expect(adapter.discover()).resolves.toMatchObject({
+      capability_profile: { auth: { preferred_source: "oauth_token_env" } },
+      auth_modes: ["local_session"],
+    });
+  });
+
   it("never injects an OAuth token when exact native auth was selected", async () => {
     let cliOptions: CliRunLoopOptions | undefined;
     const adapter = createClaudeAdapter({
@@ -765,6 +785,43 @@ describe("Claude transport-aware source selection", () => {
     expect(cliOptions?.env?.CLAUDE_CONFIG_DIR).toBe("/scoped/config");
     expect(cliOptions?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
     expect(cliOptions?.env?.ANTHROPIC_API_KEY).toBeNull();
+  });
+
+  it("does not treat a stale unprofiled native verdict as a live subscription", async () => {
+    let cliOptions: CliRunLoopOptions | undefined;
+    const adapter = createClaudeAdapter({
+      detectVersion: async () => "2.1.165",
+      probeReadonlyProfile: readonlySupported,
+      probeAuthStatus: async () => ({
+        loggedIn: true,
+        authed: true,
+        authMethod: "claude.ai",
+        probeError: null,
+        stale: true,
+        staleAgeMs: 42,
+      }),
+      anthropicApiKey: () => "api-key",
+      claudeOAuthToken: () => "oauth-token",
+      runCliHarness: async function* (options: CliRunLoopOptions): AsyncGenerator<HarnessEvent> {
+        cliOptions = options;
+        yield {
+          type: "completed",
+          session_id: options.spec.session_id,
+          ts: "2026-01-01T00:00:00.000Z",
+        };
+      },
+    });
+    const events: HarnessEvent[] = [];
+    for await (const event of adapter.run(spec({ auth_preference: "auto" }))) events.push(event);
+
+    expect(cliOptions?.env?.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-token");
+    expect(cliOptions?.env?.ANTHROPIC_API_KEY).toBeNull();
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        payload: { auth_status_stale: true, auth_status_stale_age_ms: 42 },
+      }),
+    );
   });
 
   it("reports a typed wrong native auth method as available but failed", () => {

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -218,14 +218,28 @@ export async function probeAuthStatus(
   bin: string = BIN,
   options: ClaudeAuthStatusProbeOptions = {},
 ): Promise<ClaudeAuthStatusProbe> {
-  const configDir = options.configDir ?? defaultNativeClaudeConfigDir(options.env);
-  const env = claudeNativeEnv(options.env, configDir);
-  return probeClaudeAuthStatus(bin, {
-    env,
-    configDir,
-    abortSignal: options.abortSignal,
-    runCapture: options.runCapture,
-  });
+  try {
+    const configDir = options.configDir ?? defaultNativeClaudeConfigDir(options.env);
+    const env = claudeNativeEnv(options.env, configDir);
+    return await probeClaudeAuthStatus(bin, {
+      env,
+      configDir,
+      abortSignal: options.abortSignal,
+      runCapture: options.runCapture,
+    });
+  } catch (err) {
+    // Config/home normalization is part of the probe boundary too.  A bad
+    // locator or keychain bridge must remain a typed probe failure, rather
+    // than escaping and making callers mistake a transient status problem for
+    // a harness crash or a logged-out account.
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      loggedIn: false,
+      authed: false,
+      authMethod: null,
+      probeError: redactClaudeDoctorDetail(detail),
+    };
+  }
 }
 
 export function anthropicApiKey(): string | null {

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -297,7 +297,10 @@ export function createClaudeAdapter(deps: Partial<ClaudeRuntimeDeps> = {}): Harn
       // rather than declaring one version's list for every version.
       const efforts = await runtime.probeEffortLevels();
       const native = await runtime.probeAuthStatus(BIN, { env: claudeNativeEnv() });
-      const authed = native.authed;
+      // A stale result is only bounded last-known-good evidence for an
+      // already selected profile.  Discovery must not advertise it as a
+      // currently authenticated default route.
+      const authed = native.authed && native.stale !== true;
       const oauthTokenAvailable = runtime.claudeOAuthToken() !== null;
       const authModes = [
         ...(authed || oauthTokenAvailable ? ["local_session"] : []),
@@ -820,7 +823,10 @@ async function* runClaude(
     // back to API-key auth. Preserve the exact selected subscription source so a
     // native session can never be silently replaced by an OAuth-token env route.
     const trySub = (): boolean => {
-      if (native.authed) {
+      // The process-local LKG grace belongs to explicit profile routes.  The
+      // unprofiled/default ladder must not let a stale native verdict mask the
+      // OAuth/API fallback or claim that the default session is live.
+      if (native.authed && native.stale !== true) {
         subscriptionSource = "native_session";
         return true;
       }

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -47,8 +47,6 @@ import { probeClaudeCredentialProfile, resolveClaudeProfileRoute } from "./profi
 export { canonicalProfileConfigDir } from "./profile.js";
 import { probeClaudeAuthStatus } from "./auth-status.js";
 export {
-  CLAUDE_AUTH_STATUS_CACHE_TTL_MS,
-  CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS,
   clearClaudeAuthStatusCache,
 } from "./auth-status.js";
 import { smokeIsolatedApiKey, smokeIsolatedOAuthToken } from "./smoke.js";

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -45,10 +45,19 @@ export { claudeAccountIdentity, defaultNativeClaudeConfigDir } from "./native-ho
 import { createClaudeParser } from "./parse.js";
 import { probeClaudeCredentialProfile, resolveClaudeProfileRoute } from "./profile.js";
 export { canonicalProfileConfigDir } from "./profile.js";
-import { probeClaudeAuthStatus } from "./auth-status.js";
+import {
+  claudeAuthSourceReadiness,
+  probeClaudeAuthStatus,
+  redactClaudeDoctorDetail,
+  staleClaudeAuthStatusEvent,
+  type ClaudeAuthStatusProbe,
+} from "./auth-status.js";
 export {
   clearClaudeAuthStatusCache,
+  claudeAuthSourceReadiness,
+  redactClaudeDoctorDetail,
 } from "./auth-status.js";
+export type { ClaudeAuthStatusProbe } from "./auth-status.js";
 import { smokeIsolatedApiKey, smokeIsolatedOAuthToken } from "./smoke.js";
 import {
   BIN,
@@ -165,31 +174,11 @@ async function detectVersion(abortSignal?: AbortSignal): Promise<string | null> 
   }
 }
 
-/**
- * Native-session probe with a distinct PROBE-FAILURE state (same contract as
- * the codex adapter's probeLogin). `claude auth status` prints a typed JSON
- * verdict `{loggedIn, authMethod, ...}` on stdout; the exit code alone is NOT
- * the auth verdict. When the JSON is present we trust its `loggedIn` field;
- * a probe that produces no parseable verdict is a probe error, never a silent
- * "not logged in".
- */
-export interface ClaudeAuthStatusProbe {
-  loggedIn: boolean;
-  authed: boolean;
-  authMethod: string | null;
-  probeError: string | null;
-  /** True only when the result came from the bounded LKG grace window. */
-  stale?: boolean;
-  /** Age of the LKG auth verdict in milliseconds, when `stale` is true. */
-  staleAgeMs?: number;
-}
-
+/** Options for probing the default or explicitly selected native Claude store. */
 export interface ClaudeAuthStatusProbeOptions {
   env?: Record<string, string | null | undefined>;
-  /** Explicit CLAUDE_CONFIG_DIR for the probe (INV-135, release wave round-17
-   * BLOCK): without it the probe re-normalizes onto the DEFAULT native dir —
-   * a credential-profile probe must inspect ITS OWN store, never the
-   * default's. Callers without a profile omit it and keep the default. */
+  /** Explicit CLAUDE_CONFIG_DIR for the probe (INV-135): a credential-profile
+   * probe must inspect its own store, never the default's. */
   configDir?: string;
   abortSignal?: AbortSignal;
   runCapture?: typeof runCapture;
@@ -254,64 +243,6 @@ export function anthropicApiKey(): string | null {
  * (single owner), so this reads env-only under CLAUDEXOR_DISABLE_STORED_SECRETS. */
 function claudeOAuthToken(): string | null {
   return resolveSecret("claude_oauth") || process.env.CLAUDE_CODE_OAUTH_TOKEN || null;
-}
-
-export function claudeAuthSourceReadiness(input: {
-  native: ClaudeAuthStatusProbe;
-  oauthAvailable: boolean;
-  oauthVerification: "passed" | "failed" | "not_run";
-  oauthDetail: string;
-  apiKeyAvailable: boolean;
-  apiKeyVerification: "passed" | "failed" | "not_run";
-  apiKeyDetail: string;
-}): AuthSourceReadiness[] {
-  const nativeReady =
-    input.native.authed && input.native.probeError === null && input.native.stale !== true;
-  const nativeAvailability =
-    input.native.probeError || input.native.stale
-      ? "unknown"
-      : input.native.loggedIn
-        ? "available"
-        : "unavailable";
-  const nativeVerification = nativeReady
-    ? "passed"
-    : input.native.probeError || input.native.stale || !input.native.loggedIn
-      ? "not_run"
-      : "failed";
-  return [
-    {
-      source: "native_session",
-      availability: nativeAvailability,
-      verification: nativeVerification,
-      detail: nativeReady
-        ? "vendor status confirmed authMethod=claude.ai in the exact run environment"
-        : input.native.stale
-          ? `auth-status probe is stale; using last-known-good native session${
-              input.native.staleAgeMs === undefined ? "" : ` (${input.native.staleAgeMs}ms old)`
-            }`
-          : input.native.probeError
-            ? `auth-status probe failed: ${redactClaudeDoctorDetail(input.native.probeError)}`
-            : input.native.loggedIn
-              ? `Claude is logged in via ${input.native.authMethod ?? "unknown"}, not claude.ai`
-              : "official native Claude session is not logged in",
-    },
-    {
-      source: "oauth_token_env",
-      availability: input.oauthAvailable ? "available" : "unavailable",
-      verification: input.oauthVerification,
-      detail: input.oauthDetail,
-    },
-    {
-      source: "api_key_env",
-      availability: input.apiKeyAvailable ? "available" : "unavailable",
-      verification: input.apiKeyVerification,
-      detail: input.apiKeyDetail,
-    },
-  ];
-}
-
-export function redactClaudeDoctorDetail(text: string): string {
-  return redactSecrets(text).slice(0, 500);
 }
 
 /** The runtime surface the profile module needs (test-stubbable). */
@@ -909,22 +840,8 @@ async function* runClaude(
       staleAuthStatus = { ageMs: native.staleAgeMs };
     }
 
-    if (staleAuthStatus !== null) {
-      yield {
-        type: "message",
-        session_id: spec.session_id,
-        ts: nowIso(),
-        text: `[auth] native auth-status probe stale; using last-known-good session${
-          staleAuthStatus.ageMs === undefined ? "" : ` (${staleAuthStatus.ageMs}ms old)`
-        }`,
-        payload: {
-          auth_status_stale: true,
-          ...(staleAuthStatus.ageMs === undefined
-            ? {}
-            : { auth_status_stale_age_ms: staleAuthStatus.ageMs }),
-        },
-      };
-    }
+    if (staleAuthStatus !== null)
+      yield staleClaudeAuthStatusEvent(spec.session_id, staleAuthStatus.ageMs);
 
     // Auto selecting its API-key fallback is a paid-route switch and must remain
     // typed/visible; explicit routes never fall back.
@@ -961,20 +878,7 @@ async function* runClaude(
   }
 
   if (profile && staleAuthStatus !== null) {
-    yield {
-      type: "message",
-      session_id: spec.session_id,
-      ts: nowIso(),
-      text: `[auth] native auth-status probe stale; using last-known-good session${
-        staleAuthStatus.ageMs === undefined ? "" : ` (${staleAuthStatus.ageMs}ms old)`
-      }`,
-      payload: {
-        auth_status_stale: true,
-        ...(staleAuthStatus.ageMs === undefined
-          ? {}
-          : { auth_status_stale_age_ms: staleAuthStatus.ageMs }),
-      },
-    };
+    yield staleClaudeAuthStatusEvent(spec.session_id, staleAuthStatus.ageMs);
   }
 
   const useSubscription = route === "subscription";

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -19,7 +19,6 @@ import {
   browserMcpCommand,
   HarnessUnavailableError,
   interactionChannelFromSpec,
-  labelStreams,
   needsScopedHomeKeychainBridge,
   normalizeEffort,
   providerScrubEnv,
@@ -46,6 +45,12 @@ export { claudeAccountIdentity, defaultNativeClaudeConfigDir } from "./native-ho
 import { createClaudeParser } from "./parse.js";
 import { probeClaudeCredentialProfile, resolveClaudeProfileRoute } from "./profile.js";
 export { canonicalProfileConfigDir } from "./profile.js";
+import { probeClaudeAuthStatus } from "./auth-status.js";
+export {
+  CLAUDE_AUTH_STATUS_CACHE_TTL_MS,
+  CLAUDE_AUTH_STATUS_TOTAL_TIMEOUT_MS,
+  clearClaudeAuthStatusCache,
+} from "./auth-status.js";
 import { smokeIsolatedApiKey, smokeIsolatedOAuthToken } from "./smoke.js";
 import {
   BIN,
@@ -175,6 +180,10 @@ export interface ClaudeAuthStatusProbe {
   authed: boolean;
   authMethod: string | null;
   probeError: string | null;
+  /** True only when the result came from the bounded LKG grace window. */
+  stale?: boolean;
+  /** Age of the LKG auth verdict in milliseconds, when `stale` is true. */
+  staleAgeMs?: number;
 }
 
 export interface ClaudeAuthStatusProbeOptions {
@@ -209,42 +218,14 @@ export async function probeAuthStatus(
   bin: string = BIN,
   options: ClaudeAuthStatusProbeOptions = {},
 ): Promise<ClaudeAuthStatusProbe> {
-  try {
-    const env = claudeNativeEnv(options.env, options.configDir);
-    const r = await (options.runCapture ?? runCapture)(bin, ["auth", "status"], {
-      env,
-      timeoutMs: 10_000,
-      abortSignal: options.abortSignal,
-      cancelSignal: "SIGTERM",
-      cancelKillDelayMs: 0,
-    });
-    try {
-      const verdict = JSON.parse(r.stdout.trim()) as { loggedIn?: unknown; authMethod?: unknown };
-      if (typeof verdict.loggedIn === "boolean" && typeof verdict.authMethod === "string") {
-        return {
-          loggedIn: verdict.loggedIn,
-          authed: verdict.loggedIn && verdict.authMethod === "claude.ai",
-          authMethod: verdict.authMethod,
-          probeError: null,
-        };
-      }
-    } catch {
-      /* no typed JSON verdict: fall through to probe-error disclosure */
-    }
-    const detail =
-      labelStreams(r.stderr, r.stdout, { transform: redactSecrets }) ??
-      `claude auth status exited with ${r.code ?? r.signal ?? "unknown result"}`;
-    return { loggedIn: false, authed: false, authMethod: null, probeError: detail };
-  } catch (err) {
-    return {
-      loggedIn: false,
-      authed: false,
-      authMethod: null,
-      probeError: [...redactSecrets(err instanceof Error ? err.message : String(err))]
-        .slice(0, 300)
-        .join(""),
-    };
-  }
+  const configDir = options.configDir ?? defaultNativeClaudeConfigDir(options.env);
+  const env = claudeNativeEnv(options.env, configDir);
+  return probeClaudeAuthStatus(bin, {
+    env,
+    configDir,
+    abortSignal: options.abortSignal,
+    runCapture: options.runCapture,
+  });
 }
 
 export function anthropicApiKey(): string | null {
@@ -272,15 +253,17 @@ export function claudeAuthSourceReadiness(input: {
   apiKeyVerification: "passed" | "failed" | "not_run";
   apiKeyDetail: string;
 }): AuthSourceReadiness[] {
-  const nativeReady = input.native.authed && input.native.probeError === null;
-  const nativeAvailability = input.native.probeError
-    ? "unknown"
-    : input.native.loggedIn
-      ? "available"
-      : "unavailable";
+  const nativeReady =
+    input.native.authed && input.native.probeError === null && input.native.stale !== true;
+  const nativeAvailability =
+    input.native.probeError || input.native.stale
+      ? "unknown"
+      : input.native.loggedIn
+        ? "available"
+        : "unavailable";
   const nativeVerification = nativeReady
     ? "passed"
-    : input.native.probeError || !input.native.loggedIn
+    : input.native.probeError || input.native.stale || !input.native.loggedIn
       ? "not_run"
       : "failed";
   return [
@@ -290,11 +273,15 @@ export function claudeAuthSourceReadiness(input: {
       verification: nativeVerification,
       detail: nativeReady
         ? "vendor status confirmed authMethod=claude.ai in the exact run environment"
-        : input.native.probeError
-          ? `auth-status probe failed: ${redactClaudeDoctorDetail(input.native.probeError)}`
-          : input.native.loggedIn
-            ? `Claude is logged in via ${input.native.authMethod ?? "unknown"}, not claude.ai`
-            : "official native Claude session is not logged in",
+        : input.native.stale
+          ? `auth-status probe is stale; using last-known-good native session${
+              input.native.staleAgeMs === undefined ? "" : ` (${input.native.staleAgeMs}ms old)`
+            }`
+          : input.native.probeError
+            ? `auth-status probe failed: ${redactClaudeDoctorDetail(input.native.probeError)}`
+            : input.native.loggedIn
+              ? `Claude is logged in via ${input.native.authMethod ?? "unknown"}, not claude.ai`
+              : "official native Claude session is not logged in",
     },
     {
       source: "oauth_token_env",
@@ -459,7 +446,7 @@ export function createClaudeAdapter(deps: Partial<ClaudeRuntimeDeps> = {}): Harn
             abortSignal: _spec.abortSignal,
           })
         : { loggedIn: false, authed: false, authMethod: null, probeError: null };
-      const nativeCliReady = login.authed;
+      const nativeCliReady = login.authed && login.stale !== true;
       // Native-session and stored setup-token proofs are separate sources.
       const oauthToken = probeOAuth ? runtime.claudeOAuthToken() : null;
       const oauthTokenAvailable = oauthToken !== null;
@@ -505,7 +492,9 @@ export function createClaudeAdapter(deps: Partial<ClaudeRuntimeDeps> = {}): Harn
         apiKeyAvailable: apiKey,
       });
       const probeUnknown =
-        preference !== "api_key" && login.probeError !== null && !oauthTokenAvailable;
+        preference !== "api_key" &&
+        (login.probeError !== null || login.stale === true) &&
+        !oauthTokenAvailable;
       // INV-067: name the real cause + designed remedy (see doctor-remedy.ts).
       const nativeLoginRemedy = claudeNativeLoginRemedy(nativeEnv);
       const allIntents = [
@@ -546,11 +535,15 @@ export function createClaudeAdapter(deps: Partial<ClaudeRuntimeDeps> = {}): Harn
         ? []
         : preference === "subscription"
           ? [
-              login.probeError && !oauthTokenAvailable
-                ? `Claude native-session probe failed: ${redactClaudeDoctorDetail(login.probeError)}`
-                : oauthTokenAvailable
-                  ? `Claude setup-token verification failed: ${oauthSmoke.detail}`
-                  : `Claude subscription route is not ready: ${nativeLoginRemedy}`,
+              login.stale && !oauthTokenAvailable
+                ? `Claude native-session auth-status probe is stale; using last-known-good session${
+                    login.staleAgeMs === undefined ? "" : ` (${login.staleAgeMs}ms old)`
+                  }`
+                : login.probeError && !oauthTokenAvailable
+                  ? `Claude native-session probe failed: ${redactClaudeDoctorDetail(login.probeError)}`
+                  : oauthTokenAvailable
+                    ? `Claude setup-token verification failed: ${oauthSmoke.detail}`
+                    : `Claude subscription route is not ready: ${nativeLoginRemedy}`,
             ]
           : preference === "api_key"
             ? [
@@ -558,9 +551,19 @@ export function createClaudeAdapter(deps: Partial<ClaudeRuntimeDeps> = {}): Harn
                   ? `isolated Claude API-key smoke failed: ${apiSmoke.detail}`
                   : "Claude API-key route is not configured",
               ]
-            : apiKey
-              ? [`isolated Claude API-key smoke failed: ${apiSmoke.detail}`]
-              : [`not authenticated: ${nativeLoginRemedy}`];
+            : login.stale
+              ? [
+                  `Claude native-session auth-status probe is stale; using last-known-good session${
+                    login.staleAgeMs === undefined ? "" : ` (${login.staleAgeMs}ms old)`
+                  }`,
+                ]
+              : apiKey
+                ? [`isolated Claude API-key smoke failed: ${apiSmoke.detail}`]
+                : login.probeError
+                  ? [
+                      `Claude native-session probe failed: ${redactClaudeDoctorDetail(login.probeError)}`,
+                    ]
+                  : [`not authenticated: ${nativeLoginRemedy}`];
       return ConformanceReportSchema.parse({
         harness_id: "claude",
         status: ok
@@ -588,11 +591,15 @@ export function createClaudeAdapter(deps: Partial<ClaudeRuntimeDeps> = {}): Harn
                   status: nativeCliReady ? "pass" : "fail",
                   detail: nativeCliReady
                     ? "vendor status confirmed authMethod=claude.ai in the exact run environment"
-                    : login.probeError
-                      ? `auth-status probe failed (NOT an auth verdict): ${redactClaudeDoctorDetail(login.probeError)}`
-                      : login.loggedIn
-                        ? `logged in via ${login.authMethod ?? "unknown"}, not claude.ai`
-                        : "not logged in (run `claudexor auth login claude`)",
+                    : login.stale
+                      ? `auth-status probe is stale; using last-known-good native session${
+                          login.staleAgeMs === undefined ? "" : ` (${login.staleAgeMs}ms old)`
+                        }`
+                      : login.probeError
+                        ? `auth-status probe failed (NOT an auth verdict): ${redactClaudeDoctorDetail(login.probeError)}`
+                        : login.loggedIn
+                          ? `logged in via ${login.authMethod ?? "unknown"}, not claude.ai`
+                          : "not logged in (run `claudexor auth login claude`)",
                 },
               ]
             : []),
@@ -845,6 +852,7 @@ async function* runClaude(
   let oauthToken: string | null = null;
   let subscriptionSource: "native_session" | "oauth_token_env" | null = null;
   let route: "subscription" | "api_key" | null;
+  let staleAuthStatus: { ageMs?: number } | null = null;
 
   if (profile) {
     const resolved = await resolveClaudeProfileRoute(profile, spec.env, runtime, abortSignal);
@@ -855,6 +863,7 @@ async function* runClaude(
     }
     ({ nativeEnv, key, oauthToken, subscriptionSource } = resolved);
     route = resolved.route;
+    if (resolved.authStatusStale) staleAuthStatus = { ageMs: resolved.authStatusStaleAgeMs };
   } else {
     const native: ClaudeAuthStatusProbe =
       authPreference === "api_key"
@@ -883,6 +892,27 @@ async function* runClaude(
       key ??= runtime.anthropicApiKey();
       return key !== null;
     });
+
+    if (native.stale) {
+      staleAuthStatus = { ageMs: native.staleAgeMs };
+    }
+
+    if (staleAuthStatus !== null) {
+      yield {
+        type: "message",
+        session_id: spec.session_id,
+        ts: nowIso(),
+        text: `[auth] native auth-status probe stale; using last-known-good session${
+          staleAuthStatus.ageMs === undefined ? "" : ` (${staleAuthStatus.ageMs}ms old)`
+        }`,
+        payload: {
+          auth_status_stale: true,
+          ...(staleAuthStatus.ageMs === undefined
+            ? {}
+            : { auth_status_stale_age_ms: staleAuthStatus.ageMs }),
+        },
+      };
+    }
 
     // Auto selecting its API-key fallback is a paid-route switch and must remain
     // typed/visible; explicit routes never fall back.
@@ -916,6 +946,23 @@ async function* runClaude(
       yield { type: "completed", session_id: spec.session_id, ts: nowIso() };
       return;
     }
+  }
+
+  if (profile && staleAuthStatus !== null) {
+    yield {
+      type: "message",
+      session_id: spec.session_id,
+      ts: nowIso(),
+      text: `[auth] native auth-status probe stale; using last-known-good session${
+        staleAuthStatus.ageMs === undefined ? "" : ` (${staleAuthStatus.ageMs}ms old)`
+      }`,
+      payload: {
+        auth_status_stale: true,
+        ...(staleAuthStatus.ageMs === undefined
+          ? {}
+          : { auth_status_stale_age_ms: staleAuthStatus.ageMs }),
+      },
+    };
   }
 
   const useSubscription = route === "subscription";

--- a/packages/harness-claude/src/profile.test.ts
+++ b/packages/harness-claude/src/profile.test.ts
@@ -419,6 +419,8 @@ describe("Claude credential-profile doctor probe (INV-135)", () => {
     expect(status).toMatchObject({
       availability: "unknown",
       verification: "not_run",
+      stale: true,
+      stale_age_ms: 17,
       detail: "auth-status probe is stale; using last-known-good claude.ai login (17ms old)",
     });
     expect(status.last_verified_at).toBeNull();

--- a/packages/harness-claude/src/profile.test.ts
+++ b/packages/harness-claude/src/profile.test.ts
@@ -141,6 +141,50 @@ describe("Claude strict profile routing (INV-135)", () => {
     expect(stamped?.credential_route).toBe("vendor_native");
   });
 
+  it("uses a stale last-known-good profile session and emits typed disclosure", async () => {
+    const dir = mkdtempSync(join(ownedTmp, "claudexor-profile-"));
+    dirs.push(dir);
+    const adapter = createClaudeAdapter({
+      detectVersion: async () => "2.1.165",
+      probeReadonlyProfile: readonlySupported,
+      probeAuthStatus: async () => ({
+        loggedIn: true,
+        authed: true,
+        authMethod: "claude.ai",
+        probeError: null,
+        stale: true,
+        staleAgeMs: 42,
+      }),
+      anthropicApiKey: () => {
+        throw new Error("default key ladder must not run under a profile");
+      },
+      claudeOAuthToken: () => {
+        throw new Error("default token ladder must not run under a profile");
+      },
+      resolveProfileSecret: () => null,
+      runCliHarness: async function* (options: CliRunLoopOptions): AsyncGenerator<HarnessEvent> {
+        yield {
+          type: "completed",
+          session_id: options.spec.session_id,
+          ts: new Date().toISOString(),
+        };
+      },
+    });
+    const events: HarnessEvent[] = [];
+    for await (const event of adapter.run(
+      spec({ credential_profile: profile({ isolation_locator: dir }) }),
+    )) {
+      events.push(event);
+    }
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "message",
+        payload: { auth_status_stale: true, auth_status_stale_age_ms: 42 },
+      }),
+    );
+    expect(events.some((event) => event.type === "error")).toBe(false);
+  });
+
   it("config_dir_login with no verified login refuses typed — no fallback to the default ladder", async () => {
     const dir = mkdtempSync(join(ownedTmp, "claudexor-profile-"));
     dirs.push(dir);
@@ -351,6 +395,33 @@ describe("Claude credential-profile doctor probe (INV-135)", () => {
     });
     expect(status.last_verified_at).not.toBeNull();
     expect(probedEnv?.CLAUDE_CONFIG_DIR).toBe(canonicalProfileConfigDir(dir));
+  });
+
+  it("projects a stale profile session as unknown/not_run until refreshed", async () => {
+    const dir = mkdtempSync(join(ownedTmp, "claudexor-profile-"));
+    dirs.push(dir);
+    const adapter = createClaudeAdapter({
+      detectVersion: async () => "2.1.165",
+      probeReadonlyProfile: readonlySupported,
+      probeAuthStatus: async () => ({
+        loggedIn: true,
+        authed: true,
+        authMethod: "claude.ai",
+        probeError: null,
+        stale: true,
+        staleAgeMs: 17,
+      }),
+      anthropicApiKey: () => null,
+      claudeOAuthToken: () => null,
+      resolveProfileSecret: () => null,
+    });
+    const status = await adapter.probeCredentialProfile!(profile({ isolation_locator: dir }));
+    expect(status).toMatchObject({
+      availability: "unknown",
+      verification: "not_run",
+      detail: "auth-status probe is stale; using last-known-good claude.ai login (17ms old)",
+    });
+    expect(status.last_verified_at).toBeNull();
   });
 
   it("maps the config-dir readiness edges to the documented contract (round-20)", async () => {

--- a/packages/harness-claude/src/profile.ts
+++ b/packages/harness-claude/src/profile.ts
@@ -117,6 +117,12 @@ export async function probeClaudeCredentialProfile(
           ...base,
           availability: probe.stale ? "unknown" : "available",
           verification: probe.stale ? "not_run" : "passed",
+          ...(probe.stale
+            ? {
+                stale: true,
+                ...(probe.staleAgeMs === undefined ? {} : { stale_age_ms: probe.staleAgeMs }),
+              }
+            : {}),
           detail: probe.stale
             ? `auth-status probe is stale; using last-known-good claude.ai login${
                 probe.staleAgeMs === undefined ? "" : ` (${probe.staleAgeMs}ms old)`

--- a/packages/harness-claude/src/profile.ts
+++ b/packages/harness-claude/src/profile.ts
@@ -35,6 +35,8 @@ export async function resolveClaudeProfileRoute(
       subscriptionSource: "native_session" | "oauth_token_env" | null;
       key: string | null;
       oauthToken: string | null;
+      authStatusStale?: boolean;
+      authStatusStaleAgeMs?: number;
       refusal: null;
     }
   | { refusal: string }
@@ -43,6 +45,8 @@ export async function resolveClaudeProfileRoute(
   let key: string | null = null;
   let oauthToken: string | null = null;
   let subscriptionSource: "native_session" | "oauth_token_env" | null = null;
+  let authStatusStale = false;
+  let authStatusStaleAgeMs: number | undefined;
   if (profile.credential_kind === "config_dir_login") {
     try {
       const configDir = canonicalProfileConfigDir(profile.isolation_locator ?? "");
@@ -51,8 +55,11 @@ export async function resolveClaudeProfileRoute(
       // re-normalizes its env, and without the explicit dir it would inspect
       // the DEFAULT store while claiming to verify the profile.
       const probe = await runtime.probeAuthStatus(BIN, { env: nativeEnv, configDir, abortSignal });
-      if (probe.authed) subscriptionSource = "native_session";
-      else
+      if (probe.authed) {
+        subscriptionSource = "native_session";
+        authStatusStale = probe.stale === true;
+        authStatusStaleAgeMs = probe.staleAgeMs;
+      } else
         return {
           refusal: probe.probeError
             ? `credential profile "${profile.profile_id}": auth probe failed — ${probe.probeError}`
@@ -85,6 +92,7 @@ export async function resolveClaudeProfileRoute(
     subscriptionSource,
     key,
     oauthToken,
+    ...(authStatusStale ? { authStatusStale: true, authStatusStaleAgeMs } : {}),
     refusal: null,
   };
 }
@@ -107,10 +115,14 @@ export async function probeClaudeCredentialProfile(
       if (probe.authed)
         return CredentialProfileStatusSchema.parse({
           ...base,
-          availability: "available",
-          verification: "passed",
-          detail: "claude.ai login verified in the profile config dir",
-          last_verified_at: nowIso(),
+          availability: probe.stale ? "unknown" : "available",
+          verification: probe.stale ? "not_run" : "passed",
+          detail: probe.stale
+            ? `auth-status probe is stale; using last-known-good claude.ai login${
+                probe.staleAgeMs === undefined ? "" : ` (${probe.staleAgeMs}ms old)`
+              }`
+            : "claude.ai login verified in the profile config dir",
+          ...(probe.stale ? {} : { last_verified_at: nowIso() }),
         });
       // Readiness-edge contract (ARCHITECTURE §auth / DEVELOPMENT): a probe
       // that could not decide is unknown+not_run; a cleanly logged-out dir is

--- a/packages/orchestrator/src/account-resolution.test.ts
+++ b/packages/orchestrator/src/account-resolution.test.ts
@@ -182,6 +182,27 @@ describe("explicit api_key preference (Q3=A paid election)", () => {
     expect(context.apiKeyRouteNoted()).toBe(false);
     expect(context.events).toHaveLength(0);
   });
+
+  it("keeps a bound config-dir route during the adapter's bounded stale grace", async () => {
+    const bound = profileRow({ profile_id: "bound" });
+    const context = ctx({
+      registry: [bound, profileRow({ profile_id: "other" })],
+      boundProfileId: "bound",
+      probe: async (profile) => ({
+        profile_id: profile.profile_id,
+        harness_id: profile.harness_id,
+        availability: "unknown" as const,
+        verification: "not_run" as const,
+        verification_source: "local_store" as const,
+        stale: true,
+        stale_age_ms: 42,
+        detail: "auth-status probe is stale",
+        last_verified_at: null,
+      }),
+    });
+    await expect(resolveAccountForRun(context)).resolves.toBe(bound);
+    expect(context.events).toHaveLength(0);
+  });
 });
 
 describe("bound-row A7 unusable ledger (thread stickiness)", () => {

--- a/packages/orchestrator/src/account-resolution.test.ts
+++ b/packages/orchestrator/src/account-resolution.test.ts
@@ -203,6 +203,45 @@ describe("explicit api_key preference (Q3=A paid election)", () => {
     await expect(resolveAccountForRun(context)).resolves.toBe(bound);
     expect(context.events).toHaveLength(0);
   });
+
+  it("refuses a stale explicit pin when its credential is live-condemned", async () => {
+    const pinned = profileRow({ profile_id: "pinned" });
+    let probes = 0;
+    const context = ctx({
+      registry: [pinned],
+      pinnedProfile: pinned,
+      probe: async (profile) => {
+        probes += 1;
+        return {
+          profile_id: profile.profile_id,
+          harness_id: profile.harness_id,
+          availability: "unknown" as const,
+          verification: "not_run" as const,
+          verification_source: "local_store" as const,
+          stale: true,
+          stale_age_ms: 42,
+          detail: "auth-status probe is stale",
+          last_verified_at: null,
+        };
+      },
+      unusable: [
+        {
+          harness_id: "claude",
+          profile_id: "pinned",
+          model: null,
+          code: "auth_revoked",
+          source: "vendor_poller",
+          detail: "vendor rejected this profile",
+          observed_at: "2026-01-01T00:00:00.000Z",
+          expires_at: "2099-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+    await expect(resolveAccountForRun(context)).rejects.toThrow(
+      /credential is unusable \(auth_revoked;/,
+    );
+    expect(probes).toBe(0);
+  });
 });
 
 describe("bound-row A7 unusable ledger (thread stickiness)", () => {

--- a/packages/orchestrator/src/account-resolution.ts
+++ b/packages/orchestrator/src/account-resolution.ts
@@ -394,6 +394,9 @@ export async function resolveAccountForRun(
         harnessId,
         probe: ctx.probe,
         quota,
+        // A durable binding is already selected, like an explicit pin. Pool
+        // rotation below remains fresh-only.
+        allowStale: true,
       });
       const breach = profileHeadroomBreach(
         snapshots,

--- a/packages/orchestrator/src/account-resolution.ts
+++ b/packages/orchestrator/src/account-resolution.ts
@@ -6,7 +6,11 @@ import type {
   QuotaSnapshot,
 } from "@claudexor/schema";
 import { accountPoolRows, selectFromAccountPool } from "./account-pool.js";
-import { credentialProfilePolicyProblem, type CredentialProfilePolicyState } from "@claudexor/core";
+import {
+  credentialProfilePolicyProblem,
+  HarnessUnavailableError,
+  type CredentialProfilePolicyState,
+} from "@claudexor/core";
 import {
   credentialPoolExhausted,
   liveUnusableFor,
@@ -154,6 +158,20 @@ function pinnedWindowBlocked(profileId: string, harnessId: string, block: QuotaB
   );
 }
 
+/** A live credential ledger verdict outranks bounded stale auth evidence even
+ * on a strict pin. Keep the refusal typed as harness unavailability without
+ * inventing a quota/reset code for a credential that is actually revoked. */
+function pinnedCredentialUnusable(
+  profileId: string,
+  harnessId: string,
+  observation: CredentialUnusableObservation,
+): Error {
+  return new HarnessUnavailableError(
+    `credential profile "${profileId}" (${harnessId}) credential is unusable ` +
+      `(${observation.code}; a pinned account never rotates)`,
+  );
+}
+
 /**
  * Per-candidate rejection evidence of one exhausted POOL decision, in the
  * shape the typed `credential_pool_exhausted` terminal consumes: every
@@ -250,6 +268,11 @@ export async function resolveAccountForRun(
     // block (A4: reactive cooldown / spent window, stale-but-live included)
     // refuses too, since a cooldown instant is absolute clock truth.
     const pinned = ctx.pinnedProfile;
+    // A7: a prior typed auth/credential failure is stronger than the adapter's
+    // bounded stale LKG. Check the ledger before quota or stale admission so a
+    // revoked pinned token can never reach the vendor CLI.
+    const dead = liveUnusableFor(ctx.unusable, harnessId, pinned.profile_id, model);
+    if (dead) throw pinnedCredentialUnusable(pinned.profile_id, harnessId, dead);
     const breach = profileHeadroomBreach(
       snapshots,
       harnessId,

--- a/packages/orchestrator/src/credential-profiles.test.ts
+++ b/packages/orchestrator/src/credential-profiles.test.ts
@@ -137,6 +137,37 @@ describe("selectedProfileAvailability", () => {
     expect(returned).toContain("credential rejected");
     expect(returned).not.toContain(token);
   });
+
+  it("admits stale readiness only when an already selected route opts in", async () => {
+    const stale = {
+      profile_id: "work",
+      harness_id: "claude",
+      availability: "unknown" as const,
+      verification: "not_run" as const,
+      verification_source: "local_store" as const,
+      stale: true,
+      stale_age_ms: 42,
+      detail: "auth-status probe is stale",
+      last_verified_at: null,
+    };
+    await expect(
+      selectedProfileAvailability({
+        registry: [work],
+        profileId: "work",
+        harnessId: "claude",
+        probe: async () => stale,
+      }),
+    ).resolves.toBe("auth-status probe is stale");
+    await expect(
+      selectedProfileAvailability({
+        registry: [work],
+        profileId: "work",
+        harnessId: "claude",
+        allowStale: true,
+        probe: async () => stale,
+      }),
+    ).resolves.toBe("available");
+  });
 });
 
 describe("profileStatusAdmits", () => {
@@ -156,6 +187,27 @@ describe("profileStatusAdmits", () => {
     expect(profileStatusAdmits(work, { availability: "unknown", verification: "not_run" })).toBe(
       false,
     );
+    expect(
+      profileStatusAdmits(work, {
+        availability: "unknown",
+        verification: "not_run",
+        stale: true,
+      }),
+    ).toBe(false);
+    expect(
+      profileStatusAdmits(
+        work,
+        { availability: "unknown", verification: "not_run", stale: true },
+        { allowStale: true },
+      ),
+    ).toBe(true);
+    expect(
+      profileStatusAdmits(
+        { credential_kind: "api_key" },
+        { availability: "unknown", verification: "not_run", stale: true },
+        { allowStale: true },
+      ),
+    ).toBe(false);
   });
 
   it("turns a throwing profile probe into fail-closed readiness", async () => {

--- a/packages/orchestrator/src/credential-profiles.test.ts
+++ b/packages/orchestrator/src/credential-profiles.test.ts
@@ -107,6 +107,44 @@ describe("selectedProfileAvailability", () => {
     expect(presenceOnly).toBe("available");
   });
 
+  it("rejects a live credential ledger verdict before stale LKG admission or another probe", async () => {
+    let probes = 0;
+    const verdict = await selectedProfileAvailability({
+      registry: [work],
+      profileId: "work",
+      harnessId: "claude",
+      allowStale: true,
+      unusable: [
+        {
+          harness_id: "claude",
+          profile_id: "work",
+          model: null,
+          code: "auth_revoked",
+          source: "vendor_poller",
+          detail: "vendor rejected the profile",
+          observed_at: "2026-01-01T00:00:00.000Z",
+          expires_at: "2099-01-01T00:00:00.000Z",
+        },
+      ],
+      probe: async () => {
+        probes += 1;
+        return {
+          profile_id: "work",
+          harness_id: "claude",
+          availability: "unknown" as const,
+          verification: "not_run" as const,
+          verification_source: "local_store" as const,
+          stale: true,
+          stale_age_ms: 42,
+          detail: "last-known-good",
+          last_verified_at: null,
+        };
+      },
+    });
+    expect(verdict).toContain("credential is unusable (auth_revoked)");
+    expect(probes).toBe(0);
+  });
+
   it("fails closed and redacts both thrown and returned probe diagnostics", async () => {
     const token = `sk-${"a".repeat(48)}`;
     const thrown = await selectedProfileAvailability({

--- a/packages/orchestrator/src/credential-profiles.ts
+++ b/packages/orchestrator/src/credential-profiles.ts
@@ -2,6 +2,7 @@ import type {
   AuthPreference,
   CredentialProfile,
   CredentialProfileStatus,
+  CredentialUnusableObservation,
   HarnessEvent,
   QuotaAbsence,
   QuotaSnapshot,
@@ -11,6 +12,7 @@ import {
   quotaSourceTraits,
 } from "@claudexor/schema";
 import { redactSecrets } from "@claudexor/util";
+import { liveUnusableFor } from "./credential-cooldown.js";
 export {
   effectiveLimitAction,
   limitSubjectRoute,
@@ -54,6 +56,10 @@ export async function selectedProfileAvailability(input: {
    * it. Omitting it admits on the LOCAL store alone — which is the reading of
    * `verification: passed` that let a run dispatch into a revoked token. */
   quota?: VendorQuotaObservations | null;
+  /** Live typed credential failures are stronger than a local LKG status.
+   * Admission must reject the row before probing or dispatching it. */
+  unusable?: readonly CredentialUnusableObservation[];
+  model?: string | null;
   /** Only an already selected profile (explicit pin or durable binding) may
    * consume the adapter's bounded stale observation. Pool/rotation selection
    * remains fresh-only. */
@@ -65,6 +71,15 @@ export async function selectedProfileAvailability(input: {
     profile = resolveCredentialProfile(input.registry, input.profileId, input.harnessId);
   } catch (error) {
     return error instanceof Error ? error.message : String(error);
+  }
+  const dead = liveUnusableFor(
+    input.unusable ?? [],
+    input.harnessId,
+    profile.profile_id,
+    input.model,
+  );
+  if (dead) {
+    return `credential profile "${profile.profile_id}" credential is unusable (${dead.code})`;
   }
   if (!input.probe) return `harness "${input.harnessId}" has no profile probe`;
   const result = vendorVerifiedProfileStatus(

--- a/packages/orchestrator/src/credential-profiles.ts
+++ b/packages/orchestrator/src/credential-profiles.ts
@@ -54,6 +54,10 @@ export async function selectedProfileAvailability(input: {
    * it. Omitting it admits on the LOCAL store alone — which is the reading of
    * `verification: passed` that let a run dispatch into a revoked token. */
   quota?: VendorQuotaObservations | null;
+  /** Only an already selected profile (explicit pin or durable binding) may
+   * consume the adapter's bounded stale observation. Pool/rotation selection
+   * remains fresh-only. */
+  allowStale?: boolean;
 }): Promise<string | null> {
   if (!input.profileId) return null;
   let profile: CredentialProfile;
@@ -67,7 +71,7 @@ export async function selectedProfileAvailability(input: {
     await probeCredentialProfileStatus(profile, input.probe),
     input.quota,
   );
-  return profileStatusAdmits(profile, result)
+  return profileStatusAdmits(profile, result, { allowStale: input.allowStale === true })
     ? "available"
     : (result.detail ?? `${result.availability}/${result.verification}`);
 }
@@ -182,12 +186,19 @@ export function vendorVerifiedProfileStatus(
 /** One readiness predicate shared by run admission and accounts projection. */
 export function profileStatusAdmits(
   profile: Pick<CredentialProfile, "credential_kind">,
-  result: { availability: string; verification: string },
+  result: { availability: string; verification: string; stale?: boolean },
+  options: { allowStale?: boolean } = {},
 ): boolean {
   const verificationAdmits =
     result.verification === "passed" ||
     (profile.credential_kind === "api_key" && result.verification === "not_run");
-  return result.availability === "available" && verificationAdmits;
+  const staleSelectedRoute =
+    options.allowStale === true &&
+    profile.credential_kind === "config_dir_login" &&
+    result.stale === true &&
+    result.availability === "unknown" &&
+    result.verification === "not_run";
+  return (result.availability === "available" && verificationAdmits) || staleSelectedRoute;
 }
 
 /** One fail-closed profile doctor wrapper shared by Accounts and runtime

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -4550,6 +4550,82 @@ describe("Orchestrator", () => {
     }
   });
 
+  it("does not dispatch a stale explicit pin whose credential ledger is condemned", async () => {
+    const repo = await initRepo();
+    const configDir = reapMk(join(tmpdir(), "claudexor-stale-revoked-profile-"));
+    const previousConfigDir = process.env.CLAUDEXOR_CONFIG_DIR;
+    process.env.CLAUDEXOR_CONFIG_DIR = configDir;
+    writeFileSync(
+      join(configDir, "config.yaml"),
+      [
+        "credential_profiles:",
+        "  - profile_id: work",
+        "    harness_id: asker",
+        "    display_name: Work",
+        "    credential_kind: config_dir_login",
+        "    isolation_locator: /tmp/p/work",
+        "",
+      ].join("\n"),
+    );
+    try {
+      let starts = 0;
+      const asker = askAdapter("asker", function* (sessionId) {
+        starts += 1;
+        const ts = new Date().toISOString();
+        yield { type: "started", session_id: sessionId, ts };
+        yield { type: "message", session_id: sessionId, ts, text: "4" };
+        yield { type: "completed", session_id: sessionId, ts };
+      });
+      asker.doctor = async () =>
+        ConformanceReport.parse({
+          harness_id: "asker",
+          status: "unavailable",
+          enabled_intents: [],
+          reasons: ["default auth-status probe failed"],
+        });
+      asker.probeCredentialProfile = async (profile) => ({
+        profile_id: profile.profile_id,
+        harness_id: profile.harness_id,
+        availability: "unknown",
+        verification: "not_run",
+        verification_source: "local_store",
+        stale: true,
+        stale_age_ms: 42,
+        detail: "auth-status probe is stale",
+        last_verified_at: null,
+      });
+      const res = await new Orchestrator({
+        registry: new Map([["asker", asker]]),
+        reviewers: [],
+        credentialUnusable: () => [
+          {
+            harness_id: "asker",
+            profile_id: "work",
+            model: null,
+            code: "auth_revoked",
+            source: "attempt_stream",
+            detail: "the prior attempt was rejected by the vendor",
+            observed_at: "2026-01-01T00:00:00.000Z",
+            expires_at: "2099-01-01T00:00:00.000Z",
+          },
+        ],
+      }).run({
+        repoRoot: repo,
+        prompt: "2+2?",
+        mode: "ask",
+        harnesses: ["asker"],
+        credentialProfileId: "work",
+      });
+      expect(legacyOutcome(res)).toBe("failed");
+      expect(res.summary).toContain("credential is unusable");
+      expect(res.summary).toContain("auth_revoked");
+      expect(starts).toBe(0);
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.CLAUDEXOR_CONFIG_DIR;
+      else process.env.CLAUDEXOR_CONFIG_DIR = previousConfigDir;
+    }
+  });
+
   it("a doctor-OK harness still refuses an unready selected profile before spawn", async () => {
     const repo = await initRepo();
     const configDir = reapMk(join(tmpdir(), "claudexor-profile-preflight-"));

--- a/packages/orchestrator/src/orchestrator.test.ts
+++ b/packages/orchestrator/src/orchestrator.test.ts
@@ -4491,6 +4491,65 @@ describe("Orchestrator", () => {
     }
   });
 
+  it("keeps an explicitly selected config-dir profile through bounded stale readiness", async () => {
+    const repo = await initRepo();
+    const configDir = reapMk(join(tmpdir(), "claudexor-stale-profile-preflight-"));
+    const previousConfigDir = process.env.CLAUDEXOR_CONFIG_DIR;
+    process.env.CLAUDEXOR_CONFIG_DIR = configDir;
+    writeFileSync(
+      join(configDir, "config.yaml"),
+      [
+        "credential_profiles:",
+        "  - profile_id: work",
+        "    harness_id: asker",
+        "    display_name: Work",
+        "    credential_kind: config_dir_login",
+        "    isolation_locator: /tmp/p/work",
+        "",
+      ].join("\n"),
+    );
+    try {
+      const asker = askAdapter("asker", function* (sessionId) {
+        const ts = new Date().toISOString();
+        yield { type: "started", session_id: sessionId, ts };
+        yield { type: "message", session_id: sessionId, ts, text: "4" };
+        yield { type: "completed", session_id: sessionId, ts };
+      });
+      asker.doctor = async () =>
+        ConformanceReport.parse({
+          harness_id: "asker",
+          status: "unavailable",
+          enabled_intents: [],
+          reasons: ["default store probe failed"],
+        });
+      asker.probeCredentialProfile = async (profile) => ({
+        profile_id: profile.profile_id,
+        harness_id: profile.harness_id,
+        availability: "unknown",
+        verification: "not_run",
+        verification_source: "local_store",
+        stale: true,
+        stale_age_ms: 42,
+        detail: "auth-status probe is stale",
+        last_verified_at: null,
+      });
+      const res = await new Orchestrator({
+        registry: new Map([["asker", asker]]),
+        reviewers: [],
+      }).run({
+        repoRoot: repo,
+        prompt: "2+2?",
+        mode: "ask",
+        harnesses: ["asker"],
+        credentialProfileId: "work",
+      });
+      expect(legacyOutcome(res), res.summary).toBe("success");
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.CLAUDEXOR_CONFIG_DIR;
+      else process.env.CLAUDEXOR_CONFIG_DIR = previousConfigDir;
+    }
+  });
+
   it("a doctor-OK harness still refuses an unready selected profile before spawn", async () => {
     const repo = await initRepo();
     const configDir = reapMk(join(tmpdir(), "claudexor-profile-preflight-"));

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1277,9 +1277,10 @@ export class Orchestrator {
           probe: profileProbe,
           // `verification: passed` from the local store only means a login file
           // is present. The poller's authenticated vendor call is the only
-          // liveness evidence we have, and admission is the surface that must
-          // act on it — otherwise the run dispatches into a revoked token.
+          // liveness evidence; admission must act on it or dispatch may use a revoked token.
           quota: vendorQuota,
+          // Only an explicit/bound route may consume bounded stale LKG evidence.
+          allowStale: explicitPin !== null || input.threadAccountBindings?.[id] === candidateId,
         });
         if (verdict === "available") {
           profileAdmitted = true;

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -1168,6 +1168,7 @@ export class Orchestrator {
     // One observation set for the whole admission pass, so two lanes cannot be
     // judged against different vendor epochs.
     const vendorQuota = this.credentials.vendorQuotaObservations();
+    const liveUnusable = this.deps.credentialUnusable?.() ?? [];
     for (const id of ids) {
       const adapter = this.deps.registry.get(id);
       if (!adapter) {
@@ -1246,14 +1247,8 @@ export class Orchestrator {
       const profileAdapter = this.deps.registry.get(id);
       const profileProbe = profileAdapter?.probeCredentialProfile?.bind(profileAdapter);
       const explicitPin = this.credentials.effectiveProfileId(input, id);
-      // The account candidates whose readiness may overlay the default-store
-      // verdict: the explicit pin when set; otherwise — row-aware UNPINNED
-      // admission — the thread-bound row followed by the harness's enabled
-      // pool rows, consulted only when the default doctor did not already
-      // admit the lane. A signed-in registry row is invisible to the default
-      // doctor (cursor after the host-Keychain retirement, or a named-rows-
-      // only claude/codex install), so an unpinned run must be admitted on
-      // row readiness exactly the way explicit pins already are.
+      const model = input.models?.[id] ?? cfgEntry?.default_model ?? null;
+      // Pins and bound/pool rows are checked against their own readiness.
       const rowCandidateIds: string[] = [];
       if (explicitPin) {
         rowCandidateIds.push(explicitPin);
@@ -1279,6 +1274,8 @@ export class Orchestrator {
           // is present. The poller's authenticated vendor call is the only
           // liveness evidence; admission must act on it or dispatch may use a revoked token.
           quota: vendorQuota,
+          unusable: liveUnusable,
+          model,
           // Only an explicit/bound route may consume bounded stale LKG evidence.
           allowStale: explicitPin !== null || input.threadAccountBindings?.[id] === candidateId,
         });

--- a/packages/schema/generated/ControlCredentialProfileCreateResponse.schema.json
+++ b/packages/schema/generated/ControlCredentialProfileCreateResponse.schema.json
@@ -112,6 +112,15 @@
               "default": "local_store",
               "description": "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy."
             },
+            "stale": {
+              "type": "boolean",
+              "description": "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification."
+            },
+            "stale_age_ms": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Age in milliseconds of the bounded stale observation, when stale is true."
+            },
             "detail": {
               "type": "string",
               "description": "Redacted human-readable probe evidence."

--- a/packages/schema/generated/ControlCredentialProfileUpdateResponse.schema.json
+++ b/packages/schema/generated/ControlCredentialProfileUpdateResponse.schema.json
@@ -112,6 +112,15 @@
               "default": "local_store",
               "description": "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy."
             },
+            "stale": {
+              "type": "boolean",
+              "description": "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification."
+            },
+            "stale_age_ms": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Age in milliseconds of the bounded stale observation, when stale is true."
+            },
             "detail": {
               "type": "string",
               "description": "Redacted human-readable probe evidence."

--- a/packages/schema/generated/ControlCredentialProfilesQueryResponse.schema.json
+++ b/packages/schema/generated/ControlCredentialProfilesQueryResponse.schema.json
@@ -119,6 +119,15 @@
                         "default": "local_store",
                         "description": "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy."
                       },
+                      "stale": {
+                        "type": "boolean",
+                        "description": "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification."
+                      },
+                      "stale_age_ms": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "description": "Age in milliseconds of the bounded stale observation, when stale is true."
+                      },
                       "detail": {
                         "type": "string",
                         "description": "Redacted human-readable probe evidence."

--- a/packages/schema/generated/ControlCredentialProfilesResponse.schema.json
+++ b/packages/schema/generated/ControlCredentialProfilesResponse.schema.json
@@ -117,6 +117,15 @@
                     "default": "local_store",
                     "description": "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy."
                   },
+                  "stale": {
+                    "type": "boolean",
+                    "description": "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification."
+                  },
+                  "stale_age_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Age in milliseconds of the bounded stale observation, when stale is true."
+                  },
                   "detail": {
                     "type": "string",
                     "description": "Redacted human-readable probe evidence."

--- a/packages/schema/generated/ControlCredentialProfilesSnapshotResponse.schema.json
+++ b/packages/schema/generated/ControlCredentialProfilesSnapshotResponse.schema.json
@@ -117,6 +117,15 @@
                     "default": "local_store",
                     "description": "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy."
                   },
+                  "stale": {
+                    "type": "boolean",
+                    "description": "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification."
+                  },
+                  "stale_age_ms": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Age in milliseconds of the bounded stale observation, when stale is true."
+                  },
                   "detail": {
                     "type": "string",
                     "description": "Redacted human-readable probe evidence."

--- a/packages/schema/generated/CredentialProfileStatus.schema.json
+++ b/packages/schema/generated/CredentialProfileStatus.schema.json
@@ -37,6 +37,15 @@
           "default": "local_store",
           "description": "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy."
         },
+        "stale": {
+          "type": "boolean",
+          "description": "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification."
+        },
+        "stale_age_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Age in milliseconds of the bounded stale observation, when stale is true."
+        },
         "detail": {
           "type": "string",
           "description": "Redacted human-readable probe evidence."

--- a/packages/schema/src/credential-profile.ts
+++ b/packages/schema/src/credential-profile.ts
@@ -127,6 +127,19 @@ export const CredentialProfileStatus = z
       .describe(
         "How the verification verdict was reached: local_store = the binding's required local state or managed secret is present (says nothing about a token being live); vendor = the vendor answered under the exact binding environment and effective platform credential policy.",
       ),
+    /** A bounded last-known-good transport observation. */
+    stale: z
+      .boolean()
+      .optional()
+      .describe(
+        "True only for a bounded stale last-known-good observation; stale is never a fresh passed verification.",
+      ),
+    stale_age_ms: z
+      .number()
+      .int()
+      .nonnegative()
+      .optional()
+      .describe("Age in milliseconds of the bounded stale observation, when stale is true."),
     detail: z.string().optional().describe("Redacted human-readable probe evidence."),
     last_verified_at: IsoTimestamp.nullable()
       .default(null)


### PR DESCRIPTION
## What this fixes

Claude Code authentication probes are shared by several adapter instances and can overlap, time out, or return a partial process result. The old path could turn that uncertainty into a fresh logout, route an unprofiled stale native session as a live subscription, or dispatch a profile already marked `auth_revoked`.

This PR adds one profile-store-keyed, process-local coordinator with a bounded retry budget and typed stale evidence. It keeps last-known-good state only for transport failures, preserves a real clean logout, invalidates the cache on credential/setup mutations, and keeps stale admission restricted to an already selected explicit profile. Live `credential_unusable` evidence wins before any stale fallback. A signaled child can no longer have its flushed JSON accepted as a fresh verdict.

## Evidence

- Candidate: `3148b7a9a5ebd64cb39f25387b7e1c7e6bf84150`
- Tree: `59604bb0d0897aa33b51f476bf1bb235f97530cc`
- Full direct harness tests: 219 passed; focused auth-status: 13 passed.
- Orchestrator suites: 802 passed; CLI suite: 1,191 passed, 1 skipped.
- Typechecks, generated-schema validation, complexity ratchet, formatting, and `git diff --check` passed.
- Exact Fable review, profile `proton4`, observed `claude-fable-5`: `SAFE_TO_COMMIT`.
- Exact Codex scope review, profile `gptpro2`, observed `gpt-5.6-sol` xhigh: `SAFE_TO_COMMIT`, zero findings.
- Independent local scope audit: `SAFE_TO_COMMIT`.

The external reviews were read to EOF. Fable and Codex ran in read-only constrained sessions, so their `checks=not_configured` fields are disclosed rather than presented as host-test evidence. Host checks above are the test authority.

## Deliberately deferred

This does not claim to repair Anthropic's internal OAuth refresh race, because the local receipts do not contain a direct `invalid_grant` or Keychain overwrite proof. The deployed Claudexor runtime pin is also unchanged until a real release archive is available. Cursor's separate `status`/model-inventory adapter failure is recorded for a follow-up and is not mixed into this Claude-auth change.
