### PR TITLE
release: allow the 3.8.2 review waiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ on:
         required: true
         type: string
       review_attestation_b64:
-        description: Base64 signed schema-v6 full-context owner-review attestation (Cursor operator panel); required for publish unless the exact one-release v3.8.0 or v3.8.1 waiver applies
+        description: Base64 signed schema-v6 full-context owner-review attestation (Cursor operator panel); required for publish unless an exact version-scoped v3.8.0, v3.8.1, or v3.8.2 waiver applies
         required: false
         type: string
       waive_cursor_review:
-        description: One-release owner waiver for the v3.8.1 Cursor review attestation only; requires an empty review attestation and both signed runtime manifests
+        description: Version-scoped owner waiver for the v3.8.1 or v3.8.2 Cursor review attestation only; requires an empty review attestation and both signed runtime manifests
         required: false
         type: boolean
         default: false
@@ -776,7 +776,7 @@ jobs:
           # artifact (owner normally signs it offline). Publish either ships
           # only the OWNER-SIGNED manifest after fail-closed verification
           # against the PROMOTED candidate closure. The v3.8.0 waiver omits
-          # both runtime manifests; the v3.8.1 review-only waiver still
+          # both runtime manifests; the v3.8.1/v3.8.2 review-only waiver still
           # requires and ships both owner-signed manifests.
           if [ "$RELEASE_MODE_INPUT" = publish ]; then
             if [ "$SKIP_CUSTOM_ED25519_INPUT" != true ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ Release history for Claudexor. The current version is declared in the root
   scenario keeps its original production call and assertion. Codex and Cursor
   one-shot prompts now use their native stdin contracts instead of process argv,
   so large agent-first review packets no longer fail before model startup with
-  `spawn E2BIG`.
+  `spawn E2BIG`. Publication uses the owner-approved one-release
+  `waive_cursor_review` exception to avoid repeating the full-context review
+  already completed during release work in a different execution setup; both
+  signed runtime manifests and every other release and provenance gate remain
+  required, and no schema-v6 review attestation is claimed.
 - **v3.8.1** (2026-08-22): profile-scoped Antigravity runs now create and use
   a private macOS keychain under each profile HOME before the vendor touches
   Keychain Services. This removes the recurring “Keychain not found” dialog

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -364,15 +364,18 @@ pnpm test
   DMG/ZIP signing and notarization, npm publication, SBOMs, GitHub artifact
   provenance, and npm provenance remain required. Every other version and the
   default `false` path retain the normal schema-v6 and signed-manifest gates.
-- One-release review-only exception for 3.8.1: the owner-authorized publish may
-  set `waive_cursor_review: true` when the required Cursor Fable/Sol lanes are
-  unavailable. The review input must be empty, both owner-signed runtime
-  manifests must be supplied and verified, and the final assets must omit only
-  `REVIEW_ATTESTATION.json`. This does not create or claim a formal Cursor
-  review; exact candidate provenance, signed/notarized app bytes, both runtime
-  signatures, SBOMs, npm/GitHub provenance, and every other release gate still
-  apply. The verifier rejects this waiver for all versions except 3.8.1 and
-  rejects combining it with `skip_custom_ed25519`.
+- One-release review-only exceptions for 3.8.1 and 3.8.2: the owner-authorized
+  publish may set `waive_cursor_review: true` for either exact version. The
+  3.8.1 exception covered unavailable Cursor Fable/Sol lanes; the 3.8.2
+  exception avoids repeating full-context review already completed during its
+  release work in a different execution setup. The review input must be empty,
+  both owner-signed runtime manifests must be supplied and verified, and the
+  final assets must omit only `REVIEW_ATTESTATION.json`. This does not create or
+  claim a formal Cursor review; exact candidate provenance, signed/notarized app
+  bytes, both runtime signatures, SBOMs, npm/GitHub provenance, and every other
+  release gate still apply. The verifier rejects this waiver for all versions
+  except 3.8.1 and 3.8.2 and rejects combining it with
+  `skip_custom_ed25519`.
 - The shared engine closure remains one artifact and one signed authority for
   app updates and host embedding. Its archive entries are only regular files
   or directories; internal dependency links are materialized with their
@@ -385,9 +388,9 @@ pnpm test
   full Node toolchain; POSIX local harness installation additionally proves the
   exact adjacent npm entrypoint without PATH fallback. A Windows support claim has a native
   extract/probe/handshake/graceful-stop smoke receipt.
-- Except for the explicit 3.8.0 and 3.8.1 waivers above, the publish input is an annotated
-  stable tag on exact `origin/main` plus a signed schema-v6 attestation. It binds
-  the candidate SHA/tree/version, exact
+- Except for the explicit 3.8.0, 3.8.1, and 3.8.2 waivers above, the publish
+  input is an annotated stable tag on exact `origin/main` plus a signed schema-v6
+  attestation. It binds the candidate SHA/tree/version, exact
   full-gate receipt, sealed evidence manifest/diff/wave, and the two required
   operator reviewer reports (digests + model slugs) with non-blocking verdicts
   (see the Release review protocol). Verify the Ed25519 signature against the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -267,10 +267,12 @@ publication, SBOMs, GitHub artifact provenance, and npm provenance are
 unchanged. The verifier rejects this waiver for every other version, and the
 default `false` path retains the normal schema-v6 and signed-manifest gates.
 
-Package version 3.8.1 has a separate, one-release owner waiver for the Cursor
-review attestation because the required Cursor Fable and Sol provider lanes
-were unavailable. A publish may set `waive_cursor_review: true` only for that
-exact version, with `review_attestation_b64` empty and both owner-signed runtime
+Package versions 3.8.1 and 3.8.2 each have a separate, one-release owner waiver
+for the Cursor review attestation. The 3.8.1 exception covered unavailable
+Cursor Fable and Sol provider lanes; the 3.8.2 exception avoids repeating a
+full-context review already completed during its release work in a different
+execution setup. A publish may set `waive_cursor_review: true` only for those
+exact versions, with `review_attestation_b64` empty and both owner-signed runtime
 manifest inputs present and validly base64-encoded. This waiver omits only
 `REVIEW_ATTESTATION.json`; the candidate run, exact tag and SHA, artifact
 provenance, signed runtime and remote-runtime manifests, SBOMs, signing,

--- a/packages/cli/src/release-input.test.ts
+++ b/packages/cli/src/release-input.test.ts
@@ -311,26 +311,46 @@ describe("one-release custom Ed25519 waiver", () => {
   });
 });
 
