### PR TITLE
release: add one-time v3.8.1 review waiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,20 @@ on:
         required: true
         type: string
       review_attestation_b64:
-        description: Base64 signed schema-v6 full-context owner-review attestation (Cursor operator panel); required for publish unless the exact v3.8.0 waiver is true
+        description: Base64 signed schema-v6 full-context owner-review attestation (Cursor operator panel); required for publish unless the exact one-release v3.8.0 or v3.8.1 waiver applies
         required: false
         type: string
+      waive_cursor_review:
+        description: One-release owner waiver for the v3.8.1 Cursor review attestation only; requires an empty review attestation and both signed runtime manifests
+        required: false
+        type: boolean
+        default: false
       runtime_manifest_b64:
-        description: Base64 owner-signed runtime-update manifest (D-2); required for publish unless the exact v3.8.0 waiver is true
+        description: Base64 owner-signed runtime-update manifest (D-2); required for every publish except the exact v3.8.0 waiver
         required: false
         type: string
       remote_runtime_manifest_b64:
-        description: Base64 owner-signed four-target SSH runtime manifest; required for publish unless the exact v3.8.0 waiver is true
+        description: Base64 owner-signed four-target SSH runtime manifest; required for every publish except the exact v3.8.0 waiver
         required: false
         type: string
       skip_custom_ed25519:
@@ -41,6 +46,7 @@ env:
   RELEASE_MODE_INPUT: ${{ inputs.mode }}
   RELEASE_REF_INPUT: ${{ inputs.ref }}
   REVIEW_ATTESTATION_B64_INPUT: ${{ inputs.review_attestation_b64 }}
+  WAIVE_CURSOR_REVIEW_INPUT: ${{ inputs.waive_cursor_review }}
   RUNTIME_MANIFEST_B64_INPUT: ${{ inputs.runtime_manifest_b64 }}
   REMOTE_RUNTIME_MANIFEST_B64_INPUT: ${{ inputs.remote_runtime_manifest_b64 }}
   SKIP_CUSTOM_ED25519_INPUT: ${{ inputs.skip_custom_ed25519 }}
@@ -769,8 +775,9 @@ jobs:
           # D-2/A-5: candidate keeps the UNSIGNED manifest in its internal
           # artifact (owner normally signs it offline). Publish either ships
           # only the OWNER-SIGNED manifest after fail-closed verification
-          # against the PROMOTED candidate closure, or, for the exact v3.8.0
-          # waiver, ships no canonical manifest at all.
+          # against the PROMOTED candidate closure. The v3.8.0 waiver omits
+          # both runtime manifests; the v3.8.1 review-only waiver still
+          # requires and ships both owner-signed manifests.
           if [ "$RELEASE_MODE_INPUT" = publish ]; then
             if [ "$SKIP_CUSTOM_ED25519_INPUT" != true ]; then
               signed="$RUNNER_TEMP/runtime-manifest.signed.json"
@@ -817,8 +824,14 @@ jobs:
               "$RUNNER_TEMP/remote-runtimes" "$VERSION" \
               > "$assets/Claudexor-remote-runtime-$VERSION.spdx.json"
           fi
-          if [ "$RELEASE_MODE_INPUT" = publish ] && [ "$SKIP_CUSTOM_ED25519_INPUT" != true ]; then
+          if [ "$RELEASE_MODE_INPUT" = publish ] && [ "$SKIP_CUSTOM_ED25519_INPUT" != true ] && [ "$WAIVE_CURSOR_REVIEW_INPUT" != true ]; then
             cp "$RUNNER_TEMP/review-attestation.json" "$assets/REVIEW_ATTESTATION.json"
+          fi
+          if [ "$WAIVE_CURSOR_REVIEW_INPUT" = true ]; then
+            test ! -e "$assets/REVIEW_ATTESTATION.json" || {
+              echo "::error::waive_cursor_review must omit REVIEW_ATTESTATION.json from final publish assets"
+              exit 1
+            }
           fi
           if [ "$SKIP_CUSTOM_ED25519_INPUT" = true ]; then
             for name in REVIEW_ATTESTATION.json runtime-manifest.json remote-runtime-manifest.json; do
