### PR TITLE
Refresh quotas before snapshots become stale

### DIFF
--- a/.changeset/early-quota-renewal.md
+++ b/.changeset/early-quota-renewal.md
@@ -1,0 +1,6 @@
+---
+"@claudexor/daemon": patch
+"@claudexor/cli": patch
+---
+
+Request background quota renewal on the last existing poll tick before primary evidence would become stale, while preserving current-time freshness and existing vendor pacing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2313,11 +2313,16 @@ One exhaustive schema-owned trait registry classifies every source along three
 independent axes: vendor-authenticated credential evidence, the primary harness
 whose missing observation creates refresh demand, and whether a top-level
 refresher produces it. Refresh demand is computed per enabled credential
-subject and only a fresh matching primary snapshot satisfies it. Typed absence
-is still a successful, displayable observation, but retains soft demand under
-exponential pacing; reactive rollout/retry and status-line evidence remains
-available to display and routing without triggering or satisfying primary
-demand. The poll lifecycle is a single-flight sweep paced PER VENDOR LANE:
+subject. Display and routing evaluate freshness at the actual current time:
+absent an earlier reset boundary, a snapshot is still fresh exactly five
+minutes after observation and becomes stale only after that boundary.
+Background demand additionally looks through
+the next existing 60-second poll tick, so a matching primary snapshot whose TTL
+or reset boundary is due by that deadline (including equality) no longer
+satisfies demand. Typed absence is still a successful, displayable observation,
+but retains soft demand under exponential pacing; reactive rollout/retry and
+status-line evidence remains available to display and routing without triggering
+or satisfying primary demand. The poll lifecycle is a single-flight sweep paced PER VENDOR LANE:
 each vendor with a registered refresher owns an independent
 completion-anchored exponential backoff (15-minute ceiling) that advances
 after partial/absence outcomes and resets when credential or routability

--- a/packages/cli/src/daemon-admission-runtime.test.ts
+++ b/packages/cli/src/daemon-admission-runtime.test.ts
@@ -1,6 +1,13 @@
-import type { JournalManager, ProjectPartitions } from "@claudexor/daemon";
+import {
+  QUOTA_POLL_INTERVAL_MS,
+  type JournalManager,
+  type ProjectPartitions,
+} from "@claudexor/daemon";
 import { describe, expect, it, vi } from "vitest";
