### PR TITLE
feat(harness-claude): admit claude-fable-5-1 to the manifest known-model list

### DIFF
--- a/.changeset/claude-fable-5-1-known-model.md
+++ b/.changeset/claude-fable-5-1-known-model.md
@@ -2,4 +2,4 @@
 "@claudexor/harness-claude": patch
 ---
 
-Admit `claude-fable-5-1` to the Claude manifest known-model list, so an explicit Fable 5.1 pin is accepted instead of refused as outside the manifest, and the Fable weekly window's `applies_to_models` now names the id, so the exact-match budget router applies that window to a 5.1-pinned run. The id is admitted from the vendor model table under the existing 2.1.165 `known_models_verified_against` stamp; it has not been live-verified on that CLI.
+Admit `claude-fable-5-1` (Claude Fable 5.1) to the Claude manifest known-model list, so an explicit Fable 5.1 pin is accepted and the Fable weekly window names the id; the model itself requires Claude Code 2.1.251 or newer.

--- a/.changeset/claude-fable-5-1-known-model.md
+++ b/.changeset/claude-fable-5-1-known-model.md
@@ -1,0 +1,5 @@
+---
+"@claudexor/harness-claude": patch
+---
+
+Admit `claude-fable-5-1` to the Claude manifest known-model list, so an explicit Fable 5.1 pin is accepted instead of refused as outside the manifest, and the Fable weekly window's `applies_to_models` now names the id, so the exact-match budget router applies that window to a 5.1-pinned run. The id is admitted from the vendor model table under the existing 2.1.165 `known_models_verified_against` stamp; it has not been live-verified on that CLI.

--- a/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/QuotaPresentationTests.swift
+++ b/apps/macos/ClaudexorKit/Tests/ClaudexorKitTests/QuotaPresentationTests.swift
@@ -83,6 +83,14 @@ import Testing
         #expect(group.windows.first?.appliesToModels == ["fable", "claude-fable-5", "best"])
     }
 