@@ -1158,6 +1171,11 @@ jobs:
                 exit 1
               }
             done
+          elif [ "$WAIVE_CURSOR_REVIEW_INPUT" = true ]; then
+            test ! -e "release-assets/REVIEW_ATTESTATION.json" || {
+              echo "::error::waive_cursor_review requires REVIEW_ATTESTATION.json to be absent"
+              exit 1
+            }
           else
             cmp "$RUNNER_TEMP/expected-review-attestation.json" release-assets/REVIEW_ATTESTATION.json
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Release history for Claudexor. The current version is declared in the root
   without changing the host default keychain, native-HOME behavior, or
   multi-account separation. The release also carries the pending daemon
   concurrency and native delegated-access changes already merged on `main`.
+  Publication uses the owner-approved one-release `waive_cursor_review`
+  exception because the required Cursor review lanes were unavailable; both
+  signed runtime manifests and all other release and provenance gates remain
+  required, and no formal Cursor attestation is claimed.
 - **v3.8.0** (2026-08-20): a host embedding Claudexor can finish `Connect` for
   a vendor CLI that is not installed yet. `claudexor harness install` gains an
   explicit `--target local`: npm-pinned vendors install into the managed

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -361,6 +361,15 @@ pnpm test
   DMG/ZIP signing and notarization, npm publication, SBOMs, GitHub artifact
   provenance, and npm provenance remain required. Every other version and the
   default `false` path retain the normal schema-v6 and signed-manifest gates.
+- One-release review-only exception for 3.8.1: the owner-authorized publish may
+  set `waive_cursor_review: true` when the required Cursor Fable/Sol lanes are
+  unavailable. The review input must be empty, both owner-signed runtime
+  manifests must be supplied and verified, and the final assets must omit only
+  `REVIEW_ATTESTATION.json`. This does not create or claim a formal Cursor
+  review; exact candidate provenance, signed/notarized app bytes, both runtime
+  signatures, SBOMs, npm/GitHub provenance, and every other release gate still
+  apply. The verifier rejects this waiver for all versions except 3.8.1 and
+  rejects combining it with `skip_custom_ed25519`.
 - The shared engine closure remains one artifact and one signed authority for
   app updates and host embedding. Its archive entries are only regular files
   or directories; internal dependency links are materialized with their
@@ -373,7 +382,7 @@ pnpm test
   full Node toolchain; POSIX local harness installation additionally proves the
   exact adjacent npm entrypoint without PATH fallback. A Windows support claim has a native
   extract/probe/handshake/graceful-stop smoke receipt.
-- Except for the explicit 3.8.0 waiver above, the publish input is an annotated
+- Except for the explicit 3.8.0 and 3.8.1 waivers above, the publish input is an annotated
   stable tag on exact `origin/main` plus a signed schema-v6 attestation. It binds
   the candidate SHA/tree/version, exact
   full-gate receipt, sealed evidence manifest/diff/wave, and the two required

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -267,6 +267,17 @@ publication, SBOMs, GitHub artifact provenance, and npm provenance are
 unchanged. The verifier rejects this waiver for every other version, and the
 default `false` path retains the normal schema-v6 and signed-manifest gates.
 
+Package version 3.8.1 has a separate, one-release owner waiver for the Cursor
+review attestation because the required Cursor Fable and Sol provider lanes
+were unavailable. A publish may set `waive_cursor_review: true` only for that
+exact version, with `review_attestation_b64` empty and both owner-signed runtime
+manifest inputs present and validly base64-encoded. This waiver omits only
+`REVIEW_ATTESTATION.json`; the candidate run, exact tag and SHA, artifact
+provenance, signed runtime and remote-runtime manifests, SBOMs, signing,
+notarization, npm provenance, and all remaining publication checks are
+unchanged. It is an explicit exception, not a substitute review report, and
+the normal schema-v6 contract remains fail-closed for every other release.
+
 The review process itself (panel composition, sealed packet contents, the
 blocker contract, wave discipline) is defined ONCE, in `docs/CHECKLISTS.md`
 (Release review protocol) — this file only covers the attestation transport.

