### PR TITLE
Refresh Claude OAuth before quota reads

### DIFF
--- a/.changeset/calm-claude-quota-refresh.md
+++ b/.changeset/calm-claude-quota-refresh.md
@@ -1,0 +1,6 @@
+---
+"@claudexor/cli": patch
+"@claudexor/harness-claude": patch
+---
+
+Refresh expired Claude subscription credentials through Claude Code before reading quota, without sending a model prompt or taking custody of refresh tokens.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3220,10 +3220,15 @@ code touching one of these areas must honor it or change it explicitly here.
   access token (never the refresh token itself) —
   every claude `config_dir_login` row (subject = its profile id), plus the
   legacy default native dir (subject null) only while that store is
-  UNMIGRATED. A known-expired refreshable token skips the request and yields a
-  typed `refresh_failed` absence. A refreshable token with unknown expiry is
-  still probed, but a 401/403 cannot prove revocation; it and a rejection after
-  a known-fresh token crosses expiry during the bounded request yield the same
+  UNMIGRATED. A refreshable token that is expired or within Claude Code's
+  five-minute refresh window first wakes the vendor's documented, prompt-free
+  `mcp serve` lifecycle in the exact profile environment. No MCP frame or model
+  prompt is sent; Claude Code owns its refresh lock, token rotation, and store
+  write while Claudexor observes expiry metadata only, then re-reads the access
+  token for the bounded usage request. A still-valid token remains a fallback
+  when the proactive wake fails; an expired token yields a typed
+  `refresh_failed` absence. A refreshable token with unknown expiry is still
+  probed, but a 401/403 cannot prove revocation and yields the same
   `refresh_failed` absence. Only a token proven fresh at rejection remains typed
   `auth_revoked`; a token without refresh capability retains that conservative
   real-response verdict. Other endpoint failures yield NO snapshot and no auth

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -194,13 +194,18 @@ persisted, logged, or included in errors — plus only its expiry timestamp and
 whether a refresh token exists (the refresh token itself is never projected).
 The endpoint returns proactive
 five_hour/seven_day/per-model utilization attributed to the profile
-(`subject_id`). A known-expired refreshable idle token skips the request and
-fails quota to unknown. If expiry is absent, the bounded request may still
-succeed; a 401/403 for that refreshable token, or after a known-fresh token
-crosses expiry during the request, also fails quota to unknown because freshness
-was not proven at rejection time. Claude Code owns refresh on a real use. Only a
-token proven fresh at rejection remains vendor revocation evidence and may
-degrade auth readiness; a token without refresh capability retains that
+(`subject_id`). Before probing a refreshable token that is expired or inside
+Claude Code's five-minute refresh window, Claudexor starts the vendor's
+documented, prompt-free `claude mcp serve` lifecycle in that exact profile
+environment, sends no MCP request, and waits for Claude Code to publish a fresh
+expiry under its own credential lock. No model request or inference quota is
+used, and Claudexor never reads the refresh token or writes the vendor store.
+If the proactive wake fails while the old access token is still valid, the
+bounded usage request may use that token; an expired token remains a typed
+`refresh_failed` absence. If expiry is absent, the bounded request may still
+succeed, but a 401/403 cannot prove revocation and also yields `refresh_failed`.
+Only a token proven fresh at rejection remains vendor revocation evidence and
+may degrade auth readiness; a token without refresh capability retains that
 conservative real-response behavior. The status-line collector
 stays as a secondary source: an explicit
 `claudexor plugin install claude` composes it with an existing user

