### PR TITLE
Classify refreshable Claude quota failures honestly

### DIFF
--- a/.changeset/calm-ravens-refresh.md
+++ b/.changeset/calm-ravens-refresh.md
@@ -1,0 +1,5 @@
+---
+"@claudexor/cli": patch
+---
+
+Keep refreshable Claude Code profiles signed in when an idle quota probe cannot prove their vendor-owned access token was fresh.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3215,11 +3215,19 @@ code touching one of these areas must honor it or change it explicitly here.
   cross-run authority rather than rediscovering pressure independently in each
   run. Codex uses its app-server. Claude subscription windows arrive from the
   `oauth/usage` endpoint as the PRIMARY source (since 2.1): the daemon's
-  refresher reads each logged-in config dir's OAuth token transiently —
+  refresher reads each logged-in config dir's OAuth token transiently, retaining
+  only the expiry timestamp and refresh-token presence beside the one-request
+  access token (never the refresh token itself) —
   every claude `config_dir_login` row (subject = its profile id), plus the
   legacy default native dir (subject null) only while that store is
-  UNMIGRATED — and a failing endpoint yields NO
-  snapshot, never degraded auth. The user-scoped status-line payload
+  UNMIGRATED. A known-expired refreshable token skips the request and yields a
+  typed `refresh_failed` absence. A refreshable token with unknown expiry is
+  still probed, but a 401/403 cannot prove revocation; it and a rejection after
+  a known-fresh token crosses expiry during the bounded request yield the same
+  `refresh_failed` absence. Only a token proven fresh at rejection remains typed
+  `auth_revoked`; a token without refresh capability retains that conservative
+  real-response verdict. Other endpoint failures yield NO snapshot and no auth
+  verdict. The user-scoped status-line payload
   (installed explicitly by the Claude host-plugin lifecycle) remains a
   SECONDARY source for the legacy null subject only; its collector stores only
   allowlisted windows in the external v3 root and composes/restores any

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -189,12 +189,20 @@ endpoint, read per credential profile from the profile's own vendor store:
 on macOS its keychain item
 (`Claude Code-credentials-<sha256(configDir)[:8]>`, live-verified formula),
 on Linux the vendor's `.credentials.json` inside the profile's config dir.
-Either store yields an access token held transiently for exactly one request — never
-persisted, logged, or included in errors — and returns proactive
+Either store yields an access token held transiently for at most one request — never
+persisted, logged, or included in errors — plus only its expiry timestamp and
+whether a refresh token exists (the refresh token itself is never projected).
+The endpoint returns proactive
 five_hour/seven_day/per-model utilization attributed to the profile
-(`subject_id`). An expired idle token fails to unknown (the vendor CLI
-refreshes tokens on real use); endpoint refusal never degrades auth
-readiness. The status-line collector stays as a secondary source: an explicit
+(`subject_id`). A known-expired refreshable idle token skips the request and
+fails quota to unknown. If expiry is absent, the bounded request may still
+succeed; a 401/403 for that refreshable token, or after a known-fresh token
+crosses expiry during the request, also fails quota to unknown because freshness
+was not proven at rejection time. Claude Code owns refresh on a real use. Only a
+token proven fresh at rejection remains vendor revocation evidence and may
+degrade auth readiness; a token without refresh capability retains that
+conservative real-response behavior. The status-line collector
+stays as a secondary source: an explicit
 `claudexor plugin install claude` composes it with an existing user
 `statusLine` command and restores it on uninstall; it persists only the two
 documented windows and provenance in the Claudexor-owned v3 root and does not

--- a/packages/cli/src/claude-oauth-usage.test.ts
+++ b/packages/cli/src/claude-oauth-usage.test.ts
@@ -9,6 +9,7 @@ import {
   parseClaudeOauthUsage,
   readClaudeOauthCredential,
   refreshClaudeOauthUsageQuota,
+  type ClaudeOauthCredential,
 } from "./claude-oauth-usage.js";
 
 /** The EXACT response shape of the 2026-07-17 live experiment (max plan). */
@@ -23,6 +24,16 @@ const LIVE_USAGE = {
   extra_usage: { is_enabled: true, utilization: 98.77 },
   spend: { percent: 99, severity: "critical" },
 };