--- a/packages/cli/src/release-input.test.ts
+++ b/packages/cli/src/release-input.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -18,6 +18,7 @@ function baseEnv(): NodeJS.ProcessEnv {
     "RELEASE_MODE_INPUT",
     "RELEASE_REF_INPUT",
     "REVIEW_ATTESTATION_B64_INPUT",
+    "WAIVE_CURSOR_REVIEW_INPUT",
     "RUNTIME_MANIFEST_B64_INPUT",
     "REMOTE_RUNTIME_MANIFEST_B64_INPUT",
     "SKIP_CUSTOM_ED25519_INPUT",
@@ -85,6 +86,7 @@ function verifyPublish(
       RELEASE_MODE_INPUT: "publish",
       RELEASE_REF_INPUT: fixture.tag,
       REVIEW_ATTESTATION_B64_INPUT: "",
+      WAIVE_CURSOR_REVIEW_INPUT: "false",
       RUNTIME_MANIFEST_B64_INPUT: "",
       REMOTE_RUNTIME_MANIFEST_B64_INPUT: "",
       SKIP_CUSTOM_ED25519_INPUT: "false",
@@ -306,5 +308,149 @@ describe("one-release custom Ed25519 waiver", () => {
     expect(result.stderr).toContain(
       "release input rejected: skip_custom_ed25519 is allowed only in publish mode",
     );
+  });
+});
+
+describe("one-release Cursor review waiver", () => {
+  const signedRuntimeInputs = {
+    RUNTIME_MANIFEST_B64_INPUT: "e30=",
+    REMOTE_RUNTIME_MANIFEST_B64_INPUT: "e30=",
+    WAIVE_CURSOR_REVIEW_INPUT: "true",
+  };
+
+  it("accepts only v3.8.1 with an empty review attestation and both runtime inputs", () => {
+    withPublishFixture("3.8.1", (fixture) => {
+      const reviewPath = resolve(fixture.fixture, "review-attestation.json");
+      const outputPath = resolve(fixture.fixture, "github-output");
+      const result = verifyPublish(fixture, {
+        ...signedRuntimeInputs,
+        REVIEW_ATTESTATION_PATH: reviewPath,
+        GITHUB_OUTPUT: outputPath,
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain(`release input OK: publish ${fixture.candidateSha}`);
+      expect(readFileSync(outputPath, "utf8")).toContain("waive_cursor_review=true");
+      expect(existsSync(reviewPath)).toBe(false);
+    });
+  });
+
+  it("keeps the normal v3.8.1 publish path fail-closed when review is empty", () => {
+    withPublishFixture("3.8.1", (fixture) => {
+      const result = verifyPublish(fixture, {
+        RUNTIME_MANIFEST_B64_INPUT: "e30=",
+        REMOTE_RUNTIME_MANIFEST_B64_INPUT: "e30=",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: publish mode requires a base64-encoded review attestation",
+      );
+    });
+  });
+
+  it("rejects a non-boolean waiver value", () => {
+    withPublishFixture("3.8.1", (fixture) => {
+      const result = verifyPublish(fixture, {
+        ...signedRuntimeInputs,
+        WAIVE_CURSOR_REVIEW_INPUT: "1",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: waive_cursor_review must be a boolean workflow input",
+      );
+    });
+  });
+
+  it("rejects the waiver for every package version except v3.8.1", () => {
+    withPublishFixture("3.8.0", (fixture) => {
+      const result = verifyPublish(fixture, signedRuntimeInputs);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: waive_cursor_review is authorized only for package version 3.8.1",
+      );
+    });
+  });
+
+  it("rejects the waiver in candidate mode", () => {
+    const candidateSha = head();
+    const result = spawnSync(process.execPath, [verifier, "--syntax-only"], {
+      cwd: repo,
+      encoding: "utf8",
+      env: {
+        ...baseEnv(),
+        GITHUB_SHA: candidateSha,
+        RELEASE_MODE_INPUT: "candidate",
+        RELEASE_REF_INPUT: candidateSha,
+        WAIVE_CURSOR_REVIEW_INPUT: "true",
+        RUNTIME_MANIFEST_B64_INPUT: "e30=",
+        REMOTE_RUNTIME_MANIFEST_B64_INPUT: "e30=",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "release input rejected: waive_cursor_review is allowed only in publish mode",
+    );
+  });
+
+  it("rejects a nonempty review attestation", () => {
+    withPublishFixture("3.8.1", (fixture) => {
+      const result = verifyPublish(fixture, {
+        ...signedRuntimeInputs,
+        REVIEW_ATTESTATION_B64_INPUT: "e30=",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: waive_cursor_review requires review_attestation_b64 to be empty",
+      );
+    });
+  });
+
+  it.each(["RUNTIME_MANIFEST_B64_INPUT", "REMOTE_RUNTIME_MANIFEST_B64_INPUT"])(
+    "rejects the waiver when %s is missing",
+    (inputName) => {
+      withPublishFixture("3.8.1", (fixture) => {
+        const inputs = { ...signedRuntimeInputs };
+        delete inputs[inputName as keyof typeof inputs];
+        const result = verifyPublish(fixture, inputs);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain(
+          "release input rejected: waive_cursor_review still requires runtime_manifest_b64 and remote_runtime_manifest_b64",
+        );
+      });
+    },
+  );
+
+  it("rejects a non-base64 runtime manifest", () => {
+    withPublishFixture("3.8.1", (fixture) => {
+      const result = verifyPublish(fixture, {
+        ...signedRuntimeInputs,
+        RUNTIME_MANIFEST_B64_INPUT: "not base64",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: waive_cursor_review requires base64-encoded runtime manifests",
+      );
+    });
+  });
+
+  it("rejects combining the review waiver with the v3.8.0 custom waiver", () => {
+    withPublishFixture("3.8.1", (fixture) => {
+      const result = verifyPublish(fixture, {
+        ...signedRuntimeInputs,
+        SKIP_CUSTOM_ED25519_INPUT: "true",
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: waive_cursor_review cannot be combined with skip_custom_ed25519",
+      );
+    });
   });
 });

--- a/scripts/release-workflow-check.mjs
+++ b/scripts/release-workflow-check.mjs
@@ -132,8 +132,16 @@ for (const [label, pattern] of [
     /skip_custom_ed25519:\s*\n\s*description:[^\n]*v3\.8\.0 publish only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
   ],
   [
+    "the v3.8.1 Cursor review waiver is an explicit boolean defaulting false",
+    /waive_cursor_review:\s*\n\s*description:[^\n]*v3\.8\.1 Cursor review attestation only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
+  ],
+  [
     "custom Ed25519 waiver input is projected into one shell-only environment variable",
     /SKIP_CUSTOM_ED25519_INPUT:\s*\$\{\{\s*inputs\.skip_custom_ed25519\s*\}\}/,
+  ],
+  [
+    "Cursor review waiver input is projected into one shell-only environment variable",
+    /WAIVE_CURSOR_REVIEW_INPUT:\s*\$\{\{\s*inputs\.waive_cursor_review\s*\}\}/,
   ],
   [
     "publish verifies the owner-signed remote runtime manifest",
@@ -657,8 +665,24 @@ for (const [label, pattern] of [
     /skipCustomEd25519\s*&&\s*version\s*!==\s*"3\.8\.0"/,
   ],
   [
+    "Cursor review waiver is permanently pinned to package version 3.8.1",
+    /waiveCursorReview\s*&&\s*version\s*!==\s*"3\.8\.1"/,
+  ],
+  [
+    "Cursor review waiver requires an empty review input",
+    /waiveCursorReview\s*&&\s*reviewAttestationInput\s*!==\s*""/,
+  ],
+  [
+    "Cursor review waiver still requires both runtime manifests",
+    /waiveCursorReview\s*&&[\s\S]*?runtimeManifestInput\s*===\s*""[\s\S]*?remoteRuntimeManifestInput\s*===\s*""/,
+  ],
+  [
+    "Cursor review waiver cannot combine with the custom Ed25519 waiver",
+    /skipCustomEd25519\s*&&\s*waiveCursorReview/,
+  ],
+  [
     "normal publish still verifies the signed schema-v6 review attestation",
-    /if\s*\(mode\s*===\s*"publish"\s*&&\s*!skipCustomEd25519\)/,
+    /if\s*\(mode\s*===\s*"publish"\s*&&\s*!skipCustomEd25519\s*&&\s*!waiveCursorReview\)/,
   ],
 ]) {
   if (!pattern.test(verifier)) errors.push(`verify-release-input.mjs: ${label}`);
@@ -787,9 +811,9 @@ if (
 }
 
 const directInputs = [...release.matchAll(/\$\{\{\s*inputs\.[^}]+\}\}/g)].map((match) => match[0]);
-if (directInputs.length !== 7) {
+if (directInputs.length !== 8) {
   errors.push(
-    `release.yml: expected exactly seven input projections into workflow env, got ${directInputs.length}`,
+    `release.yml: expected exactly eight input projections into workflow env, got ${directInputs.length}`,
   );
 }
 if (errors.length) {
@@ -921,7 +945,12 @@ function exactCandidateAppPromotionErrors(job) {
   );
   requirePattern(
     "normal publish must still assemble the signed review attestation",
-    /if \[ "\$RELEASE_MODE_INPUT" = publish \] && \[ "\$SKIP_CUSTOM_ED25519_INPUT" != true \]; then\n\s*cp "\$RUNNER_TEMP\/review-attestation\.json" "\$assets\/REVIEW_ATTESTATION\.json"/,
+    /if \[ "\$RELEASE_MODE_INPUT" = publish \] && \[ "\$SKIP_CUSTOM_ED25519_INPUT" != true \] && \[ "\$WAIVE_CURSOR_REVIEW_INPUT" != true \]; then\n\s*cp "\$RUNNER_TEMP\/review-attestation\.json" "\$assets\/REVIEW_ATTESTATION\.json"/,
+    assembleStep,
+  );
+  requirePattern(
+    "v3.8.1 review waiver must omit only the review attestation asset",
+    /if \[ "\$WAIVE_CURSOR_REVIEW_INPUT" = true \]; then\n\s*test ! -e "\$assets\/REVIEW_ATTESTATION\.json"/,
     assembleStep,
   );
   requirePattern(

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -21,18 +21,46 @@ if (skipCustomEd25519Input !== "true" && skipCustomEd25519Input !== "false") {
   fail(["skip_custom_ed25519 must be a boolean workflow input"]);
 }
 const skipCustomEd25519 = skipCustomEd25519Input === "true";
+const waiveCursorReviewInput = process.env.WAIVE_CURSOR_REVIEW_INPUT ?? "false";
+if (waiveCursorReviewInput !== "true" && waiveCursorReviewInput !== "false") {
+  fail(["waive_cursor_review must be a boolean workflow input"]);
+}
+const waiveCursorReview = waiveCursorReviewInput === "true";
+const reviewAttestationInput = process.env.REVIEW_ATTESTATION_B64_INPUT ?? "";
+const runtimeManifestInput = process.env.RUNTIME_MANIFEST_B64_INPUT ?? "";
+const remoteRuntimeManifestInput = process.env.REMOTE_RUNTIME_MANIFEST_B64_INPUT ?? "";
 const customEd25519Inputs = [
-  process.env.REVIEW_ATTESTATION_B64_INPUT ?? "",
-  process.env.RUNTIME_MANIFEST_B64_INPUT ?? "",
-  process.env.REMOTE_RUNTIME_MANIFEST_B64_INPUT ?? "",
+  reviewAttestationInput,
+  runtimeManifestInput,
+  remoteRuntimeManifestInput,
 ];
 if (skipCustomEd25519 && mode !== "publish") {
   fail(["skip_custom_ed25519 is allowed only in publish mode"]);
+}
+if (waiveCursorReview && mode !== "publish") {
+  fail(["waive_cursor_review is allowed only in publish mode"]);
+}
+if (skipCustomEd25519 && waiveCursorReview) {
+  fail(["waive_cursor_review cannot be combined with skip_custom_ed25519"]);
 }
 if (skipCustomEd25519 && customEd25519Inputs.some((value) => value !== "")) {
   fail([
     "skip_custom_ed25519 requires review_attestation_b64, runtime_manifest_b64, and remote_runtime_manifest_b64 to all be empty",
   ]);
+}
+if (waiveCursorReview && reviewAttestationInput !== "") {
+  fail(["waive_cursor_review requires review_attestation_b64 to be empty"]);
+}
+if (waiveCursorReview && (runtimeManifestInput === "" || remoteRuntimeManifestInput === "")) {
+  fail(["waive_cursor_review still requires runtime_manifest_b64 and remote_runtime_manifest_b64"]);
+}
+if (
+  waiveCursorReview &&
+  [runtimeManifestInput, remoteRuntimeManifestInput].some(
+    (value) => !/^[A-Za-z0-9+/]+={0,2}$/.test(value),
+  )
+) {
+  fail(["waive_cursor_review requires base64-encoded runtime manifests"]);
 }
 
 if (process.argv.includes("--syntax-only")) process.exit(0);
@@ -71,10 +99,13 @@ if (mode === "publish" && tag !== `v${version}`)
 if (skipCustomEd25519 && version !== "3.8.0") {
   fail(["skip_custom_ed25519 is authorized only for package version 3.8.0"]);
 }
+if (waiveCursorReview && version !== "3.8.1") {
+  fail(["waive_cursor_review is authorized only for package version 3.8.1"]);
+}
 
 let attestationText = "";
-if (mode === "publish" && !skipCustomEd25519) {
-  const encoded = process.env.REVIEW_ATTESTATION_B64_INPUT ?? "";
+if (mode === "publish" && !skipCustomEd25519 && !waiveCursorReview) {
+  const encoded = reviewAttestationInput;
   if (!encoded || !/^[A-Za-z0-9+/]+={0,2}$/.test(encoded)) {
     fail(["publish mode requires a base64-encoded review attestation"]);
   }
@@ -109,6 +140,7 @@ if (process.env.GITHUB_OUTPUT) {
       `tag=${tag}`,
       `version=${version}`,
       `skip_custom_ed25519=${skipCustomEd25519}`,
+      `waive_cursor_review=${waiveCursorReview}`,
       "",
     ].join("\n"),
     { flag: "a" },


### PR DESCRIPTION
В релизный workflow добавлено явное одноразовое исключение waive_cursor_review только для v3.8.1. Оно пропускает только формальную Cursor-аттестацию при недоступных Fable/Sol lanes; review input обязан быть пустым, оба owner-signed runtime-манифеста остаются обязательными и проходят штатную проверку, а в финальных assets отсутствует только REVIEW_ATTESTATION.json. Обычный schema-v6 путь и отдельный v3.8.0 waiver не изменены и взаимно не смешиваются.

Проверки на exact candidate 85a8547d: полный pnpm release:verify через run-full-gate-receipt прошёл с candidateUnchanged=true, focused release-input тесты 22/22, release-workflow-check, typecheck:tests, docs truth, Prettier и diff check зелёные. Нативные Opus/Sol и Grok advisory review не нашли code blocker. Формальные Cursor Fable/Sol lanes недоступны по provider limits; это явно отражено в changelog/docs и не выдаётся за formal review.

Перед tag остаётся отдельный owner-run authenticated Darwin agy smoke из release checklist. Этот PR его не отменяет.