-import { createStartupAdmissionRuntime } from "./daemon-admission-runtime.js";
+import {
+  createDaemonQuotaPoller,
+  createStartupAdmissionRuntime,
+} from "./daemon-admission-runtime.js";
 import { DaemonStartupAdmission } from "./daemon-startup.js";
 
 vi.mock("./daemon-lifecycle.js", () => ({
@@ -189,5 +196,29 @@ describe("startup admission recovery verdict ordering", () => {
     await expect(second).rejects.toThrow("setup failed");
     expect(frozenStartup).toHaveBeenCalledTimes(1);
     expect(fixture.normalPlane.startSetup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("daemon quota poll cadence", () => {
+  it("uses the shared interval, starts immediately, and owns only one timer", async () => {
+    vi.useFakeTimers();
+    try {
+      const poll = vi.fn();
+      const poller = createDaemonQuotaPoller(poll);
+
+      poller.arm();
+      poller.arm();
+      expect(poll).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(QUOTA_POLL_INTERVAL_MS);
+      expect(poll).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(1);
+
+      poller.stop();
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/cli/src/daemon-admission-runtime.ts
+++ b/packages/cli/src/daemon-admission-runtime.ts
@@ -12,6 +12,7 @@
 import {
   daemonDir,
   logPath,
+  QUOTA_POLL_INTERVAL_MS,
   type DaemonServingMode,
   type JournalManager,
   type ProjectPartitions,
@@ -93,7 +94,7 @@ export function createDaemonQuotaPoller(poll: () => void): { arm(): void; stop()
   return {
     arm: () => {
       if (timer) return;
-      timer = setInterval(poll, 60_000);
+      timer = setInterval(poll, QUOTA_POLL_INTERVAL_MS);
       timer.unref();
       poll();
     },

--- a/packages/daemon/src/quota-poll-lanes.ts
+++ b/packages/daemon/src/quota-poll-lanes.ts
@@ -3,6 +3,8 @@ import type { QuotaAbsence, QuotaSnapshot, QuotaSubject } from "@claudexor/schem
 import { QuotaPollPacer, type QuotaPacerStateStore } from "./quota-poll-pacer.js";
 import { quotaSubjectIdentity, remainingQuotaRefreshDemand } from "./quota-refresh-demand.js";
 
+export const QUOTA_POLL_INTERVAL_MS = 60_000;
+
 /** One refresh cycle's fruit: the snapshots a source observed, plus the typed
  * absences it CLAIMS for subjects it tried and could not observe. Absence is
  * stated by the source, never inferred from an empty snapshot list. */
@@ -60,7 +62,7 @@ export function buildRefresherLanes(
 export interface PollSweepDeps {
   readonly now: () => Date;
   readonly publishClockTransition: () => void;
-  readonly laneHasDemand: (vendor: string | null, now: number) => boolean;
+  readonly laneHasDemand: (vendor: string | null, now: number, dueBefore: number) => boolean;
   readonly currentGeneration: () => number;
   readonly isCurrentGeneration: (generation: number) => boolean;
   readonly runLaneCycle: (lane: PacingLane) => Promise<unknown>;
@@ -80,7 +82,7 @@ export async function performPollSweep(
   for (const lane of lanes) {
     const now = deps.now().getTime();
     if (!lane.pacer.pollEligible(now)) continue;
-    if (!deps.laneHasDemand(lane.vendor, now)) continue;
+    if (!deps.laneHasDemand(lane.vendor, now, now + QUOTA_POLL_INTERVAL_MS)) continue;
     const generation = deps.currentGeneration();
     try {
       await deps.runLaneCycle(lane);
@@ -89,7 +91,10 @@ export async function performPollSweep(
       // outcome: the fresh-generation poll re-decides from scratch.
       if (!deps.isCurrentGeneration(generation)) continue;
       const completedAt = deps.now().getTime();
-      lane.pacer.notePollSuccess(completedAt, deps.laneHasDemand(lane.vendor, completedAt));
+      lane.pacer.notePollSuccess(
+        completedAt,
+        deps.laneHasDemand(lane.vendor, completedAt, completedAt + QUOTA_POLL_INTERVAL_MS),
+      );
     } catch {
       if (deps.isCurrentGeneration(generation)) {
         lane.pacer.notePollFailure(deps.now().getTime());
@@ -105,12 +110,14 @@ export function laneHasDemand(
   vendor: string | null,
   snapshots: readonly QuotaSnapshot[],
   subjects?: readonly QuotaSubject[],
+  dueBefore?: number,
 ): boolean {
-  if (vendor === null) return remainingQuotaRefreshDemand(snapshots, subjects).size > 0;
+  if (vendor === null) return remainingQuotaRefreshDemand(snapshots, subjects, dueBefore).size > 0;
   return (
     remainingQuotaRefreshDemand(
       snapshots.filter((snapshot) => snapshot.subject.harness === vendor),
       subjects?.filter((subject) => subject.harness === vendor),
+      dueBefore,
     ).size > 0
   );
 }

--- a/packages/daemon/src/quota-refresh-demand.test.ts
+++ b/packages/daemon/src/quota-refresh-demand.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { QuotaSnapshot, QuotaSubject } from "@claudexor/schema";
 import { remainingQuotaRefreshDemand } from "./quota-refresh-demand.js";
+import { staleAt } from "./quota-registry-support.js";
 
 const subject = (harness: string, subjectId: string | null): QuotaSubject => ({
   harness,
@@ -30,5 +31,60 @@ describe("remainingQuotaRefreshDemand", () => {
     expect(remainingQuotaRefreshDemand([snapshot(owner, "codex_app_server")], [owner])).toEqual(
       new Set(),
     );
+  });
+
+  it("keeps current-time staleness strict while horizon demand includes TTL equality", () => {
+    const owner = subject("codex", "work");
+    const primary = snapshot(owner, "codex_app_server");
+    const boundary = Date.parse("2026-08-09T00:05:00.000Z");
+
+    expect(staleAt(primary, boundary).freshness).toBe("fresh");
+    expect(staleAt(primary, boundary + 1).freshness).toBe("stale");
+    expect(remainingQuotaRefreshDemand([primary], [owner])).toEqual(new Set());
+    expect(remainingQuotaRefreshDemand([primary], [owner], boundary - 1)).toEqual(new Set());
+    expect(remainingQuotaRefreshDemand([primary], [owner], boundary)).toEqual(
+      new Set(["codex\0work"]),
+    );
+  });
+
+  it("treats reset boundaries at or before the horizon as demand", () => {
+    const owner = subject("codex", "work");
+    const deadline = Date.parse("2026-08-09T00:05:00.000Z");
+    const withReset = (resetsAt: string): QuotaSnapshot => ({
+      ...snapshot(owner, "codex_app_server"),
+      observed_at: "2026-08-09T00:04:00.000Z",
+      constraints: [
+        {
+          id: "primary",
+          label: "5 hour",
+          used_ratio: 0.2,
+          window_seconds: 18_000,
+          resets_at: resetsAt,
+          cooldown_until: null,
+        },
+      ],
+    });
+
+    expect(
+      remainingQuotaRefreshDemand([withReset("2026-08-09T00:05:00.000Z")], [owner], deadline),
+    ).toEqual(new Set(["codex\0work"]));
+    expect(
+      remainingQuotaRefreshDemand([withReset("2026-08-09T00:04:59.999Z")], [owner], deadline),
+    ).toEqual(new Set(["codex\0work"]));
+    expect(
+      remainingQuotaRefreshDemand([withReset("2026-08-09T00:05:00.001Z")], [owner], deadline),
+    ).toEqual(new Set());
+  });
+
+  it("preserves missing and already-stale demand", () => {
+    const owner = subject("codex", "work");
+    expect(remainingQuotaRefreshDemand([], [owner], Date.now())).toEqual(new Set(["codex\0work"]));
+    expect(
+      remainingQuotaRefreshDemand(
+        [{ ...snapshot(owner, "codex_app_server"), freshness: "stale" }],
+        [owner],
+        Date.now(),
+      ),
+    ).toEqual(new Set(["codex\0work"]));
   });
 });

--- a/packages/daemon/src/quota-refresh-demand.ts
+++ b/packages/daemon/src/quota-refresh-demand.ts
@@ -4,6 +4,7 @@ import {
   type QuotaSnapshot,
   type QuotaSubject,
 } from "@claudexor/schema";
+import { quotaSnapshotDueBefore } from "./quota-registry-support.js";
 
 const REFRESH_CAPABLE_HARNESSES = new Set<string>(quotaRefreshDemandHarnesses());
 
@@ -19,13 +20,15 @@ export function quotaSubjectIdentity(subject: QuotaSubject): string {
 export function remainingQuotaRefreshDemand(
   snapshots: readonly QuotaSnapshot[],
   subjects?: readonly QuotaSubject[],
+  dueBefore?: number,
 ): Set<string> {
   const satisfied = new Set(
     snapshots
       .filter(
         (snapshot) =>
           snapshot.freshness === "fresh" &&
-          quotaSourceTraits(snapshot.source).refreshDemandHarness === snapshot.subject.harness,
+          quotaSourceTraits(snapshot.source).refreshDemandHarness === snapshot.subject.harness &&
+          (dueBefore === undefined || !quotaSnapshotDueBefore(snapshot, dueBefore)),
       )
       .map((snapshot) => quotaSubjectIdentity(snapshot.subject)),
   );

--- a/packages/daemon/src/quota-registry-support.ts
+++ b/packages/daemon/src/quota-registry-support.ts
@@ -11,6 +11,8 @@ import {
   type QuotaSnapshot,
 } from "@claudexor/schema";
 
+export const QUOTA_FRESHNESS_TTL_MS = 5 * 60_000;
+
 export function snapshotKey(snapshot: QuotaSnapshot): string {
   const subject = snapshot.subject;
   return [
@@ -50,8 +52,21 @@ export function staleAt(snapshot: QuotaSnapshot, now: number): QuotaSnapshot {
   if (snapshot.freshness !== "fresh") return snapshot;
   const observed = Date.parse(snapshot.observed_at);
   const resetExpired = snapshot.constraints.some((constraint) => resetExpiredAt(constraint, now));
-  const tooOld = !Number.isFinite(observed) || now - observed > 5 * 60_000;
+  const tooOld = !Number.isFinite(observed) || now - observed > QUOTA_FRESHNESS_TTL_MS;
   return resetExpired || tooOld ? { ...snapshot, freshness: "stale" } : snapshot;
+}
+
+/** Whether primary evidence will be due by a future demand horizon. Unlike
+ * `staleAt`, the TTL comparison includes equality so the last existing poll
+ * before expiry requests renewal instead of waiting for the following tick. */
+export function quotaSnapshotDueBefore(snapshot: QuotaSnapshot, deadline: number): boolean {
+  if (snapshot.freshness !== "fresh") return true;
+  const observed = Date.parse(snapshot.observed_at);
+  return (
+    !Number.isFinite(observed) ||
+    observed + QUOTA_FRESHNESS_TTL_MS <= deadline ||
+    snapshot.constraints.some((constraint) => resetExpiredAt(constraint, deadline))
+  );
 }
 
 function resetExpiredAt(constraint: Pick<QuotaConstraint, "resets_at">, now: number): boolean {

--- a/packages/daemon/src/quota-registry.test.ts
+++ b/packages/daemon/src/quota-registry.test.ts
@@ -1125,6 +1125,178 @@ describe("QuotaRegistry", () => {
     rmSync(root, { recursive: true, force: true });
   });
 
+  it("refreshes healthy primary evidence on the last existing tick before TTL expiry", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-quota-horizon-tick-")));
+    const journal = new DurableJournal({ rootDir: root, partition: "global" });
+    const observedAt = Date.parse("2026-07-28T00:00:00.000Z");
+    let nowMs = observedAt + 4 * 60_000;
+    let calls = 0;
+    const subject = quotaSnapshot("codex", null, 0.2).subject;
+    const registry = new QuotaRegistry(
+      journal,
+      [
+        {
+          vendor: "codex",
+          refresh: async () => {
+            calls += 1;
+            return {
+              snapshots: [
+                {
+                  ...quotaSnapshot("codex", null, 0.3),
+                  source: "codex_app_server" as const,
+                  observed_at: new Date(nowMs).toISOString(),
+                },
+              ],
+            };
+          },
+        },
+      ],
+      () => new Date(nowMs),
+      () => [subject],
+    );
+    registry.upsert({
+      ...quotaSnapshot("codex", null, 0.2),
+      source: "codex_app_server",
+      observed_at: new Date(observedAt).toISOString(),
+    });
+
+    await expect(registry.pollStale()).resolves.toBe(true);
+    expect(calls).toBe(1);
+    expect(registry.read().snapshots[0]).toMatchObject({
+      freshness: "fresh",
+      observed_at: new Date(nowMs).toISOString(),
+    });
+    await expect(registry.pollStale()).resolves.toBe(false);
+    expect(calls).toBe(1);
+
+    journal.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("keeps explicit foreground refresh unconditional when background demand is absent", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-quota-fg-demand-")));
+    const journal = new DurableJournal({ rootDir: root, partition: "global" });
+    const observedAt = Date.parse("2026-07-28T00:00:00.000Z");
+    const nowMs = observedAt + 60_000;
+    let calls = 0;
+    const subject = quotaSnapshot("codex", null, 0.2).subject;
+    const registry = new QuotaRegistry(
+      journal,
+      [
+        {
+          vendor: "codex",
+          refresh: async () => {
+            calls += 1;
+            return {
+              snapshots: [
+                {
+                  ...quotaSnapshot("codex", null, 0.3),
+                  source: "codex_app_server" as const,
+                  observed_at: new Date(nowMs).toISOString(),
+                },
+              ],
+            };
+          },
+        },
+      ],
+      () => new Date(nowMs),
+      () => [subject],
+    );
+    registry.upsert({
+      ...quotaSnapshot("codex", null, 0.2),
+      source: "codex_app_server",
+      observed_at: new Date(observedAt).toISOString(),
+    });
+
+    await expect(registry.pollStale()).resolves.toBe(false);
+    expect(calls).toBe(0);
+    await expect(registry.refresh()).resolves.toMatchObject({
+      snapshots: [expect.objectContaining({ observed_at: new Date(nowMs).toISOString() })],
+    });
+    expect(calls).toBe(1);
+
+    journal.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("feeds a pre-aged fresh result into the existing pacer instead of tight re-polling", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-quota-preaged-")));
+    const journal = new DurableJournal({ rootDir: root, partition: "global" });
+    const observedAt = Date.parse("2026-07-28T00:00:00.000Z");
+    let nowMs = observedAt + 4 * 60_000;
+    let calls = 0;
+    const subject = quotaSnapshot("codex", null, 0.2).subject;
+    const registry = new QuotaRegistry(
+      journal,
+      [
+        {
+          vendor: "codex",
+          refresh: async () => {
+            calls += 1;
+            return {
+              snapshots: [
+                {
+                  ...quotaSnapshot("codex", null, 0.3),
+                  source: "codex_app_server" as const,
+                  observed_at: new Date(nowMs - 4 * 60_000 - 30_000).toISOString(),
+                },
+              ],
+            };
+          },
+        },
+      ],
+      () => new Date(nowMs),
+      () => [subject],
+    );
+    registry.upsert({
+      ...quotaSnapshot("codex", null, 0.2),
+      source: "codex_app_server",
+      observed_at: new Date(observedAt).toISOString(),
+    });
+
+    await expect(registry.pollStale()).resolves.toBe(true);
+    expect(calls).toBe(1);
+    expect(registry.read().snapshots[0]?.freshness).toBe("fresh");
+    await expect(registry.pollStale()).resolves.toBe(false);
+    nowMs += 59_999;
+    await expect(registry.pollStale()).resolves.toBe(false);
+    expect(calls).toBe(1);
+    nowMs += 1;
+    await expect(registry.pollStale()).resolves.toBe(true);
+    expect(calls).toBe(2);
+
+    journal.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does not leak lookahead demand into current-time absence projection", async () => {
+    const root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-quota-horizon-absence-")));
+    const journal = new DurableJournal({ rootDir: root, partition: "global" });
+    const observedAt = Date.parse("2026-07-28T00:00:00.000Z");
+    const nowMs = observedAt + 4 * 60_000;
+    const subject = quotaSnapshot("codex", null, 0.2).subject;
+    const registry = new QuotaRegistry(
+      journal,
+      [{ vendor: "codex", refresh: async () => ({ snapshots: [] }) }],
+      () => new Date(nowMs),
+      () => [subject],
+    );
+    registry.upsert({
+      ...quotaSnapshot("codex", null, 0.2),
+      source: "codex_app_server",
+      observed_at: new Date(observedAt).toISOString(),
+    });
+
+    await expect(registry.pollStale()).resolves.toBe(true);
+    expect(registry.read()).toMatchObject({
+      snapshots: [expect.objectContaining({ freshness: "fresh" })],
+      absences: [],
+    });
+
+    journal.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
   it("polls empty or stale official sources with bounded failure backoff", async () => {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "claudexor-quota-poll-")));
     const journal = new DurableJournal({ rootDir: join(root, "journal"), partition: "global" });

--- a/packages/daemon/src/quota-registry.ts
+++ b/packages/daemon/src/quota-registry.ts
@@ -400,8 +400,8 @@ export class QuotaRegistry {
     const sweep = performPollSweep(this.refresherLanes.lanes, {
       now: this.now,
       publishClockTransition: () => this.publishClockTransitionIfNeeded(),
-      laneHasDemand: (vendor, now) =>
-        laneHasDemand(vendor, this.activeSnapshots(now), this.subjects?.()),
+      laneHasDemand: (vendor, now, dueBefore) =>
+        laneHasDemand(vendor, this.activeSnapshots(now), this.subjects?.(), dueBefore),
       currentGeneration: () => this.refreshCoordinator.currentGeneration(),
       isCurrentGeneration: (generation) => this.refreshCoordinator.isCurrent(generation),
       runLaneCycle: (lane) => this.refreshCycle(false, lane),


### PR DESCRIPTION
## Summary

- make background quota demand look through the next existing 60-second poll tick
- refresh when the five-minute TTL or a reset boundary will be reached by that tick
- keep current-time display and routing freshness, foreground refresh, pacing, backoff, coalescing, and persistence unchanged
- use one shared poll-interval constant and include a patch changeset for the daemon and CLI packages

## Why

The previous poller waited until a quota snapshot was already stale before requesting a replacement. With a five-minute freshness TTL and a one-minute poll cadence, healthy accounts could therefore spend roughly a minute showing only stale data on every cycle.

## Verification

- 65 focused quota-registry, demand, and daemon-timer tests passed
- daemon and CLI typechecks passed
- docs, formatting, knip, and complexity-ratchet checks passed
- Node release verification passed: 4,600 tests passed, 11 skipped, plus 42 canary tests
- final exact-commit reviews found no blocking code or scope issues
