### PR TITLE
release: add one-time v3.9.1 review waiver

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,11 @@ on:
         required: true
         type: string
       review_attestation_b64:
-        description: Base64 signed schema-v6 full-context owner-review attestation (Cursor operator panel); required for publish unless an exact version-scoped v3.8.0, v3.8.1, v3.8.2, or v3.9.0 waiver applies
+        description: Base64 signed schema-v6 full-context owner-review attestation (Cursor operator panel); required for publish unless an exact version-scoped v3.8.0, v3.8.1, v3.8.2, v3.9.0, or v3.9.1 waiver applies
         required: false
         type: string
       waive_cursor_review:
-        description: Version-scoped owner waiver for the v3.8.1 or v3.8.2 Cursor review attestation only; requires an empty review attestation and both signed runtime manifests
+        description: Version-scoped owner waiver for the v3.8.1, v3.8.2, or v3.9.1 Cursor review attestation only; requires an empty review attestation and both signed runtime manifests
         required: false
         type: boolean
         default: false
@@ -776,7 +776,7 @@ jobs:
           # artifact (owner normally signs it offline). Publish either ships
           # only the OWNER-SIGNED manifest after fail-closed verification
           # against the PROMOTED candidate closure. The v3.8.0/v3.9.0 waiver
-          # omits both runtime manifests; the v3.8.1/v3.8.2 review-only waiver
+          # omits both runtime manifests; the v3.8.1/v3.8.2/v3.9.1 review-only waiver
           # still requires and ships both owner-signed manifests.
           if [ "$RELEASE_MODE_INPUT" = publish ]; then
             if [ "$SKIP_CUSTOM_ED25519_INPUT" != true ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Release history for Claudexor. The current version is declared in the root
   is fresh. Known-expired refreshable tokens skip the usage request, while an
   unknown-expiry 401/403 is reported as the typed `refresh_failed` quota
   absence instead of falsely downgrading the account to `auth_revoked`.
+  Publication uses the owner-approved one-release `waive_cursor_review`
+  exception after the required Fable subagent tier disappeared from the live
+  Cursor catalog; both owner-signed runtime manifests and every other release,
+  notarization, and provenance gate remain required, and no formal Cursor
+  attestation is claimed.
 - **v3.9.0** (2026-08-29): quota polling is paced per vendor lane with a
   persisted Retry-After floor (a 429 or restart no longer amplifies vendor
   traffic); foreground quota refreshes honor vendor cooldowns and disclose

--- a/docs/CHECKLISTS.md
+++ b/docs/CHECKLISTS.md
@@ -368,17 +368,20 @@ pnpm test
   DMG/ZIP signing and notarization, npm publication, SBOMs, GitHub artifact
   provenance, and npm provenance remain required. Every other version and the
   default `false` path retain the normal schema-v6 and signed-manifest gates.
-- One-release review-only exceptions for 3.8.1 and 3.8.2: the owner-authorized
-  publish may set `waive_cursor_review: true` for either exact version. The
+- One-release review-only exceptions for 3.8.1, 3.8.2, and 3.9.1: the
+  owner-authorized publish may set `waive_cursor_review: true` for those exact
+  versions. The
   3.8.1 exception covered unavailable Cursor Fable/Sol lanes; the 3.8.2
   exception avoids repeating full-context review already completed during its
-  release work in a different execution setup. The review input must be empty,
+  release work in a different execution setup. The 3.9.1 exception records the
+  owner's 2026-08-30 acceleration decision after the exact Fable slot was absent
+  from the live Cursor subagent catalog. The review input must be empty,
   both owner-signed runtime manifests must be supplied and verified, and the
   final assets must omit only `REVIEW_ATTESTATION.json`. This does not create or
   claim a formal Cursor review; exact candidate provenance, signed/notarized app
   bytes, both runtime signatures, SBOMs, npm/GitHub provenance, and every other
   release gate still apply. The verifier rejects this waiver for all versions
-  except 3.8.1 and 3.8.2 and rejects combining it with
+  except 3.8.1, 3.8.2, and 3.9.1 and rejects combining it with
   `skip_custom_ed25519`.
 - The shared engine closure remains one artifact and one signed authority for
   app updates and host embedding. Its archive entries are only regular files
@@ -392,7 +395,7 @@ pnpm test
   full Node toolchain; POSIX local harness installation additionally proves the
   exact adjacent npm entrypoint without PATH fallback. A Windows support claim has a native
   extract/probe/handshake/graceful-stop smoke receipt.
-- Except for the explicit 3.8.0, 3.8.1, 3.8.2, and 3.9.0 waivers above, the publish
+- Except for the explicit 3.8.0, 3.8.1, 3.8.2, 3.9.0, and 3.9.1 waivers above, the publish
   input is an annotated stable tag on exact `origin/main` plus a signed schema-v6
   attestation. It binds the candidate SHA/tree/version, exact
   full-gate receipt, sealed evidence manifest/diff/wave, and the two required

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -271,12 +271,14 @@ quota-throttling/cursor-belt release (no attestation wave is run for it). The
 verifier rejects this waiver for every other version, and the
 default `false` path retains the normal schema-v6 and signed-manifest gates.
 
-Package versions 3.8.1 and 3.8.2 each have a separate, one-release owner waiver
-for the Cursor review attestation. The 3.8.1 exception covered unavailable
+Package versions 3.8.1, 3.8.2, and 3.9.1 each have a separate, one-release owner
+waiver for the Cursor review attestation. The 3.8.1 exception covered unavailable
 Cursor Fable and Sol provider lanes; the 3.8.2 exception avoids repeating a
 full-context review already completed during its release work in a different
-execution setup. A publish may set `waive_cursor_review: true` only for those
-exact versions, with `review_attestation_b64` empty and both owner-signed runtime
+execution setup; the 3.9.1 exception is the owner's 2026-08-30 acceleration
+decision after the exact Fable slot disappeared from the live Cursor subagent
+catalog. A publish may set `waive_cursor_review: true` only for those exact
+versions, with `review_attestation_b64` empty and both owner-signed runtime
 manifest inputs present and validly base64-encoded. This waiver omits only
 `REVIEW_ATTESTATION.json`; the candidate run, exact tag and SHA, artifact
 provenance, signed runtime and remote-runtime manifests, SBOMs, signing,

--- a/packages/cli/src/release-input.test.ts
+++ b/packages/cli/src/release-input.test.ts
@@ -324,7 +324,7 @@ describe("version-scoped Cursor review waiver", () => {
     WAIVE_CURSOR_REVIEW_INPUT: "true",
   };
 
-  it.each(["3.8.1", "3.8.2"])(
+  it.each(["3.8.1", "3.8.2", "3.9.1"])(
     "accepts v%s with an empty review attestation and both runtime inputs",
     (version) => {
       withPublishFixture(version, (fixture) => {
@@ -395,7 +395,7 @@ describe("version-scoped Cursor review waiver", () => {
 
       expect(result.status).toBe(1);
       expect(result.stderr).toContain(
-        "release input rejected: waive_cursor_review is authorized only for package versions 3.8.1 and 3.8.2",
+        "release input rejected: waive_cursor_review is authorized only for package versions 3.8.1, 3.8.2, and 3.9.1",
       );
     });
   });

--- a/scripts/release-workflow-check.mjs
+++ b/scripts/release-workflow-check.mjs
@@ -132,8 +132,8 @@ for (const [label, pattern] of [
     /skip_custom_ed25519:\s*\n\s*description:[^\n]*v3\.8\.0 or v3\.9\.0 publish only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
   ],
   [
-    "the v3.8.1/v3.8.2 Cursor review waiver is an explicit boolean defaulting false",
-    /waive_cursor_review:\s*\n\s*description:[^\n]*v3\.8\.1 or v3\.8\.2 Cursor review attestation only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
+    "the v3.8.1/v3.8.2/v3.9.1 Cursor review waiver is an explicit boolean defaulting false",
+    /waive_cursor_review:\s*\n\s*description:[^\n]*v3\.8\.1, v3\.8\.2, or v3\.9\.1 Cursor review attestation only[^\n]*\n\s*required:\s*false\n\s*type:\s*boolean\n\s*default:\s*false/,
   ],
   [
     "custom Ed25519 waiver input is projected into one shell-only environment variable",
@@ -665,8 +665,8 @@ for (const [label, pattern] of [
     /skipCustomEd25519\s*&&\s*!\["3\.8\.0",\s*"3\.9\.0"\]\.includes\(version\)/,
   ],
   [
-    "Cursor review waiver is permanently pinned to package versions 3.8.1 and 3.8.2",
-    /waiveCursorReview\s*&&\s*!\["3\.8\.1",\s*"3\.8\.2"\]\.includes\(version\)/,
+    "Cursor review waiver is permanently pinned to package versions 3.8.1, 3.8.2, and 3.9.1",
+    /waiveCursorReview\s*&&\s*!\["3\.8\.1",\s*"3\.8\.2",\s*"3\.9\.1"\]\.includes\(version\)/,
   ],
   [
     "Cursor review waiver requires an empty review input",
@@ -949,7 +949,7 @@ function exactCandidateAppPromotionErrors(job) {
     assembleStep,
   );
   requirePattern(
-    "v3.8.1/v3.8.2 review waiver must omit only the review attestation asset",
+    "v3.8.1/v3.8.2/v3.9.1 review waiver must omit only the review attestation asset",
     /if \[ "\$WAIVE_CURSOR_REVIEW_INPUT" = true \]; then\n\s*test ! -e "\$assets\/REVIEW_ATTESTATION\.json"/,
     assembleStep,
   );

--- a/scripts/verify-release-input.mjs
+++ b/scripts/verify-release-input.mjs
@@ -99,8 +99,8 @@ if (mode === "publish" && tag !== `v${version}`)
 if (skipCustomEd25519 && !["3.8.0", "3.9.0"].includes(version)) {
   fail(["skip_custom_ed25519 is authorized only for package versions 3.8.0 and 3.9.0"]);
 }
-if (waiveCursorReview && !["3.8.1", "3.8.2"].includes(version)) {
-  fail(["waive_cursor_review is authorized only for package versions 3.8.1 and 3.8.2"]);
+if (waiveCursorReview && !["3.8.1", "3.8.2", "3.9.1"].includes(version)) {
+  fail(["waive_cursor_review is authorized only for package versions 3.8.1, 3.8.2, and 3.9.1"]);
 }
 
 let attestationText = "";


### PR DESCRIPTION
The required Fable model disappeared from the live Cursor subagent catalog, so the owner explicitly authorized accelerating this release without manufacturing a formal review attestation. This version-scoped exception applies only to 3.9.1. It keeps the review input empty, still requires both owner-signed runtime manifests, and preserves the exact candidate, provenance, signing, notarization, SBOM, npm, and GitHub release gates. Focused release-input tests pass 29/29; workflow integrity, docs truth, formatting, and diff checks are green.