--- a/packages/cli/src/claude-oauth-usage.test.ts
+++ b/packages/cli/src/claude-oauth-usage.test.ts
@@ -2,6 +2,7 @@ import { rmSync } from "node:fs";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED } from "@claudexor/harness-claude";
 import { afterAll, describe, expect, it } from "vitest";
 import {
   claudeOauthKeychainItem,
@@ -207,12 +208,17 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     "fails a rejected refreshable credential with unknown expiry to refresh_failed (%i)",
     async (status) => {
       let fetches = 0;
+      let refreshes = 0;
       const result = await refreshClaudeOauthUsageQuota({
         readCredential: async () =>
           oauthCredential({
             expiresAtMs: null,
             hasRefreshToken: true,
           }),
+        refreshCredential: async () => {
+          refreshes += 1;
+          throw new Error("unknown expiry must not invoke the vendor refresh wake");
+        },
         fetchUsage: async () => {
           fetches += 1;
           throw Object.assign(new Error(`oauth/usage responded ${status}`), {
@@ -222,14 +228,47 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
         now: () => new Date("2026-07-18T00:00:00Z"),
       });
       expect(fetches).toBe(1);
+      expect(refreshes).toBe(0);
       const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
       expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
-      expect(nativeAbsence?.detail).toContain("Claude Code owns refresh");
+      expect(nativeAbsence?.detail).toContain("freshness is unknown");
       expect(nativeAbsence?.detail).not.toContain(String(status));
     },
   );
 
-  it("skips oauth/usage for an already-expired refreshable credential", async () => {
+  it("automatically refreshes an expired credential before reading quota", async () => {
+    let fetches = 0;
+    let refreshes = 0;
+    const result = await refreshClaudeOauthUsageQuota({
+      readCredential: async () =>
+        oauthCredential({
+          accessToken: "access-secret-needle",
+          expiresAtMs: Date.parse("2026-07-17T23:59:59Z"),
+          hasRefreshToken: true,
+        }),
+      refreshCredential: async () => {
+        refreshes += 1;
+        return oauthCredential({
+          accessToken: "fresh-token",
+          expiresAtMs: Date.parse("2026-07-18T08:00:00Z"),
+          hasRefreshToken: true,
+        });
+      },
+      fetchUsage: async (accessToken) => {
+        fetches += 1;
+        expect(accessToken).toBe("fresh-token");
+        return LIVE_USAGE;
+      },
+      now: () => new Date("2026-07-18T00:00:00Z"),
+    });
+    expect(refreshes).toBe(1);
+    expect(fetches).toBe(1);
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.absences ?? []).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain("access-secret-needle");
+  });
+
+  it("keeps quota unknown when automatic refresh fails, without exposing the access token", async () => {
     let fetches = 0;
     const result = await refreshClaudeOauthUsageQuota({
       readCredential: async () =>
@@ -238,42 +277,123 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
           expiresAtMs: Date.parse("2026-07-17T23:59:59Z"),
           hasRefreshToken: true,
         }),
+      refreshCredential: async () => {
+        throw new Error(
+          "Claude Code's automatic OAuth refresh did not publish a fresh access token",
+        );
+      },
       fetchUsage: async () => {
         fetches += 1;
-        throw new Error("should not be called");
+        return LIVE_USAGE;
       },
       now: () => new Date("2026-07-18T00:00:00Z"),
     });
     expect(fetches).toBe(0);
     const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
     expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
-    expect(nativeAbsence?.detail).toContain("Claude Code owns refresh");
+    expect(nativeAbsence?.detail).toContain("automatic OAuth refresh");
     expect(nativeAbsence?.detail).not.toContain("access-secret-needle");
   });
 
+  it("refreshes proactively inside Claude Code's five-minute window", async () => {
+    let refreshes = 0;
+    const result = await refreshClaudeOauthUsageQuota({
+      readCredential: async () =>
+        oauthCredential({
+          expiresAtMs: Date.parse("2026-07-18T00:04:00Z"),
+          hasRefreshToken: true,
+        }),
+      refreshCredential: async () => {
+        refreshes += 1;
+        return oauthCredential({ expiresAtMs: Date.parse("2026-07-18T08:00:00Z") });
+      },
+      fetchUsage: async () => LIVE_USAGE,
+      now: () => new Date("2026-07-18T00:00:00Z"),
+    });
+    expect(refreshes).toBe(1);
+    expect(result.snapshots).toHaveLength(1);
+  });
+
+  it("falls back to a still-valid near-expiry token when the proactive wake fails", async () => {
+    let fetches = 0;
+    const result = await refreshClaudeOauthUsageQuota({
+      readCredential: async () =>
+        oauthCredential({
+          accessToken: "still-valid",
+          expiresAtMs: Date.parse("2026-07-18T00:04:00Z"),
+          hasRefreshToken: true,
+        }),
+      refreshCredential: async () => {
+        throw new Error("vendor helper exited early");
+      },
+      fetchUsage: async (accessToken) => {
+        fetches += 1;
+        expect(accessToken).toBe("still-valid");
+        return LIVE_USAGE;
+      },
+      now: () => new Date("2026-07-18T00:00:00Z"),
+    });
+    expect(fetches).toBe(1);
+    expect(result.snapshots).toHaveLength(1);
+    expect(result.absences ?? []).toEqual([]);
+  });
+
   it.each([401, 403])(
-    "reclassifies %i when the refreshable credential expires during the request",
+    "keeps a token that expires during a failed proactive refresh out of auth_revoked (%i)",
     async (status) => {
-      const times = [new Date("2026-07-18T00:00:00.000Z"), new Date("2026-07-18T00:00:00.002Z")];
+      let fetches = 0;
+      const times = ["2026-07-18T00:00:00Z", "2026-07-18T00:00:00Z", "2026-07-18T00:05:00Z"];
       const result = await refreshClaudeOauthUsageQuota({
         readCredential: async () =>
           oauthCredential({
-            expiresAtMs: Date.parse("2026-07-18T00:00:00.001Z"),
+            accessToken: "access-secret-needle",
+            expiresAtMs: Date.parse("2026-07-18T00:04:00Z"),
             hasRefreshToken: true,
           }),
+        refreshCredential: async () => {
+          throw new Error("vendor helper exited early");
+        },
         fetchUsage: async () => {
+          fetches += 1;
           throw Object.assign(new Error(`oauth/usage responded ${status}`), {
             quotaAbsenceReason: "auth_revoked" as const,
           });
         },
-        now: () => times.shift() ?? new Date("2026-07-18T00:00:00.002Z"),
+        now: () => new Date(times.shift() ?? "2026-07-18T00:05:00Z"),
       });
+      expect(fetches).toBe(1);
       const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
       expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
-      expect(nativeAbsence?.detail).toContain("Claude Code owns refresh");
+      expect(nativeAbsence?.detail).toContain("freshness is unknown");
       expect(nativeAbsence?.detail).not.toContain(String(status));
+      expect(nativeAbsence?.detail).not.toContain("access-secret-needle");
     },
   );
+
+  it("never falls back while refresh-helper termination remains unconfirmed", async () => {
+    let fetches = 0;
+    const result = await refreshClaudeOauthUsageQuota({
+      readCredential: async () =>
+        oauthCredential({
+          expiresAtMs: Date.parse("2026-07-18T00:04:00Z"),
+          hasRefreshToken: true,
+        }),
+      refreshCredential: async () => {
+        throw Object.assign(new Error("vendor helper termination could not be confirmed"), {
+          code: CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED,
+        });
+      },
+      fetchUsage: async () => {
+        fetches += 1;
+        return LIVE_USAGE;
+      },
+      now: () => new Date("2026-07-18T00:00:00Z"),
+    });
+    expect(fetches).toBe(0);
+    const nativeAbsence = result.absences?.find((a) => a.subject.subject_id === null);
+    expect(nativeAbsence).toMatchObject({ reason: "refresh_failed" });
+    expect(nativeAbsence?.detail).toContain("termination could not be confirmed");
+  });
 
   it("retains the real-response auth verdict for an expired token without a refresh token", async () => {
     let fetches = 0;

--- a/packages/cli/src/claude-oauth-usage.ts
+++ b/packages/cli/src/claude-oauth-usage.ts
@@ -7,8 +7,12 @@ import { loadConfig } from "@claudexor/config";
 import type { QuotaRefreshResult } from "@claudexor/daemon";
 import {
   canonicalProfileConfigDir,
+  CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED,
+  claudeNativeEnv,
+  claudeOauthAccessTokenIsFresh,
   claudeQuotaModelAliases,
   defaultNativeClaudeConfigDir,
+  refreshClaudeNativeAuth,
 } from "@claudexor/harness-claude";
 import {
   QuotaSnapshot as QuotaSnapshotSchema,
@@ -33,9 +37,10 @@ const FETCH_TIMEOUT_MS = 10_000;
  * vendor store — the keychain item on macOS, the vendor's
  * `<configDir>/.credentials.json` (documented 0600 file store) elsewhere —
  * held transiently for at most one usage request, and never persisted,
- * logged, or included in errors. A known-expired refreshable credential
- * yields NO snapshot and never degrades auth readiness; a known-fresh
- * 401/403 remains the vendor's explicit rejection evidence.
+ * logged, or included in errors. Before probing a known-expired or near-expiry
+ * refreshable credential, Claudexor wakes Claude Code's prompt-free MCP server
+ * and lets the vendor refresh its own store; a known-fresh 401/403 remains the
+ * vendor's explicit rejection evidence.
  */
 
 /** Vendor formula, live-verified: `Claude Code-credentials-<sha256(configDir)[:8]>`. */
@@ -134,7 +139,9 @@ export function parseClaudeOauthCredential(raw: string): ClaudeOauthCredential |
 }
 
 const VENDOR_REFRESH_REQUIRED_DETAIL =
-  "OAuth access token is not proven fresh; Claude Code owns refresh on a real run before quota can be read";
+  "OAuth access token freshness is unknown; Claude Code did not expose a refreshable expiry for quota reading";
+const VENDOR_REFRESH_FAILED_DETAIL =
+  "Claude Code's automatic OAuth refresh did not publish a fresh access token before quota reading";
 
 /** Expiry and refresh-token PRESENCE are the only refresh metadata retained.
  * The refresh token itself never leaves the vendor credential body (INV-062). */
@@ -142,8 +149,34 @@ function needsVendorRefresh(credential: ClaudeOauthCredential, observedAt: Date)
   return (
     credential.hasRefreshToken &&
     credential.expiresAtMs !== null &&
-    credential.expiresAtMs <= observedAt.getTime()
+    !claudeOauthAccessTokenIsFresh(credential.expiresAtMs, observedAt.getTime())
   );
+}
+
+export type ClaudeOauthCredentialRefresher = (
+  configDir: string,
+  platform: NodeJS.Platform,
+  readCredential: typeof readClaudeOauthCredential,
+) => Promise<ClaudeOauthCredential | null>;
+
+/** Keep refresh-token custody and store writes inside Claude Code. Claudexor
+ * wakes the vendor's prompt-free MCP server, observes expiry metadata, then
+ * re-reads the access token only after the vendor has published fresh state. */
+async function refreshCredentialDefault(
+  configDir: string,
+  platform: NodeJS.Platform,
+  readCredential: typeof readClaudeOauthCredential,
+): Promise<ClaudeOauthCredential | null> {
+  const refreshed = await refreshClaudeNativeAuth(
+    claudeNativeEnv(undefined, configDir),
+    async () => (await readCredential(configDir, platform))?.expiresAtMs ?? null,
+  );
+  if (!refreshed) throw taggedRefreshFailure(VENDOR_REFRESH_FAILED_DETAIL);
+  const credential = await readCredential(configDir, platform);
+  if (credential === null || !claudeOauthAccessTokenIsFresh(credential.expiresAtMs)) {
+    throw taggedRefreshFailure(VENDOR_REFRESH_FAILED_DETAIL);
+  }
+  return credential;
 }
 
 /** Pure mapping of the oauth/usage response onto QuotaSnapshot (testable). */
@@ -223,6 +256,7 @@ function scopedConstraints(value: unknown): Array<Record<string, unknown> | null
 
 export interface ClaudeOauthUsageDeps {
   readCredential: typeof readClaudeOauthCredential;
+  refreshCredential: ClaudeOauthCredentialRefresher;
   fetchUsage: (accessToken: string) => Promise<unknown>;
   now: () => Date;
   platform: NodeJS.Platform;
@@ -317,14 +351,15 @@ function claudeOauthAbsence(
  * a null credential is not_logged_in (on macOS the keychain read cannot tell
  * a missing item from an unavailable keychain, so its detail states both; off
  * macOS a missing credential file IS the vendor's logged-out state), a store
- * read fault is the tagged reason it carries, an expired refreshable token
- * waits for Claude Code's vendor-owned refresh, and a fetch refusal is
- * refresh_failed unless a known-fresh credential is explicitly rejected.
+ * read fault is the tagged reason it carries, an expired refreshable token is
+ * automatically refreshed by Claude Code without inference, and a fetch
+ * refusal is refresh_failed unless a known-fresh credential is explicitly rejected.
  * Absence is stated, never inferred. */
 export async function refreshClaudeOauthUsageQuota(
   deps: Partial<ClaudeOauthUsageDeps> = {},
 ): Promise<QuotaRefreshResult> {
   const readCredential = deps.readCredential ?? readClaudeOauthCredential;
+  const refreshCredential = deps.refreshCredential ?? refreshCredentialDefault;
   const fetchUsage = deps.fetchUsage ?? fetchUsageDefault;
   const now = deps.now ?? (() => new Date());
   const platform = deps.platform ?? process.platform;
@@ -378,17 +413,40 @@ export async function refreshClaudeOauthUsageQuota(
       );
       continue;
     }
-    const beforeRequest = now();
+    let beforeRequest = now();
     if (needsVendorRefresh(credential, beforeRequest)) {
-      absences.push(
-        claudeOauthAbsence(
-          candidate.subjectId,
-          "refresh_failed",
-          VENDOR_REFRESH_REQUIRED_DETAIL,
-          beforeRequest,
-        ),
-      );
-      continue;
+      const originalCredentialStillValid =
+        credential.expiresAtMs !== null && credential.expiresAtMs > beforeRequest.getTime();
+      try {
+        const refreshed = await refreshCredential(candidate.configDir, platform, readCredential);
+        if (
+          refreshed === null ||
+          !claudeOauthAccessTokenIsFresh(refreshed.expiresAtMs, now().getTime())
+        ) {
+          throw taggedRefreshFailure(VENDOR_REFRESH_FAILED_DETAIL);
+        }
+        credential = refreshed;
+        beforeRequest = now();
+      } catch (error) {
+        // The five-minute wake is proactive. If Claude Code cannot refresh yet
+        // but the presented access token is still unexpired, use that proven
+        // token for this bounded request rather than hiding an available quota.
+        const terminationUnconfirmed =
+          (error as { code?: unknown })?.code === CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED;
+        if (originalCredentialStillValid && !terminationUnconfirmed) {
+          beforeRequest = now();
+        } else {
+          absences.push(
+            claudeOauthAbsence(
+              candidate.subjectId,
+              "refresh_failed",
+              error instanceof Error ? error.message : VENDOR_REFRESH_FAILED_DETAIL,
+              now(),
+            ),
+          );
+          continue;
+        }
+      }
     }
     try {
       const usage = await fetchUsage(credential.accessToken);

--- a/packages/harness-claude/src/auth-refresh.test.ts
+++ b/packages/harness-claude/src/auth-refresh.test.ts
@@ -1,0 +1,180 @@
+import type { SpawnOptions } from "@claudexor/core";
+import { describe, expect, it } from "vitest";
+import {
+  CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED,
+  CLAUDE_OAUTH_REFRESH_SKEW_MS,
+  claudeOauthAccessTokenIsFresh,
+  refreshClaudeNativeAuth,
+} from "./auth-refresh.js";
+
+describe("Claude native OAuth refresh wake", () => {
+  it("uses the vendor five-minute refresh window", () => {
+    const now = Date.parse("2026-08-30T07:00:00Z");
+    expect(claudeOauthAccessTokenIsFresh(null, now)).toBe(false);
+    expect(claudeOauthAccessTokenIsFresh(now + CLAUDE_OAUTH_REFRESH_SKEW_MS, now)).toBe(false);
+    expect(claudeOauthAccessTokenIsFresh(now + CLAUDE_OAUTH_REFRESH_SKEW_MS + 1, now)).toBe(true);
+  });
+
+  it("holds a prompt-free vendor MCP process until expiry metadata advances", async () => {
+    let captured:
+      | {
+          cmd: string;
+          args: string[];
+          options: SpawnOptions;
+        }
+      | undefined;
+    let stdinEnded = false;
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const spawn = async function* (cmd: string, args: string[], options: SpawnOptions = {}) {
+      captured = { cmd, args, options };
+      options.onSpawn?.({
+        write: () => {},
+        end: () => {
+          stdinEnded = true;
+          resolveClosed();
+        },
+        closed,
+      });
+      await closed;
+      yield { type: "exit" as const, code: 0, signal: null };
+    };
+    const now = Date.parse("2026-08-30T07:00:00Z");
+    const expiries = [now - 1, now + 8 * 60 * 60_000];
+
+    const refreshed = await refreshClaudeNativeAuth(
+      { CLAUDE_CONFIG_DIR: "/profiles/claude-a", ANTHROPIC_API_KEY: null },
+      async () => expiries.shift() ?? null,
+      {
+        spawn: spawn as typeof import("@claudexor/core").spawnProcess,
+        nowMs: () => now,
+        sleep: async () => {},
+        bin: "/vendor/claude",
+        cwd: process.cwd(),
+      },
+    );
+
+    expect(refreshed).toBe(true);
+    expect(captured?.cmd).toBe("/vendor/claude");
+    expect(captured?.args).toEqual(["--setting-sources", "", "mcp", "serve"]);
+    expect(captured?.args).not.toContain("-p");
+    expect(captured?.options.input).toBeUndefined();
+    expect(captured?.options.keepStdinOpen).toBe(true);
+    expect(captured?.options.env).toMatchObject({
+      CLAUDE_CONFIG_DIR: "/profiles/claude-a",
+      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+      CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1",
+    });
+    expect(stdinEnded).toBe(true);
+    expect(captured?.options.abortSignal?.aborted).toBe(false);
+  });
+
+  it("returns false and reaps the exact child when it exits before refreshing", async () => {
+    let stdinEnded = false;
+    const spawn = async function* (_cmd: string, _args: string[], options: SpawnOptions = {}) {
+      options.onSpawn?.({
+        write: () => {},
+        end: () => {
+          stdinEnded = true;
+        },
+        closed: Promise.resolve(),
+      });
+      yield { type: "exit" as const, code: 1, signal: null };
+    };
+
+    const refreshed = await refreshClaudeNativeAuth({}, async () => 0, {
+      spawn: spawn as typeof import("@claudexor/core").spawnProcess,
+      nowMs: () => 10_000,
+      sleep: async () => {},
+      cwd: process.cwd(),
+    });
+
+    expect(refreshed).toBe(false);
+    expect(stdinEnded).toBe(false);
+  });
+
+  it("bounds a silent helper and aborts it after the refresh deadline", async () => {
+    let aborted = false;
+    let stdinEnded = false;
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const spawn = async function* (_cmd: string, _args: string[], options: SpawnOptions = {}) {
+      options.onSpawn?.({
+        write: () => {},
+        end: () => {
+          stdinEnded = true;
+        },
+        closed,
+      });
+      await new Promise<void>((resolve) => {
+        options.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            aborted = true;
+            resolveClosed();
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      yield { type: "exit" as const, code: null, signal: "SIGTERM" as const };
+    };
+    const times = [0, 0, 20_001];
+
+    const refreshed = await refreshClaudeNativeAuth({}, async () => 0, {
+      spawn: spawn as typeof import("@claudexor/core").spawnProcess,
+      nowMs: () => times.shift() ?? 20_001,
+      sleep: async () => {},
+      cwd: process.cwd(),
+      timeoutMs: 20_000,
+    });
+
+    expect(refreshed).toBe(false);
+    expect(stdinEnded).toBe(true);
+    expect(aborted).toBe(true);
+  });
+
+  it("fails closed when the helper process tree cannot be proven dead", async () => {
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const spawn = async function* (_cmd: string, _args: string[], options: SpawnOptions = {}) {
+      options.onSpawn?.({ write: () => {}, end: () => {}, closed });
+      await new Promise<void>((resolve) => {
+        options.abortSignal?.addEventListener(
+          "abort",
+          () => {
+            resolveClosed();
+            resolve();
+          },
+          { once: true },
+        );
+      });
+      yield { type: "exit" as const, code: null, signal: "SIGTERM" as const };
+      yield {
+        type: "termination_unconfirmed" as const,
+        rootPid: 42,
+        survivors: [43],
+        unresolved: [],
+      };
+    };
+    const now = Date.parse("2026-08-30T07:00:00Z");
+
+    await expect(
+      refreshClaudeNativeAuth({}, async () => now + 8 * 60 * 60_000, {
+        spawn: spawn as typeof import("@claudexor/core").spawnProcess,
+        nowMs: () => now,
+        sleep: async () => {},
+        cwd: process.cwd(),
+      }),
+    ).rejects.toMatchObject({
+      code: CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED,
+      message: expect.stringContaining("termination could not be confirmed"),
+    });
+  });
+});

--- a/packages/harness-claude/src/auth-refresh.ts
+++ b/packages/harness-claude/src/auth-refresh.ts
@@ -1,0 +1,114 @@
+import type { ChildStdin } from "@claudexor/core";
+import { spawnProcess } from "@claudexor/core";
+import { ensureDir, noProjectRepoRoot } from "@claudexor/util";
+import { setTimeout as sleep } from "node:timers/promises";
+import { BIN } from "./effort-probe.js";
+
+/** Claude Code refreshes OAuth access tokens inside this five-minute window. */
+export const CLAUDE_OAUTH_REFRESH_SKEW_MS = 5 * 60_000;
+const REFRESH_WAKE_TIMEOUT_MS = 20_000;
+const REFRESH_WAKE_POLL_MS = 250;
+const REFRESH_WAKE_SHUTDOWN_GRACE_MS = 500;
+export const CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED =
+  "claude_oauth_refresh_termination_unconfirmed";
+
+export function claudeOauthAccessTokenIsFresh(
+  expiresAtMs: number | null,
+  nowMs: number = Date.now(),
+): boolean {
+  return (
+    expiresAtMs !== null &&
+    Number.isFinite(expiresAtMs) &&
+    expiresAtMs > nowMs + CLAUDE_OAUTH_REFRESH_SKEW_MS
+  );
+}
+
+export interface ClaudeNativeAuthRefreshDeps {
+  spawn: typeof spawnProcess;
+  nowMs: () => number;
+  sleep: (ms: number) => Promise<void>;
+  bin: string;
+  cwd: string;
+  timeoutMs: number;
+  pollMs: number;
+}
+
+/**
+ * Wake Claude Code's own OAuth refresher without sending a prompt or making a
+ * model request. `mcp serve` is the vendor's documented, long-lived stdio
+ * command: holding stdin open gives its startup refresh time to finish under
+ * Claude Code's credential lock. Claudexor observes expiry metadata only;
+ * Claude Code remains the sole reader/writer of the refresh token and store.
+ */
+export async function refreshClaudeNativeAuth(
+  env: Record<string, string | null | undefined>,
+  readExpiresAtMs: () => Promise<number | null>,
+  overrides: Partial<ClaudeNativeAuthRefreshDeps> = {},
+): Promise<boolean> {
+  const spawn = overrides.spawn ?? spawnProcess;
+  const nowMs = overrides.nowMs ?? Date.now;
+  const wait = overrides.sleep ?? ((ms: number) => sleep(ms));
+  const bin = overrides.bin ?? BIN;
+  const cwd = overrides.cwd ?? noProjectRepoRoot();
+  const timeoutMs = overrides.timeoutMs ?? REFRESH_WAKE_TIMEOUT_MS;
+  const pollMs = overrides.pollMs ?? REFRESH_WAKE_POLL_MS;
+  ensureDir(cwd);
+
+  const controller = new AbortController();
+  let stdin: ChildStdin | null = null;
+  let childExited = false;
+  let terminationUnconfirmed = false;
+  const child = (async () => {
+    try {
+      for await (const event of spawn(bin, ["--setting-sources", "", "mcp", "serve"], {
+        cwd,
+        env: {
+          ...env,
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+          CLAUDE_CODE_SKIP_PROMPT_HISTORY: "1",
+        },
+        keepStdinOpen: true,
+        onSpawn: (io) => {
+          stdin = io;
+        },
+        abortSignal: controller.signal,
+        timeoutMs,
+        cancelSignal: "SIGTERM",
+        cancelKillDelayMs: 1_000,
+      })) {
+        if (event.type === "termination_unconfirmed") terminationUnconfirmed = true;
+        if (event.type === "exit" || event.type === "termination_unconfirmed") childExited = true;
+      }
+    } catch {
+      childExited = true;
+    }
+  })();
+
+  try {
+    const deadline = nowMs() + timeoutMs;
+    for (;;) {
+      const expiresAtMs = await readExpiresAtMs();
+      if (claudeOauthAccessTokenIsFresh(expiresAtMs, nowMs())) return true;
+      if (childExited || nowMs() >= deadline) return false;
+      await wait(pollMs);
+    }
+  } finally {
+    const activeStdin = stdin as ChildStdin | null;
+    let closedAfterEof = childExited;
+    if (activeStdin && !childExited) {
+      activeStdin.end();
+      closedAfterEof = await Promise.race([
+        activeStdin.closed.then(() => true),
+        wait(REFRESH_WAKE_SHUTDOWN_GRACE_MS).then(() => false),
+      ]);
+    }
+    if (!closedAfterEof && !childExited) controller.abort();
+    await child;
+    if (terminationUnconfirmed) {
+      throw Object.assign(
+        new Error("Claude Code OAuth refresh helper termination could not be confirmed"),
+        { code: CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED },
+      );
+    }
+  }
+}

--- a/packages/harness-claude/src/index.ts
+++ b/packages/harness-claude/src/index.ts
@@ -68,6 +68,11 @@ import {
   probeClaudeHelp,
 } from "./effort-probe.js";
 export { BIN, CLAUDE_EFFORT_SNAPSHOT } from "./effort-probe.js";
+export {
+  CLAUDE_AUTH_REFRESH_TERMINATION_UNCONFIRMED,
+  claudeOauthAccessTokenIsFresh,
+  refreshClaudeNativeAuth,
+} from "./auth-refresh.js";
 export { CLAUDE_VENDOR_CLI_VERSION } from "./vendor-cli-version.js";
 import {
   claudeAttachmentBlocks,


### PR DESCRIPTION
Claude quota polling currently stops at refresh_failed when an otherwise valid profile has an expired access token. The user then cannot see quota until Claude Code happens to run and refresh its own credential.

This change keeps refresh ownership inside Claude Code. Before reading quota for an expired or near-expiry credential, Claudexor starts the documented prompt-free `claude mcp serve` lifecycle in the exact profile environment, sends no MCP frame or model prompt, waits for Claude Code to publish fresh expiry metadata under its own lock, then re-reads the access token for the bounded usage request. Claudexor never reads the refresh token or writes the vendor credential store. A still-valid near-expiry token remains a bounded fallback if the proactive wake fails; expired and unknown-freshness cases remain honest typed absences.

Verified on the exact pinned Claude Code 2.1.165 binary with a real expired profile: expiry advanced by roughly eight hours and the subsequent quota call returned live windows without a prompt or model usage. The same candidate path restored live snapshots for all 8 Claude profiles in the embedded Ouroboros registry.

`pnpm release:verify:node` passed: 341 test files, 4,549 tests, 140 generated schemas, all documentation/integrity/workflow gates, and canary 42/42. The PR carries patch changesets for `@claudexor/cli` and `@claudexor/harness-claude`; it does not bump a release version directly.