+
+const oauthCredential = (
+  overrides: Partial<ClaudeOauthCredential> = {},
+): ClaudeOauthCredential => ({
+  accessToken: "tok",
+  subscriptionType: "max",
+  expiresAtMs: null,
+  hasRefreshToken: false,
+  ...overrides,
+});
 
 describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
   it("keychain item name follows the live-verified vendor formula", () => {
@@ -92,15 +103,46 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     expect(parseClaudeOauthUsage({ five_hour: { utilization: "38" } }, null, null)).toBeNull();
   });
 
-  it("reads both credential shapes and never invents a token", () => {
-    expect(
-      parseClaudeOauthCredential(JSON.stringify({ accessToken: "tok", subscriptionType: "max" })),
-    ).toEqual({ accessToken: "tok", subscriptionType: "max" });
+  it("reads both credential shapes and retains only non-secret refresh metadata", () => {
     expect(
       parseClaudeOauthCredential(
-        JSON.stringify({ claudeAiOauth: { accessToken: "tok2", subscriptionType: "pro" } }),
+        JSON.stringify({
+          accessToken: "tok",
+          subscriptionType: "max",
+          expiresAt: 1_787_011_200_000,
+          refreshToken: "refresh-secret",
+        }),
       ),
-    ).toEqual({ accessToken: "tok2", subscriptionType: "pro" });
+    ).toEqual({
+      accessToken: "tok",
+      subscriptionType: "max",
+      expiresAtMs: 1_787_011_200_000,
+      hasRefreshToken: true,
+    });
+    expect(
+      parseClaudeOauthCredential(
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "tok2",
+            subscriptionType: "pro",
+            expiresAt: 1_787_011_300_000,
+            refreshToken: "wrapped-refresh-secret",
+          },
+        }),
+      ),
+    ).toEqual({
+      accessToken: "tok2",
+      subscriptionType: "pro",
+      expiresAtMs: 1_787_011_300_000,
+      hasRefreshToken: true,
+    });
+    expect(
+      JSON.stringify(
+        parseClaudeOauthCredential(
+          JSON.stringify({ accessToken: "tok", refreshToken: "refresh-secret" }),
+        ),
+      ),
+    ).not.toContain("refresh-secret");
     expect(parseClaudeOauthCredential("not json")).toBeNull();
     expect(parseClaudeOauthCredential(JSON.stringify({ refreshToken: "only" }))).toBeNull();
   });
