### PR TITLE
fix(journal): keep large snapshot activation healthy

### DIFF
--- a/.changeset/large-journal-replay.md
+++ b/.changeset/large-journal-replay.md
@@ -1,0 +1,7 @@
+---
+"@claudexor/journal": patch
+---
+
+Keep prepared journal activation healthy for large compacted snapshots by
+replaying records without one whole-array string conversion and treating an
+unmaterializable opportunistic compaction as a no-op.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,6 +186,10 @@ at every wire boundary.
   directory-entry flushes are tolerated to fail (`fsyncDirectory`), so a Windows
   crash can resurrect a completed append's intent file and recovery will then
   discard that acknowledged frame (disclosed, loud in the journal record).
+  Compacted snapshots keep their gzip framing but replay logical records one at
+  a time. Replay bounds decompressed output, and opportunistic compaction leaves
+  the existing frames untouched when a replacement cannot be materialized within
+  that bound, so a large valid history remains readable and startup stays ready.
 - `packages/daemon`: durable local queue (Unix socket on POSIX, named pipe on win32) and journal projections for commands, projects, and threads.
 - `packages/cli`: thin command surface plus local host-integration lifecycle
   (`claudexor plugin`) for generated Claude Code/Codex/Cursor/OpenCode

--- a/packages/journal/src/frame-codec.test.ts
+++ b/packages/journal/src/frame-codec.test.ts
@@ -1,0 +1,101 @@
+import { gzipSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import { COMPACTED_SNAPSHOT, encodeFrame, replayFrames, ZERO_HASH } from "./frame-codec.js";
+
+function compactedFrame(records: unknown[], encodedRecords = JSON.stringify(records)): Buffer {
+  const payload = Buffer.from(
+    JSON.stringify({
+      version: 1,
+      count: records.length,
+      encoding: "gzip-base64",
+      data: gzipSync(Buffer.from(encodedRecords)).toString("base64"),
+    }),
+  );
+  return encodeFrame(
+    {
+      partition: "global",
+      epoch: "epoch-test",
+      seq: 1,
+      previousFrameHash: ZERO_HASH,
+      time: "2026-01-01T00:00:00.000Z",
+      type: COMPACTED_SNAPSHOT,
+      logicalSpan: records.length,
+    },
+    payload,
+  );
+}
+
+describe("compacted journal frames", () => {
+  it("replays nested records with escaped delimiters and Unicode payloads", () => {
+    const records = [
+      {
+        time: "2026-01-01T00:00:00.000Z",
+        type: "probe.saved",
+        payload: {
+          text: 'braces { } and brackets [ ] and comma, quote " and slash \\',
+          nested: [{ value: "Привет 🌍" }],
+        },
+      },
+      {
+        time: "2026-01-01T00:00:01.000Z",
+        type: "probe.finished",
+        payload: { ok: true },
+      },
+    ];
+
+    const result = replayFrames(compactedFrame(records), "global");
+
+    expect(result.error).toBeNull();
+    expect(result.incompleteOffset).toBeNull();
+    expect(result.records.map(({ time, type, payload }) => ({ time, type, payload }))).toEqual(
+      records,
+    );
+  });
+
+  it("rejects trailing JSON after the declared compacted array", () => {
+    const records = [
+      { time: "2026-01-01T00:00:00.000Z", type: "probe.saved", payload: { value: 1 } },
+    ];
+
+    const result = replayFrames(
+      compactedFrame(records, `${JSON.stringify(records)} trailing`),
+      "global",
+    );
+
+    expect(result.records).toEqual([]);
+    expect(result.error?.reason).toContain("compacted snapshot is invalid");
+  });
+
+  it("replays a multi-megabyte logical snapshot without a whole-array parse", () => {
+    const records = Array.from({ length: 40_000 }, (_, index) => ({
+      time: "2026-01-01T00:00:00.000Z",
+      type: "grown.history",
+      payload: { index, repeated: "same-value".repeat(40) },
+    }));
+    const frame = compactedFrame(records);
+    // Keep the physical frame small so the guard below only catches the old
+    // whole-decompressed-buffer conversion, not ordinary frame decoding.
+    expect(frame.length).toBeLessThan(1024 * 1024);
+    const originalToString = Buffer.prototype.toString;
+    Buffer.prototype.toString = function (
+      encoding?: BufferEncoding,
+      start?: number,
+      end?: number,
+    ): string {
+      if (this.length > 1024 * 1024) throw new Error("whole snapshot conversion");
+      return originalToString.call(this, encoding, start, end);
+    };
+
+    const result = (() => {
+      try {
+        return replayFrames(frame, "global");
+      } finally {
+        Buffer.prototype.toString = originalToString;
+      }
+    })();
+
+    expect(result.error).toBeNull();
+    expect(result.records).toHaveLength(records.length);
+    expect(result.records.at(-1)?.payload).toEqual(records.at(-1)?.payload);
+  });
+});

--- a/packages/journal/src/frame-codec.ts
+++ b/packages/journal/src/frame-codec.ts
@@ -9,6 +9,10 @@ const PREFIX_BYTES = PREFIX_CORE_BYTES + PREFIX_CHECKSUM_BYTES;
 export const HASH_BYTES = 32;
 const MAX_HEADER_BYTES = 64 * 1024;
 export const MAX_PAYLOAD_BYTES = 16 * 1024 * 1024;
+// A compacted frame's physical payload is bounded, but gzip expansion is not.
+// Keep replay fail-closed before an unbounded allocation while retaining
+// headroom for the large snapshots already produced by the journal.
+export const MAX_COMPACTED_LOGICAL_BYTES = 512 * 1024 * 1024;
 export const ZERO_HASH = "0".repeat(64);
 export const COMPACTED_SNAPSHOT = "journal.compacted_snapshot";
 
@@ -205,21 +209,100 @@ function decodeCompactedSnapshot(
     throw new Error("record count mismatch");
   }
   if (typeof payload.data !== "string") throw new Error("encoded data is missing");
-  const decoded = JSON.parse(gunzipSync(Buffer.from(payload.data, "base64")).toString("utf8"));
-  if (!Array.isArray(decoded) || decoded.length !== payload.count)
-    throw new Error("invalid records");
-  return decoded.map((record) => {
-    if (
-      !isRecord(record) ||
-      typeof record.time !== "string" ||
-      typeof record.type !== "string" ||
-      !record.type ||
-      record.type === COMPACTED_SNAPSHOT
-    ) {
-      throw new Error("invalid logical record");
-    }
-    return { time: record.time, type: record.type, payload: record.payload };
+  const decoded = gunzipSync(Buffer.from(payload.data, "base64"), {
+    maxOutputLength: MAX_COMPACTED_LOGICAL_BYTES,
   });
+  return parseCompactedRecords(decoded, payload.count as number);
+}
+
+function parseCompactedRecords(bytes: Buffer, count: number): CompactedRecord[] {
+  let cursor = skipJsonWhitespace(bytes, 0);
+  if (bytes[cursor] !== 0x5b) throw new Error("invalid records");
+  cursor += 1;
+  const records: CompactedRecord[] = [];
+  for (let index = 0; index < count; index += 1) {
+    cursor = skipJsonWhitespace(bytes, cursor);
+    const end = scanCompactedRecord(bytes, cursor);
+    let value: unknown;
+    try {
+      // Parse one logical record at a time. Converting the complete decompressed
+      // array to a JavaScript string is what overflows on large valid journals.
+      value = JSON.parse(bytes.subarray(cursor, end).toString("utf8"));
+    } catch {
+      throw new Error("invalid records");
+    }
+    records.push(validateCompactedRecord(value));
+    cursor = skipJsonWhitespace(bytes, end);
+    const separator = bytes[cursor];
+    if (index + 1 < count) {
+      if (separator !== 0x2c) throw new Error("invalid records");
+      cursor += 1;
+    } else {
+      if (separator !== 0x5d) throw new Error("invalid records");
+      cursor += 1;
+    }
+  }
+  cursor = skipJsonWhitespace(bytes, cursor);
+  if (cursor !== bytes.length) throw new Error("invalid records");
+  return records;
+}
+
+function validateCompactedRecord(record: unknown): CompactedRecord {
+  if (
+    !isRecord(record) ||
+    typeof record.time !== "string" ||
+    typeof record.type !== "string" ||
+    !record.type ||
+    record.type === COMPACTED_SNAPSHOT
+  ) {
+    throw new Error("invalid logical record");
+  }
+  return { time: record.time, type: record.type, payload: record.payload };
+}
+
+function scanCompactedRecord(bytes: Buffer, start: number): number {
+  if (bytes[start] !== 0x7b) throw new Error("invalid records");
+  const stack: number[] = [];
+  let inString = false;
+  let escaped = false;
+  for (let cursor = start; cursor < bytes.length; cursor += 1) {
+    const value = bytes[cursor];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (value === 0x5c) escaped = true;
+      else if (value === 0x22) inString = false;
+      continue;
+    }
+    if (value === 0x22) {
+      inString = true;
+      continue;
+    }
+    if (value === 0x7b || value === 0x5b) {
+      stack.push(value);
+      continue;
+    }
+    if (value !== 0x7d && value !== 0x5d) continue;
+    const opening = stack.pop();
+    if ((value === 0x7d && opening !== 0x7b) || (value === 0x5d && opening !== 0x5b)) {
+      throw new Error("invalid records");
+    }
+    if (stack.length === 0) return cursor + 1;
+  }
+  throw new Error("invalid records");
+}
+
+function skipJsonWhitespace(bytes: Buffer, start: number): number {
+  let cursor = start;
+  while (
+    cursor < bytes.length &&
+    (bytes[cursor] === 0x20 ||
+      bytes[cursor] === 0x09 ||
+      bytes[cursor] === 0x0a ||
+      bytes[cursor] === 0x0d)
+  ) {
+    cursor += 1;
+  }
+  return cursor;
 }
 
 function encodeJson(value: unknown): Buffer {

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -10,7 +10,7 @@ import {
 import { randomBytes } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DurableJournal,
   JournalAppendUncertainError,
@@ -60,6 +60,75 @@ describe("DurableJournal", () => {
     });
     expect(journal.compact()).toBeNull();
     expect(journal.state().status).toBe("ready");
+    journal.close();
+  });
+
+  it("keeps a ready journal when compacted snapshot serialization hits the string limit", () => {
+    const journal = openJournal();
+    const internals = journal as unknown as {
+      entries: Array<{ time: string; type: string; payload: unknown }>;
+      knownFileBytes: number;
+    };
+    internals.entries.push({
+      time: "2026-01-01T00:00:00.000Z",
+      type: "oversized.history",
+      payload: { value: 1 },
+    });
+    internals.knownFileBytes = Number.MAX_SAFE_INTEGER;
+    const before = readFileSync(journal.path);
+    const originalStringify = JSON.stringify;
+    const stringify = vi.spyOn(JSON, "stringify").mockImplementation((value, replacer, space) => {
+      if (
+        Array.isArray(value) &&
+        value.length === 1 &&
+        (value[0] as { type?: unknown } | undefined)?.type === "oversized.history"
+      ) {
+        throw new RangeError("Invalid string length");
+      }
+      return originalStringify(value, replacer, space);
+    });
+    try {
+      expect(journal.compact()).toBeNull();
+      expect(readFileSync(journal.path)).toEqual(before);
+      expect(journal.state()).toMatchObject({ status: "ready" });
+    } finally {
+      stringify.mockRestore();
+    }
+    journal.close();
+  });
+
+  it("keeps a ready journal when one logical payload cannot be cloned", () => {
+    const journal = openJournal();
+    const internals = journal as unknown as {
+      entries: Array<{ time: string; type: string; payload: unknown }>;
+      knownFileBytes: number;
+    };
+    internals.entries.push({
+      time: "2026-01-01T00:00:00.000Z",
+      type: "oversized.payload",
+      payload: { capacityMarker: true },
+    });
+    internals.knownFileBytes = Number.MAX_SAFE_INTEGER;
+    const before = readFileSync(journal.path);
+    const originalStringify = JSON.stringify;
+    const stringify = vi.spyOn(JSON, "stringify").mockImplementation((value, replacer, space) => {
+      if (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        (value as { capacityMarker?: unknown }).capacityMarker === true
+      ) {
+        throw new RangeError("Invalid string length");
+      }
+      return originalStringify(value, replacer, space);
+    });
+    try {
+      expect(journal.compact()).toBeNull();
+      expect(readFileSync(journal.path)).toEqual(before);
+      expect(journal.state()).toMatchObject({ status: "ready" });
+    } finally {
+      stringify.mockRestore();
+    }
     journal.close();
   });
 

--- a/packages/journal/src/index.test.ts
+++ b/packages/journal/src/index.test.ts
@@ -132,6 +132,34 @@ describe("DurableJournal", () => {
     journal.close();
   });
 
+  it("keeps a ready journal when compacted payload materialization hits the string limit", () => {
+    const journal = openJournal();
+    const internals = journal as unknown as {
+      entries: Array<{ time: string; type: string; payload: unknown }>;
+      knownFileBytes: number;
+    };
+    internals.entries.push({
+      time: "2026-01-01T00:00:00.000Z",
+      type: "oversized.compacted.payload",
+      payload: { capacityMarker: true },
+    });
+    internals.knownFileBytes = Number.MAX_SAFE_INTEGER;
+    const before = readFileSync(journal.path);
+    const originalToString = Buffer.prototype.toString;
+    Buffer.prototype.toString = function (encoding?: BufferEncoding, start?: number, end?: number) {
+      if (encoding === "base64") throw new RangeError("Invalid string length");
+      return originalToString.call(this, encoding, start, end);
+    };
+    try {
+      expect(journal.compact()).toBeNull();
+      expect(readFileSync(journal.path)).toEqual(before);
+      expect(journal.state()).toMatchObject({ status: "ready" });
+    } finally {
+      Buffer.prototype.toString = originalToString;
+    }
+    journal.close();
+  });
+
   it("replays an fsynced hash chain and resumes an epoch-bound cursor at N+1", () => {
     const journal = openJournal();
     const first = journal.append("setup.job.saved", { id: "one" });

--- a/packages/journal/src/journal-compaction.ts
+++ b/packages/journal/src/journal-compaction.ts
@@ -63,13 +63,27 @@ export function compactJournalFile(input: {
     if (isCompactionCapacityError(error)) return null;
     throw error;
   }
-  const payload: CompactedSnapshotPayload = {
-    version: 1,
-    count: logical.length,
-    encoding: "gzip-base64",
-    data: compressed.toString("base64"),
-  };
-  const payloadBytes = encodeJournalPayload(payload);
+  // A base64 representation plus its JSON envelope is always larger than the
+  // compressed bytes, so this snapshot cannot fit the frame payload. Avoid
+  // creating an unnecessarily large string before returning the no-op.
+  if (compressed.length > MAX_PAYLOAD_BYTES) return null;
+  // Base64 and payload JSON are also materialization steps. Keep them inside
+  // the same capacity boundary so an otherwise readable journal remains the
+  // authoritative file when either conversion hits a runtime limit.
+  let payload: CompactedSnapshotPayload;
+  let payloadBytes: Buffer;
+  try {
+    payload = {
+      version: 1,
+      count: logical.length,
+      encoding: "gzip-base64",
+      data: compressed.toString("base64"),
+    };
+    payloadBytes = encodeJournalPayload(payload);
+  } catch (error) {
+    if (isCompactionCapacityError(error)) return null;
+    throw error;
+  }
   if (payloadBytes.length > MAX_PAYLOAD_BYTES) return null;
   const epoch = randomUUID();
   const header: FrameHeader = {
@@ -127,12 +141,18 @@ export function compactJournalFile(input: {
 }
 
 function isCompactionCapacityError(error: unknown): boolean {
-  if (error instanceof RangeError && error.message === "Invalid string length") return true;
+  if (
+    error instanceof RangeError &&
+    (error.message === "Invalid string length" ||
+      ("code" in error && error.code === "ERR_STRING_TOO_LONG"))
+  ) {
+    return true;
+  }
   return (
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    error.code === "ERR_BUFFER_TOO_LARGE"
+    (error.code === "ERR_BUFFER_TOO_LARGE" || error.code === "ERR_STRING_TOO_LONG")
   );
 }
 

--- a/packages/journal/src/journal-compaction.ts
+++ b/packages/journal/src/journal-compaction.ts
@@ -7,6 +7,7 @@ import { encodeJournalPayload } from "./append-batch.js";
 import {
   COMPACTED_SNAPSHOT,
   HASH_BYTES,
+  MAX_COMPACTED_LOGICAL_BYTES,
   MAX_PAYLOAD_BYTES,
   ZERO_HASH,
   encodeFrame,
@@ -34,12 +35,34 @@ export function compactJournalFile(input: {
   now: () => Date;
 }): JournalCompactionResult | null {
   if (input.entries.length === 0) return null;
-  const logical: CompactedRecord[] = input.entries.map((record) => ({
-    time: record.time,
-    type: record.type,
-    payload: cloneJson(record.payload),
-  }));
-  const compressed = gzipSync(Buffer.from(JSON.stringify(logical)));
+  let logical: CompactedRecord[];
+  try {
+    logical = input.entries.map((record) => ({
+      time: record.time,
+      type: record.type,
+      payload: cloneJson(record.payload),
+    }));
+  } catch (error) {
+    if (isCompactionCapacityError(error)) return null;
+    throw error;
+  }
+  let serialized: string;
+  try {
+    const value = JSON.stringify(logical);
+    if (value === undefined) return null;
+    serialized = value;
+  } catch (error) {
+    if (isCompactionCapacityError(error)) return null;
+    throw error;
+  }
+  if (Buffer.byteLength(serialized, "utf8") > MAX_COMPACTED_LOGICAL_BYTES) return null;
+  let compressed: Buffer;
+  try {
+    compressed = gzipSync(Buffer.from(serialized));
+  } catch (error) {
+    if (isCompactionCapacityError(error)) return null;
+    throw error;
+  }
   const payload: CompactedSnapshotPayload = {
     version: 1,
     count: logical.length,
@@ -60,6 +83,26 @@ export function compactJournalFile(input: {
   };
   const frame = encodeFrame(header, payloadBytes);
   if (frame.length >= input.knownFileBytes) return null;
+  const frameHash = frame.subarray(frame.length - HASH_BYTES).toString("hex");
+  // Materialize the replacement records before the rename. If cloning a
+  // payload fails, the existing journal must remain the authoritative file.
+  let records: JournalRecord[];
+  try {
+    records = logical.map((record, index) => ({
+      partition: input.partition,
+      epoch,
+      seq: index + 1,
+      previousFrameHash: index === 0 ? ZERO_HASH : frameHash,
+      frameHash,
+      time: record.time,
+      type: record.type,
+      payload: cloneJson(record.payload),
+      byteOffset: 0,
+    }));
+  } catch (error) {
+    if (isCompactionCapacityError(error)) return null;
+    throw error;
+  }
   const temp = `${input.path}.${randomUUID()}.compact`;
   const tempFd = openSync(temp, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL, 0o600);
   try {
@@ -69,18 +112,6 @@ export function compactJournalFile(input: {
   }
   renameSync(temp, input.path);
   fsyncDirectory(dirname(input.path));
-  const frameHash = frame.subarray(frame.length - HASH_BYTES).toString("hex");
-  const records = logical.map((record, index) => ({
-    partition: input.partition,
-    epoch,
-    seq: index + 1,
-    previousFrameHash: index === 0 ? ZERO_HASH : frameHash,
-    frameHash,
-    time: record.time,
-    type: record.type,
-    payload: cloneJson(record.payload),
-    byteOffset: 0,
-  }));
   return {
     receipt: {
       beforeBytes: input.knownFileBytes,
@@ -93,6 +124,16 @@ export function compactJournalFile(input: {
     previousFrameHash: frameHash,
     knownFileBytes: frame.length,
   };
+}
+
+function isCompactionCapacityError(error: unknown): boolean {
+  if (error instanceof RangeError && error.message === "Invalid string length") return true;
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ERR_BUFFER_TOO_LARGE"
+  );
 }
 
 function cloneJson<T>(value: T): T {

--- a/packages/journal/src/live-journal.test.ts
+++ b/packages/journal/src/live-journal.test.ts
@@ -6,10 +6,11 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { DurableJournal, journalPartitionDirectory } from "./index.js";
@@ -29,12 +30,16 @@ describe.skipIf(!sourcePath)("large live journal dogfood", () => {
     expect(replay.records.length).toBeGreaterThanOrEqual(200_000);
     const first = replay.records[0];
     const last = replay.records.at(-1);
-    expect(first).toMatchObject({ seq: 1, partition });
+    expect(first?.seq).toBe(1);
+    expect(first?.partition).toBe(partition);
     expect(last?.seq).toBe(replay.records.length);
+    expect(last?.partition).toBe(partition);
 
     const sourceDir = dirname(source);
     expect(existsSync(join(sourceDir, "append.pending.json"))).toBe(false);
-    const tempRoot = mkdtempSync(join(homedir(), ".claudexor-journal-live-test-"));
+    const tempRoot = realpathSync.native(
+      mkdtempSync(join(tmpdir(), ".claudexor-journal-live-test-")),
+    );
     chmodSync(tempRoot, 0o700);
     try {
       const journalRoot = join(tempRoot, "journal");
@@ -62,13 +67,15 @@ describe.skipIf(!sourcePath)("large live journal dogfood", () => {
         expect(prepared.state().status).toBe("ready");
         expect(prepared.currentSequence()).toBe(last?.seq);
         const preparedTail = prepared.records(prepared.currentSequence() - 1)[0];
-        expect(preparedTail).toMatchObject({ seq: last?.seq, partition });
+        expect(preparedTail?.seq).toBe(last?.seq);
+        expect(preparedTail?.partition).toBe(partition);
 
         prepared.activatePrepared();
         expect(prepared.state().status).toBe("ready");
         expect(prepared.currentSequence()).toBe(last?.seq);
         const activatedTail = prepared.records(prepared.currentSequence() - 1)[0];
-        expect(activatedTail).toMatchObject({ seq: last?.seq, partition });
+        expect(activatedTail?.seq).toBe(last?.seq);
+        expect(activatedTail?.partition).toBe(partition);
       } finally {
         prepared.close();
       }

--- a/packages/journal/src/live-journal.test.ts
+++ b/packages/journal/src/live-journal.test.ts
@@ -1,0 +1,99 @@
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DurableJournal, journalPartitionDirectory } from "./index.js";
+import { replayFrames } from "./frame-codec.js";
+
+const sourcePath = process.env.CLAUDEXOR_LIVE_JOURNAL;
+const partition = process.env.CLAUDEXOR_LIVE_PARTITION ?? "global";
+
+describe.skipIf(!sourcePath)("large live journal dogfood", () => {
+  it("prepares and activates an immutable production-shaped snapshot", () => {
+    const source = resolve(sourcePath!);
+    const before = readStableFile(source);
+    expect(before.bytes.length).toBeGreaterThan(100 * 1024 * 1024);
+    const replay = replayFrames(before.bytes, partition);
+    expect(replay.error).toBeNull();
+    expect(replay.incompleteOffset).toBeNull();
+    expect(replay.records.length).toBeGreaterThanOrEqual(200_000);
+    const first = replay.records[0];
+    const last = replay.records.at(-1);
+    expect(first).toMatchObject({ seq: 1, partition });
+    expect(last?.seq).toBe(replay.records.length);
+
+    const sourceDir = dirname(source);
+    expect(existsSync(join(sourceDir, "append.pending.json"))).toBe(false);
+    const tempRoot = mkdtempSync(join(homedir(), ".claudexor-journal-live-test-"));
+    chmodSync(tempRoot, 0o700);
+    try {
+      const journalRoot = join(tempRoot, "journal");
+      const partitionDir = journalPartitionDirectory(journalRoot, partition);
+      mkdirSync(partitionDir, { recursive: true, mode: 0o700 });
+      chmodSync(journalRoot, 0o700);
+      chmodSync(partitionDir, 0o700);
+      const copyPath = join(partitionDir, "journal.bin");
+      writeFileSync(copyPath, before.bytes, { mode: 0o600 });
+
+      const prepared = (
+        DurableJournal as unknown as {
+          prepare(options: {
+            rootDir: string;
+            partition: string;
+            compactionThresholdBytes: number;
+          }): DurableJournal;
+        }
+      ).prepare({
+        rootDir: journalRoot,
+        partition,
+        compactionThresholdBytes: Number.MAX_SAFE_INTEGER,
+      });
+      try {
+        expect(prepared.state().status).toBe("ready");
+        expect(prepared.currentSequence()).toBe(last?.seq);
+        const preparedTail = prepared.records(prepared.currentSequence() - 1)[0];
+        expect(preparedTail).toMatchObject({ seq: last?.seq, partition });
+
+        prepared.activatePrepared();
+        expect(prepared.state().status).toBe("ready");
+        expect(prepared.currentSequence()).toBe(last?.seq);
+        const activatedTail = prepared.records(prepared.currentSequence() - 1)[0];
+        expect(activatedTail).toMatchObject({ seq: last?.seq, partition });
+      } finally {
+        prepared.close();
+      }
+      expect(readStableFile(copyPath).hash).toBe(before.hash);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+    expect(readStableFile(source).hash).toBe(before.hash);
+  }, 120_000);
+});
+
+function readStableFile(path: string): { bytes: Buffer; hash: string } {
+  const before = lstatSync(path, { bigint: true });
+  if (!before.isFile() || before.nlink !== 1n) throw new Error("journal is not a private file");
+  const bytes = readFileSync(path);
+  const after = lstatSync(path, { bigint: true });
+  if (
+    !after.isFile() ||
+    after.nlink !== 1n ||
+    after.dev !== before.dev ||
+    after.ino !== before.ino ||
+    after.size !== before.size ||
+    after.mtimeNs !== before.mtimeNs
+  ) {
+    throw new Error("journal changed during dogfood read");
+  }
+  return { bytes, hash: createHash("sha256").update(bytes).digest("hex") };
+}


### PR DESCRIPTION
Large valid compacted journals could make prepared activation fail with `Invalid string length` while the existing journal was healthy. The daemon then stayed recovery-only and closed product routes.

This patch keeps opportunistic compaction non-fatal when materialization hits a known capacity limit, moves replacement-record materialization before the atomic rename, and replays compacted records without converting the whole decompressed array to one JavaScript string. It also bounds decompressed snapshot output and documents the recovery contract.

Verification:

Journal tests: 33/33 passed.
Full test suite: 4,481 passed, 10 skipped, 0 failed across 338 files.
Full workspace typecheck and test typecheck passed.
Docs, format, invariant, retired-key, sensitive-resource, complexity, knip, and staged checks passed.
Exact production-shaped dogfood on an immutable copy of the current 349,696,072-byte global journal: the old decoder reproduced the capacity failure; the patched replay and prepared activation completed with 441,338 records, and the source/copy SHA-256 stayed unchanged.

The changeset is a patch release. The published v3.8.2 tag remains untouched; release tooling should assign the next patch version.