-describe("one-release Cursor review waiver", () => {
+describe("version-scoped Cursor review waiver", () => {
   const signedRuntimeInputs = {
     RUNTIME_MANIFEST_B64_INPUT: "e30=",
     REMOTE_RUNTIME_MANIFEST_B64_INPUT: "e30=",
     WAIVE_CURSOR_REVIEW_INPUT: "true",
   };
 
-  it("accepts only v3.8.1 with an empty review attestation and both runtime inputs", () => {
-    withPublishFixture("3.8.1", (fixture) => {
+  it.each(["3.8.1", "3.8.2"])(
+    "accepts v%s with an empty review attestation and both runtime inputs",
+    (version) => {
+      withPublishFixture(version, (fixture) => {
+        const reviewPath = resolve(fixture.fixture, "review-attestation.json");
+        const outputPath = resolve(fixture.fixture, "github-output");
+        const result = verifyPublish(fixture, {
+          ...signedRuntimeInputs,
+          REVIEW_ATTESTATION_PATH: reviewPath,
+          GITHUB_OUTPUT: outputPath,
+        });
+
+        expect(result.status).toBe(0);
+        expect(result.stdout).toContain(`release input OK: publish ${fixture.candidateSha}`);
+        expect(readFileSync(outputPath, "utf8")).toContain("waive_cursor_review=true");
+        expect(existsSync(reviewPath)).toBe(false);
+      });
+    },
+  );
+
+  it("keeps the normal v3.8.2 publish path fail-closed when review is empty", () => {
+    withPublishFixture("3.8.2", (fixture) => {
       const reviewPath = resolve(fixture.fixture, "review-attestation.json");
-      const outputPath = resolve(fixture.fixture, "github-output");
       const result = verifyPublish(fixture, {
-        ...signedRuntimeInputs,
         REVIEW_ATTESTATION_PATH: reviewPath,
-        GITHUB_OUTPUT: outputPath,
+        RUNTIME_MANIFEST_B64_INPUT: "e30=",
+        REMOTE_RUNTIME_MANIFEST_B64_INPUT: "e30=",
       });
 
-      expect(result.status).toBe(0);
-      expect(result.stdout).toContain(`release input OK: publish ${fixture.candidateSha}`);
-      expect(readFileSync(outputPath, "utf8")).toContain("waive_cursor_review=true");
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "release input rejected: publish mode requires a base64-encoded review attestation",
+      );
       expect(existsSync(reviewPath)).toBe(false);
     });
   });
@@ -363,13 +383,13 @@ describe("one-release Cursor review waiver", () => {
     });
   });
 
-  it("rejects the waiver for every package version except v3.8.1", () => {
-    withPublishFixture("3.8.0", (fixture) => {
+  it.each(["3.8.0", "3.8.3"])("rejects the waiver for package version %s", (version) => {
+    withPublishFixture(version, (fixture) => {
       const result = verifyPublish(fixture, signedRuntimeInputs);
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
-        "release input rejected: waive_cursor_review is authorized only for package version 3.8.1",
+        "release input rejected: waive_cursor_review is authorized only for package versions 3.8.1 and 3.8.2",
       );
     });
   });

--- a/scripts/release-workflow-check.mjs
+++ b/scripts/release-workflow-check.mjs
@@ -132,8 +132,8 @@ for (const [label, pattern] of [
     /skip_custom_ed25519:\s*\n\s*description:[^\n]*v3\.8\.0 publish only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
   ],
   [
-    "the v3.8.1 Cursor review waiver is an explicit boolean defaulting false",
-    /waive_cursor_review:\s*\n\s*description:[^\n]*v3\.8\.1 Cursor review attestation only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
+    "the v3.8.1/v3.8.2 Cursor review waiver is an explicit boolean defaulting false",
+    /waive_cursor_review:\s*\n\s*description:[^\n]*v3\.8\.1 or v3\.8\.2 Cursor review attestation only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
   ],
   [
     "custom Ed25519 waiver input is projected into one shell-only environment variable",
@@ -665,8 +665,8 @@ for (const [label, pattern] of [
     /skipCustomEd25519\s*&&\s*version\s*!==\s*"3\.8\.0"/,
   ],
   [
-    "Cursor review waiver is permanently pinned to package version 3.8.1",
-    /waiveCursorReview\s*&&\s*version\s*!==\s*"3\.8\.1"/,
+    "Cursor review waiver is permanently pinned to package versions 3.8.1 and 3.8.2",
+    /waiveCursorReview\s*&&\s*!\["3\.8\.1",\s*"3\.8\.2"\]\.includes\(version\)/,
   ],
   [
     "Cursor review waiver requires an empty review input",
@@ -949,7 +949,7 @@ function exactCandidateAppPromotionErrors(job) {
     assembleStep,
   );
   requirePattern(
-    "v3.8.1 review waiver must omit only the review attestation asset",
+    "v3.8.1/v3.8.2 review waiver must omit only the review attestation asset",
     /if \[ "\$WAIVE_CURSOR_REVIEW_INPUT" = true \]; then\n\s*test ! -e "\$assets\/REVIEW_ATTESTATION\.json"/,
     assembleStep,
   );

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -99,8 +99,8 @@ if (mode === "publish" && tag !== `v${version}`)
 if (skipCustomEd25519 && version !== "3.8.0") {
   fail(["skip_custom_ed25519 is authorized only for package version 3.8.0"]);
 }
-if (waiveCursorReview && version !== "3.8.1") {
-  fail(["waive_cursor_review is authorized only for package version 3.8.1"]);
+if (waiveCursorReview && !["3.8.1", "3.8.2"].includes(version)) {
+  fail(["waive_cursor_review is authorized only for package versions 3.8.1 and 3.8.2"]);
 }
 
 let attestationText = "";


### PR DESCRIPTION
This adds the owner-approved, version-scoped review waiver for 3.8.2 so the already-reviewed release can publish without claiming a new schema-v6 attestation. Both owner-signed runtime manifests, candidate provenance, signing, notarization, SBOM, npm provenance, and every other release gate remain required.

Verified with the focused release-input suite, the release workflow invariant check, the build, test typecheck, formatting, and diff check.