### PR TITLE
Fix Codex plugin manifest prompt

### DIFF
--- a/packages/cli/src/plugins.test.ts
+++ b/packages/cli/src/plugins.test.ts
@@ -218,6 +218,9 @@ describe("plugin lifecycle", () => {
       );
       expect(codexManifest.skills).toBe("./skills/");
       expect(codexManifest.mcpServers).toBe("./.mcp.json");
+      expect(codexManifest.interface.defaultPrompt).toEqual([
+        "Use Claudexor for harness-agnostic planning, execution, and review.",
+      ]);
       expect(
         existsSync(join(home, ".codex", "plugins", "claudexor", "commands", "claudexor.md")),
       ).toBe(false);

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -370,6 +370,7 @@ function manifest(kind: "claude" | "codex" | "cursor"): string {
         shortDescription: "Harness-agnostic coding through the local Claudexor CLI.",
         longDescription:
           "Use Claudexor for local planning, runs, races, and review through generated skills and durable-handle MCP tools.",
+        defaultPrompt: ["Use Claudexor for harness-agnostic planning, execution, and review."],
         developerName: "Claudexor",
         category: "Productivity",
         capabilities: ["Productivity"],


### PR DESCRIPTION
Codex now requires interface.defaultPrompt in plugin manifests. This adds the missing generated field and pins its exact value in the plugin lifecycle test. The CLI build, 37 focused tests, typecheck, Prettier, and diff check pass locally. Version carriers remain unchanged.