+    @Test func modelScopeLabelCollapsesEveryVersionedFableAliasOntoTheFamily() {
+        // The live Fable window carries two versioned ids next to the family
+        // alias (claude-fable-5-1 joined claude-fable-5); both fold onto the
+        // family label and the generic `best` alias drops.
+        let models = ["fable", "claude-fable-5-1", "claude-fable-5", "best"]
+        #expect(QuotaPresentation.modelScopeLabel(models) == "Fable only")
+    }
+
     @Test func availabilityFoldUnionsScopedExhaustionsWithoutRatioInference() throws {
         func decorated(_ source: String, availability: [String: Any]) throws -> QuotaSnapshot {
             let object: [String: Any] = [

--- a/packages/cli/src/claude-oauth-usage.test.ts
+++ b/packages/cli/src/claude-oauth-usage.test.ts
@@ -70,7 +70,7 @@ describe("claude oauth/usage quota source (W5.3, INV-062)", () => {
     expect(byId.get("weekly_scoped:Fable")).toMatchObject({
       used_ratio: 0.17,
       label: "7 day (Fable)",
-      applies_to_models: ["fable", "claude-fable-5", "best"],
+      applies_to_models: ["fable", "claude-fable-5-1", "claude-fable-5", "best"],
     });
   });
 

--- a/packages/harness-claude/src/capability-profile.ts
+++ b/packages/harness-claude/src/capability-profile.ts
@@ -18,6 +18,7 @@ export const CLAUDE_KNOWN_MODELS: readonly string[] = [
   "haiku",
   "fable",
   "best",
+  "claude-fable-5-1",
   "claude-fable-5",
   "claude-sonnet-5",
   "claude-opus-5",

--- a/packages/harness-claude/src/capability-profile.ts
+++ b/packages/harness-claude/src/capability-profile.ts
@@ -18,6 +18,10 @@ export const CLAUDE_KNOWN_MODELS: readonly string[] = [
   "haiku",
   "fable",
   "best",
+  // Claude Fable 5.1 needs Claude Code >= 2.1.251: older CLIs (incl. the
+  // 2.1.165 pin) refuse it at the vendor with "version 2.1.251 or newer is
+  // required". Live-verified through Claudexor on 2.1.258 (observed_model
+  // claude-fable-5-1).
   "claude-fable-5-1",
   "claude-fable-5",
   "claude-sonnet-5",

--- a/packages/harness-claude/src/models.test.ts
+++ b/packages/harness-claude/src/models.test.ts
@@ -36,9 +36,10 @@ const stubAdapter = () =>
   });
 
 describe("the claude manifest model truth source", () => {
-  it("advertises the current Opus generation — claude-opus-5 AND the still-active claude-opus-4-5", async () => {
+  it("advertises the newest Fable (claude-fable-5-1) AND the current Opus generation — claude-opus-5 plus the still-active claude-opus-4-5", async () => {
     const manifest = await stubAdapter().discover();
     const known = manifest.capabilities.known_models;
+    expect(known).toContain("claude-fable-5-1");
     expect(known).toContain("claude-opus-5");
     expect(known).toContain("claude-opus-4-5");
   });
@@ -58,6 +59,7 @@ describe("the claude manifest model truth source", () => {
     // flattens the route-scoped list, then `validateModel` judges against it.
     const manifest = await stubAdapter().discover();
     const known = knownModelIdsForRoute(manifest.capabilities.known_models, "local_session");
+    expect(validateModel("claude-fable-5-1", known, "manifest").status).toBe("ok");
     expect(validateModel("claude-opus-5", known, "manifest").status).toBe("ok");
     expect(validateModel("claude-opus-4-5", known, "manifest").status).toBe("ok");
     // STRICT semantics: outside the list → rejected, naming the truth source.
@@ -67,6 +69,14 @@ describe("the claude manifest model truth source", () => {
   });
 
   it("projects vendor quota family names onto the manifest aliases", () => {
+    // The projection inherits catalog order (newest full id first within a
+    // family); nothing routes on it, but `models` listings display it.
+    expect(claudeQuotaModelAliases("Fable")).toEqual([
+      "fable",
+      "claude-fable-5-1",
+      "claude-fable-5",
+      "best",
+    ]);
     expect(claudeQuotaModelAliases(" Opus ")).toEqual([
       "opus",
       "claude-opus-5",


### PR DESCRIPTION
## What & why

Claude Fable 5.1 (`claude-fable-5-1`) is the newest Fable. Claudexor's manifest model truth source refused an explicit pin (`--model claude-fable-5-1`, settings `default_model`, reviewer lanes) with `not in the harness's manifest known-model list` — INV-104 strict semantics, no pass-through. This PR admits the id.

- `packages/harness-claude/src/capability-profile.ts`: `claude-fable-5-1` inserted as the first full id, before `claude-fable-5` (newest-first within the family), with its vendor CLI floor documented inline. The Fable quota family picks it up via the `claude-fable-` prefix, so the weekly Fable window's `applies_to_models` names the id for the exact-match budget router.
- `packages/harness-claude/src/models.test.ts`: pins the addition end to end (advertised in the manifest; accepted by `knownModelIdsForRoute -> validateModel`; projected into `claudeQuotaModelAliases("Fable")` in catalog order).
- `packages/cli/src/claude-oauth-usage.test.ts`: the derived `weekly_scoped:Fable` expectation follows the projection.
- `apps/macos/ClaudexorKit/Tests/.../QuotaPresentationTests.swift`: the four-alias Fable window folds onto the `Fable only` label.
- `.changeset/claude-fable-5-1-known-model.md`: patch for `@claudexor/harness-claude`.

No docs enumerate the catalog (ARCHITECTURE/README describe the mechanism), no schema change (`known_models` is an open array), `CLAUDEXOR_BIBLE.md` untouched, complexity ratchet unaffected.

## Live verification (1d99c825 protocol)

- Claudexor run `run-cb0eb5af41ac`, harness `claude`, pinned subscription profile `claude-default`, `--model claude-fable-5-1 --effort low`, marker prompt → reply `MARKER-FABLE51 model=claude-fable-5-1` (**observed_model `claude-fable-5-1`**) on **Claude Code 2.1.258** (`CLAUDEXOR_CLAUDE_BIN` pointed at an isolated `@anthropic-ai/claude-code@2.1.258` install).
- **Vendor floor:** the same run on Claude Code **2.1.90** was refused by the vendor API: `Claude Code 2.1.90 does not support this model; version 2.1.251 or newer is required.` Fable 5.1 therefore cannot run on the currently stamped/pinned **2.1.165** either — an explicit pin on that CLI fails with that vendor error rather than silently falling back.
- The `known_models_verified_against` stamp (2.1.165) is deliberately **left unchanged** here: moving it is a full vendor-pin bump (the constant aliases the effort-snapshot stamp and the `@anthropic-ai/claude-code@<v>` installer pin, and all seven recorded fixtures in `packages/harness-claude/fixtures/manifest.yaml` are stamped 2.1.165, so `fixture-freshness-check --strict` would demand re-recording them). Data point for that follow-up: the 2.1.258 `--help` effort ladder is identical to the recorded snapshot (`low, medium, high, xhigh, max`), so `CLAUDE_EFFORT_SNAPSHOT` would not change.

Maintainer decision requested: admit the id now with the documented floor (this PR), or fold it into the next vendor-pin bump (≥ 2.1.251).

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass (344 files / 4600 tests passed, 11 skipped; harness-claude + cli oauth-usage suites re-run after the doc commit: 264 passed)
- [x] Docs updated in the SAME PR where behavior they describe changed (nothing enumerates the catalog — verified by grep; vacuous)
- [x] `CLAUDEXOR_BIBLE.md` unchanged (no `CONCEPT-CHANGE` marker needed)
- [x] No secrets, tokens, or machine-local paths in the diff
- [x] `node scripts/complexity-ratchet.mjs` OK; `pnpm format:check` OK
- [x] Live-verified through Claudexor with `observed_model` recorded (see above) — on 2.1.258, not on the stamped 2.1.165, which the vendor refuses for this model
- [ ] Swift test not executed locally (no Swift toolchain on the authoring machine); please run `pnpm release:verify:swift` or CI
- [ ] `scripts/model-hints-freshness.mjs --strict` warns on the authoring machine only because the installed CLI differs from the stamp; pre-existing, unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