@@ -126,7 +168,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
 
   it("claims a refresh_failed absence when the usage endpoint refuses", async () => {
     const result = await refreshClaudeOauthUsageQuota({
-      readCredential: async () => ({ accessToken: "tok", subscriptionType: "max" }),
+      readCredential: async () => oauthCredential(),
       fetchUsage: async () => {
         throw new Error("oauth/usage responded 500");
       },
@@ -138,23 +180,121 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     expect(nativeAbsence?.detail).toContain("500");
   });
 
-  it("claims auth_revoked, not refresh_failed, when the vendor rejects the credential", async () => {
-    // A 401/403 from a call made with THIS subject's own token is the vendor
-    // saying the credential is dead — the one fact that separates a revoked
-    // login from an unreachable endpoint, and the one the profile status reads.
+  it.each([401, 403])(
+    "claims auth_revoked when the vendor rejects a known-fresh credential (%i)",
+    async (status) => {
+      const result = await refreshClaudeOauthUsageQuota({
+        readCredential: async () =>
+          oauthCredential({
+            expiresAtMs: Date.parse("2026-07-18T01:00:00Z"),
+            hasRefreshToken: true,
+          }),
+        fetchUsage: async () => {
+          throw Object.assign(new Error(`oauth/usage responded ${status}`), {
+            quotaAbsenceReason: "auth_revoked" as const,
+          });
+        },
+        now: () => new Date("2026-07-18T00:00:00Z"),
+      });
+      expect(result.snapshots).toEqual([]);
+      const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
+      expect(nativeAbsence?.reason).toBe("auth_revoked");
+      expect(nativeAbsence?.detail).toContain(String(status));
+    },
+  );
+
+  it.each([401, 403])(
+    "fails a rejected refreshable credential with unknown expiry to refresh_failed (%i)",
+    async (status) => {
+      let fetches = 0;
+      const result = await refreshClaudeOauthUsageQuota({
+        readCredential: async () =>
+          oauthCredential({
+            expiresAtMs: null,
+            hasRefreshToken: true,
+          }),
+        fetchUsage: async () => {
+          fetches += 1;
+          throw Object.assign(new Error(`oauth/usage responded ${status}`), {
+            quotaAbsenceReason: "auth_revoked" as const,
+          });
+        },
+        now: () => new Date("2026-07-18T00:00:00Z"),
+      });
+      expect(fetches).toBe(1);
+      const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
+      expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
+      expect(nativeAbsence?.detail).toContain("Claude Code owns refresh");
+      expect(nativeAbsence?.detail).not.toContain(String(status));
+    },
+  );
+
+  it("skips oauth/usage for an already-expired refreshable credential", async () => {
+    let fetches = 0;
     const result = await refreshClaudeOauthUsageQuota({
-      readCredential: async () => ({ accessToken: "tok", subscriptionType: "max" }),
+      readCredential: async () =>
+        oauthCredential({
+          accessToken: "access-secret-needle",
+          expiresAtMs: Date.parse("2026-07-17T23:59:59Z"),
+          hasRefreshToken: true,
+        }),
       fetchUsage: async () => {
+        fetches += 1;
+        throw new Error("should not be called");
+      },
+      now: () => new Date("2026-07-18T00:00:00Z"),
+    });
+    expect(fetches).toBe(0);
+    const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
+    expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
+    expect(nativeAbsence?.detail).toContain("Claude Code owns refresh");
+    expect(nativeAbsence?.detail).not.toContain("access-secret-needle");
+  });
+
+  it.each([401, 403])(
+    "reclassifies %i when the refreshable credential expires during the request",
+    async (status) => {
+      const times = [new Date("2026-07-18T00:00:00.000Z"), new Date("2026-07-18T00:00:00.002Z")];
+      const result = await refreshClaudeOauthUsageQuota({
+        readCredential: async () =>
+          oauthCredential({
+            expiresAtMs: Date.parse("2026-07-18T00:00:00.001Z"),
+            hasRefreshToken: true,
+          }),
+        fetchUsage: async () => {
+          throw Object.assign(new Error(`oauth/usage responded ${status}`), {
+            quotaAbsenceReason: "auth_revoked" as const,
+          });
+        },
+        now: () => times.shift() ?? new Date("2026-07-18T00:00:00.002Z"),
+      });
+      const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
+      expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
+      expect(nativeAbsence?.detail).toContain("Claude Code owns refresh");
+      expect(nativeAbsence?.detail).not.toContain(String(status));
+    },
+  );
+
+  it("retains the real-response auth verdict for an expired token without a refresh token", async () => {
+    let fetches = 0;
+    const result = await refreshClaudeOauthUsageQuota({
+      readCredential: async () =>
+        oauthCredential({
+          expiresAtMs: Date.parse("2026-07-17T23:59:59Z"),
+          hasRefreshToken: false,
+        }),
+      fetchUsage: async () => {
+        fetches += 1;
         throw Object.assign(new Error("oauth/usage responded 401"), {
           quotaAbsenceReason: "auth_revoked" as const,
         });
       },
       now: () => new Date("2026-07-18T00:00:00Z"),
     });
-    expect(result.snapshots).toEqual([]);
-    const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
-    expect(nativeAbsence?.reason).toBe("auth_revoked");
-    expect(nativeAbsence?.detail).toContain("401");
+    expect(fetches).toBe(1);
+    expect(result.absences?.find((a) => a.subject.subject_id === null)?.reason).toBe(
+      "auth_revoked",
+    );
   });
 
   it("claims a typed rate_limited absence carrying the vendor Retry-After floor on a 429", async () => {
@@ -162,7 +302,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     // stays distinct from refresh_failed so the pacer can honor the vendor
     // floor, and the absence carries retry_after_ms only when the header came.
     const result = await refreshClaudeOauthUsageQuota({
-      readCredential: async () => ({ accessToken: "tok", subscriptionType: "max" }),
+      readCredential: async () => oauthCredential(),
       fetchUsage: async () => {
         throw Object.assign(new Error("oauth/usage responded 429"), {
           quotaAbsenceReason: "rate_limited" as const,
@@ -181,7 +321,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     // Anthropic does not always send Retry-After; the absence then simply
     // omits retry_after_ms (absence of the floor is stated, never invented).
     const result = await refreshClaudeOauthUsageQuota({
-      readCredential: async () => ({ accessToken: "tok", subscriptionType: "max" }),
+      readCredential: async () => oauthCredential(),
       fetchUsage: async () => {
         throw Object.assign(new Error("oauth/usage responded 429"), {
           quotaAbsenceReason: "rate_limited" as const,
@@ -273,7 +413,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
       const result = await refreshClaudeOauthUsageQuota({
         readCredential: async (configDir) => {
           probedDirs.push(configDir);
-          return { accessToken: "tok", subscriptionType: "max" };
+          return oauthCredential();
         },
         fetchUsage: async () => LIVE_USAGE,
         now: () => new Date("2026-08-18T00:00:00Z"),
@@ -336,7 +476,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
       }));
       let fetches = 0;
       const result = await refreshClaudeOauthUsageQuota({
-        readCredential: async () => ({ accessToken: "tok", subscriptionType: "max" }),
+        readCredential: async () => oauthCredential(),
         fetchUsage: async () => {
           fetches += 1;
           throw Object.assign(new Error("oauth/usage responded 429"), {
@@ -368,7 +508,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     // windows must yield a typed absence, not silent emptiness — the registry
     // needs the observation to back off instead of re-polling forever.
     const result = await refreshClaudeOauthUsageQuota({
-      readCredential: async () => ({ accessToken: "tok", subscriptionType: "max" }),
+      readCredential: async () => oauthCredential(),
       fetchUsage: async () => ({ unrelated: "payload", limits: [] }),
       now: () => new Date("2026-07-18T00:00:00Z"),
     });
@@ -403,16 +543,27 @@ describe("claude credential-file store off macOS (Linux quota parity)", () => {
     await expect(readClaudeOauthCredential(flat, "linux")).resolves.toEqual({
       accessToken: bait,
       subscriptionType: "max",
+      expiresAtMs: null,
+      hasRefreshToken: false,
     });
 
     const wrapped = await configDir();
     await writeFile(
       join(wrapped, ".credentials.json"),
-      JSON.stringify({ claudeAiOauth: { accessToken: bait, subscriptionType: "pro" } }),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: bait,
+          subscriptionType: "pro",
+          expiresAt: 1_787_011_300_000,
+          refreshToken: "refresh-secret",
+        },
+      }),
     );
     await expect(readClaudeOauthCredential(wrapped, "linux")).resolves.toEqual({
       accessToken: bait,
       subscriptionType: "pro",
+      expiresAtMs: 1_787_011_300_000,
+      hasRefreshToken: true,
     });
   });
 

--- a/packages/cli/src/claude-oauth-usage.ts
+++ b/packages/cli/src/claude-oauth-usage.ts
@@ -32,9 +32,10 @@ const FETCH_TIMEOUT_MS = 10_000;
  * Security (INV-062 class): the access token is read from the profile's OWN
  * vendor store — the keychain item on macOS, the vendor's
  * `<configDir>/.credentials.json` (documented 0600 file store) elsewhere —
- * held transiently for exactly one usage request, and never persisted,
- * logged, or included in errors. A failing endpoint yields NO snapshot
- * (fail-to-unknown) and never degrades auth readiness.
+ * held transiently for at most one usage request, and never persisted,
+ * logged, or included in errors. A known-expired refreshable credential
+ * yields NO snapshot and never degrades auth readiness; a known-fresh
+ * 401/403 remains the vendor's explicit rejection evidence.
  */
 
 /** Vendor formula, live-verified: `Claude Code-credentials-<sha256(configDir)[:8]>`. */
@@ -45,6 +46,8 @@ export function claudeOauthKeychainItem(configDir: string): string {
 export interface ClaudeOauthCredential {
   accessToken: string;
   subscriptionType: string | null;
+  expiresAtMs: number | null;
+  hasRefreshToken: boolean;
 }
 
 const execFileAsync = promisify(execFile);
@@ -119,10 +122,28 @@ export function parseClaudeOauthCredential(raw: string): ClaudeOauthCredential |
       accessToken: token,
       subscriptionType:
         typeof body["subscriptionType"] === "string" ? body["subscriptionType"] : null,
+      expiresAtMs:
+        typeof body["expiresAt"] === "number" && Number.isFinite(body["expiresAt"])
+          ? body["expiresAt"]
+          : null,
+      hasRefreshToken: typeof body["refreshToken"] === "string" && body["refreshToken"].length > 0,
     };
   } catch {
     return null;
   }
+}
+
+const VENDOR_REFRESH_REQUIRED_DETAIL =
+  "OAuth access token is not proven fresh; Claude Code owns refresh on a real run before quota can be read";
+
+/** Expiry and refresh-token PRESENCE are the only refresh metadata retained.
+ * The refresh token itself never leaves the vendor credential body (INV-062). */
+function needsVendorRefresh(credential: ClaudeOauthCredential, observedAt: Date): boolean {
+  return (
+    credential.hasRefreshToken &&
+    credential.expiresAtMs !== null &&
+    credential.expiresAtMs <= observedAt.getTime()
+  );
 }
 
 /** Pure mapping of the oauth/usage response onto QuotaSnapshot (testable). */
@@ -246,9 +267,10 @@ async function fetchUsageDefault(accessToken: string): Promise<unknown> {
     },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
   });
-  // A 401/403 from an endpoint called with THIS subject's own access token is
-  // the vendor stating the credential is no longer honored — the one live
-  // liveness fact the daemon gets for free, without spending a run's quota.
+  // A 401/403 is tagged as the vendor rejecting the presented access token.
+  // The caller owns the credential-expiry context: a token known to have
+  // expired while refreshable is awaiting Claude Code's vendor-owned refresh,
+  // not evidence that the account itself was revoked.
   if (res.status === 401 || res.status === 403) {
     throw Object.assign(new Error(`oauth/usage responded ${res.status}`), {
       quotaAbsenceReason: "auth_revoked" as QuotaAbsence["reason"],
@@ -295,8 +317,10 @@ function claudeOauthAbsence(
  * a null credential is not_logged_in (on macOS the keychain read cannot tell
  * a missing item from an unavailable keychain, so its detail states both; off
  * macOS a missing credential file IS the vendor's logged-out state), a store
- * read fault is the tagged reason it carries, and a fetch refusal is
- * refresh_failed. Absence is stated, never inferred. */
+ * read fault is the tagged reason it carries, an expired refreshable token
+ * waits for Claude Code's vendor-owned refresh, and a fetch refusal is
+ * refresh_failed unless a known-fresh credential is explicitly rejected.
+ * Absence is stated, never inferred. */
 export async function refreshClaudeOauthUsageQuota(
   deps: Partial<ClaudeOauthUsageDeps> = {},
 ): Promise<QuotaRefreshResult> {
@@ -354,6 +378,18 @@ export async function refreshClaudeOauthUsageQuota(
       );
       continue;
     }
+    const beforeRequest = now();
+    if (needsVendorRefresh(credential, beforeRequest)) {
+      absences.push(
+        claudeOauthAbsence(
+          candidate.subjectId,
+          "refresh_failed",
+          VENDOR_REFRESH_REQUIRED_DETAIL,
+          beforeRequest,
+        ),
+      );
+      continue;
+    }
     try {
       const usage = await fetchUsage(credential.accessToken);
       const snapshot = parseClaudeOauthUsage(
@@ -376,18 +412,29 @@ export async function refreshClaudeOauthUsageQuota(
           ),
         );
     } catch (error) {
-      // The fetch path carries its own typed reasons for a rejected credential
+      // The fetch path carries typed reasons for a rejected presented token
       // (auth_revoked) and a throttled poll (rate_limited, with the vendor's
-      // Retry-After floor when known); anything untagged stays an undiagnosed
-      // refresh failure.
+      // Retry-After floor when known). A refreshable credential whose freshness
+      // cannot be proven at rejection time waits for Claude Code's vendor-owned
+      // refresh instead of condemning the row. Anything untagged stays an
+      // undiagnosed refresh failure.
       const tagged = (error as { quotaAbsenceReason?: QuotaAbsence["reason"] })?.quotaAbsenceReason;
       const retryAfterMs = (error as { retryAfterMs?: number | null })?.retryAfterMs;
+      const observedAt = now();
+      const rejectedWithoutFreshnessProof =
+        tagged === "auth_revoked" &&
+        credential.hasRefreshToken &&
+        (credential.expiresAtMs === null || needsVendorRefresh(credential, observedAt));
       absences.push({
         ...claudeOauthAbsence(
           candidate.subjectId,
-          tagged ?? "refresh_failed",
-          error instanceof Error ? error.message : String(error),
-          now(),
+          rejectedWithoutFreshnessProof ? "refresh_failed" : (tagged ?? "refresh_failed"),
+          rejectedWithoutFreshnessProof
+            ? VENDOR_REFRESH_REQUIRED_DETAIL
+            : error instanceof Error
+              ? error.message
+              : String(error),
+          observedAt,
         ),
         ...(typeof retryAfterMs === "number" && retryAfterMs >= 0
           ? { retry_after_ms: Math.round(retryAfterMs) }

--- a/packages/orchestrator/src/credential-profiles.test.ts
+++ b/packages/orchestrator/src/credential-profiles.test.ts
@@ -836,6 +836,12 @@ describe("vendor credential observation (honest profile verification)", () => {
     observed_at: "2026-07-17T12:00:00Z",
   } as const;
 
+  const awaitingVendorRefresh = {
+    ...revoked,
+    reason: "refresh_failed",
+    detail: "OAuth access token expired; Claude Code must refresh it on a real run",
+  } as const;
+
   it("reads a successful authenticated poll as the vendor honoring the credential", () => {
     expect(
       vendorCredentialObservation(
@@ -910,6 +916,18 @@ describe("vendor credential observation (honest profile verification)", () => {
 
   it("leaves the status untouched when the poller has no verdict", () => {
     expect(withVendorCredentialObservation(local, null)).toEqual(local);
+  });
+
+  it("keeps an expired-refreshable profile locally passed and admissible", () => {
+    const observation = vendorCredentialObservation(
+      { snapshots: [], absences: [awaitingVendorRefresh] },
+      "claude",
+      "work",
+    );
+    expect(observation).toBeNull();
+    const status = withVendorCredentialObservation(local, observation);
+    expect(status).toEqual(local);
+    expect(profileStatusAdmits({ credential_kind: "config_dir_login" }, status)).toBe(true);
   });
 
   it("lets a rejection outrank a cached success, and refuses the profile", () => {
@@ -988,6 +1006,23 @@ describe("run admission reads the vendor's verdict, not just the local store", (
         harnessId: "claude",
         probe: locallyPassing,
         quota: { snapshots: [], absences: [] },
+      }),
+    ).toBe("available");
+  });
+
+  it("still admits a locally-passing profile whose idle token awaits vendor refresh", async () => {
+    const awaitingVendorRefresh = {
+      ...revoked,
+      reason: "refresh_failed" as const,
+      detail: "OAuth access token expired; Claude Code must refresh it on a real run",
+    };
+    expect(
+      await selectedProfileAvailability({
+        registry: [work],
+        profileId: "work",
+        harnessId: "claude",
+        probe: locallyPassing,
+        quota: { snapshots: [], absences: [awaitingVendorRefresh] },
       }),
     ).toBe("available");
   });


### PR DESCRIPTION
A 401 or 403 from Claude's oauth/usage endpoint was classified as auth_revoked even when the saved access token was expired or its freshness was unknown and Claude Code still held a refresh token. That downgraded a locally valid profile to Verification failed and removed it from routing, although Claude Code owns refresh on real use.

This change retains only non-secret expiry and refresh-token-presence metadata. It skips the quota request for a known-expired refreshable token and maps unknown-expiry or during-request-expiry rejections to the existing refresh_failed absence. A positively fresh rejection and a token without refresh capability retain the conservative auth_revoked verdict. Refresh tokens are never projected, login and credential refresh are not invoked, and existing 429 Retry-After pacing and sibling short-circuit behavior are unchanged.

Verified at 574711fa549e503079b917259394e9388104e1e4: pnpm release:verify:node completed with exit 0, 340 test files passed and 4 skipped, 4,539 tests passed and 11 skipped, all 140 generated schemas and repository integrity checks passed, and the canary completed 42/42. An isolated protocol-3 candidate-daemon E2E reported the fixture profile as available, passed, and local_store, with exactly one refresh_failed absence, no snapshot, and zero auth_revoked absences. The exact build SHA was verified and every disposable process was stopped.

The companion consumer/UI change is https://github.com/razzant/ouroboros/pull/373. This PR alone corrects the false auth verdict; existing clients may continue showing a generic no-live-reading message until their projection is updated. It includes a patch changeset but does not publish a release.
