### PR TITLE
Fix billing routing for selected native profiles

### DIFF
--- a/packages/orchestrator/src/auth-route-classification.ts
+++ b/packages/orchestrator/src/auth-route-classification.ts
@@ -1,4 +1,5 @@
-import type { AuthPreference } from "@claudexor/schema";
+import type { RouteAuthEvidence } from "@claudexor/budget";
+import type { AuthPreference, AuthSourceReadiness, AuthVerification } from "@claudexor/schema";
 
 /**
  * Auth-mode classification for route ranking and billing evidence (#121
@@ -27,4 +28,36 @@ export function authModeForPreference(
   if (preference === "api_key") return "api_key";
   if (preference === "subscription") return "local_session";
   return null;
+}
+
+/** Typed auth evidence for the concrete route selected before budget ranking. */
+export function authRouteEvidenceFor(
+  authMode: "local_session" | "api_key" | "unknown",
+  sources: AuthSourceReadiness[],
+  profileVerification: AuthVerification | null,
+): RouteAuthEvidence | undefined {
+  const usable = (source: AuthSourceReadiness): boolean =>
+    source.availability === "available" && source.verification !== "failed";
+  if (authMode === "local_session") {
+    if (profileVerification !== null) {
+      return { route: "vendor_native", verification: profileVerification };
+    }
+    const native = sources.find(
+      (source) =>
+        usable(source) &&
+        (source.source === "native_session" || source.source === "oauth_token_env"),
+    );
+    return { route: "vendor_native", verification: native?.verification ?? "not_run" };
+  }
+  if (authMode === "api_key") {
+    const key = sources.find(
+      (source) =>
+        usable(source) &&
+        (source.source === "api_key_env" ||
+          source.source === "api_key_flag" ||
+          source.source === "provider_auth_file"),
+    );
+    return { route: "managed_api_key", verification: key?.verification ?? "not_run" };
+  }
+  return undefined;
 }

--- a/packages/orchestrator/src/orchestrator-credentials.ts
+++ b/packages/orchestrator/src/orchestrator-credentials.ts
@@ -9,6 +9,7 @@
  */
 import type {
   AuthPreference,
+  AuthVerification,
   CredentialProfile,
   CredentialUnusableObservation,
   HarnessRunSpec,
@@ -332,5 +333,18 @@ export class OrchestratorCredentials {
       notePoolApiKeyRoute: () => this.poolApiKeyRoutes.note(input, harnessId),
       emit: (type, payload) => log?.emit(type, payload),
     });
+  }
+
+  /** Billing evidence for the exact profile selected by preflight. The default
+   * doctor's auth sources describe a different credential store, so they must
+   * not classify a named profile. Only a vendor-backed profile verification is
+   * strong enough to prove a subscription-entitled native route. */
+  async profileAuthVerification(profile: CredentialProfile): Promise<AuthVerification> {
+    const adapter = this.host.registry().get(profile.harness_id);
+    const status = vendorVerifiedProfileStatus(
+      await probeCredentialProfileStatus(profile, adapter?.probeCredentialProfile?.bind(adapter)),
+      this.vendorQuotaObservations(),
+    );
+    return status.verification_source === "vendor" ? status.verification : "not_run";
   }
 }

--- a/packages/orchestrator/src/orchestrator.ts
+++ b/packages/orchestrator/src/orchestrator.ts
@@ -45,6 +45,7 @@ import { join } from "node:path";
 import type {
   AccessProfile,
   AuthSourceReadiness,
+  AuthVerification,
   DeepScanSynthesis,
   RouteRankingRationale,
   RouteDropStage,
@@ -118,7 +119,11 @@ import {
   withInactivityWatchdog,
 } from "@claudexor/core";
 import { assertRouteModelsAllowed, runModelGovernedRoute } from "./modelGovernance.js";
-import { authModeForCredentialRoute, authModeForPreference } from "./auth-route-classification.js";
+import {
+  authModeForCredentialRoute,
+  authModeForPreference,
+  authRouteEvidenceFor,
+} from "./auth-route-classification.js";
 import { governRouteEffort } from "./effortGovernance.js";
 import { isFullAccess, RequestRequirementsResolver } from "./requestRequirements.js";
 import { DelegationBudgetAuthority } from "./delegationBudgetAuthority.js";
@@ -272,7 +277,6 @@ import {
   attemptUsageCostSettlement,
   BudgetLedger,
   isBudgetTerminal,
-  type RouteAuthEvidence,
   type RouterCandidate,
   explainRanking,
   loadHarnessMetrics,
@@ -620,6 +624,7 @@ export interface RoutedAdapter {
     model: string | null;
     profile: CredentialProfile | null;
     route: "vendor_native" | "managed_api_key" | null;
+    profileVerification: AuthVerification | null;
   };
   /** Manifest `synthesize` capability (#27 / D-6): only such routes are eligible
    * to run the deep-scan bounded synthesis reducer over the scout reports. */
@@ -1392,7 +1397,12 @@ export class Orchestrator {
               this.authPreferenceForHarness(input.repoRoot, id, input.authPreference),
               status.authSources,
             ),
-          quotaAdmission: { model: null, profile: null, route: null },
+          quotaAdmission: {
+            model: null,
+            profile: null,
+            route: null,
+            profileVerification: null,
+          },
           supportsSynthesize: manifest.capabilities.synthesize,
           supportsInteractive: manifest.capabilities.interactive,
           supportsJsonSchemaOutput: manifest.capabilities.json_schema_output,
@@ -1476,8 +1486,14 @@ export class Orchestrator {
               : routed.authRouteEstimate === "local_session"
                 ? ("vendor_native" as const)
                 : null;
+        const profileVerification = profile
+          ? await this.credentials.profileAuthVerification(profile)
+          : null;
         return {
-          prepared: { ...routed, quotaAdmission: { model, profile, route } },
+          prepared: {
+            ...routed,
+            quotaAdmission: { model, profile, route, profileVerification },
+          },
           refused: null,
         };
       }),
@@ -1638,7 +1654,11 @@ export class Orchestrator {
         // paid_fallback:never and ranks with a real economy tuple instead of
         // reading as unknown/paid. Absent (unknown route) falls back to the
         // metric-derived billingKnowledge below.
-        const authRoute = this.authRouteEvidenceFor(authMode, status?.authSources ?? []);
+        const authRoute = authRouteEvidenceFor(
+          authMode,
+          status?.authSources ?? [],
+          r.quotaAdmission.profileVerification,
+        );
         return {
           harnessId: r.adapter.id,
           available: true,
@@ -1752,40 +1772,6 @@ export class Orchestrator {
           : ledger.cooldownActive(id);
       },
     };
-  }
-
-  /**
-   * Typed auth-route evidence for one candidate (QA-034): the concrete
-   * credential route the resolved auth mode maps to, plus the doctor's
-   * verification for the source that route runs under. `local_session` →
-   * vendor_native + the native/OAuth source verification; `api_key` →
-   * managed_api_key + the key source verification. Unknown route → no evidence
-   * (the router keeps its conservative metric-derived billing). Verification is
-   * the source's typed verdict — never inferred from mere availability.
-   */
-  private authRouteEvidenceFor(
-    authMode: "local_session" | "api_key" | "unknown",
-    sources: AuthSourceReadiness[],
-  ): RouteAuthEvidence | undefined {
-    const usable = (s: AuthSourceReadiness): boolean =>
-      s.availability === "available" && s.verification !== "failed";
-    if (authMode === "local_session") {
-      const native = sources.find(
-        (s) => usable(s) && (s.source === "native_session" || s.source === "oauth_token_env"),
-      );
-      return { route: "vendor_native", verification: native?.verification ?? "not_run" };
-    }
-    if (authMode === "api_key") {
-      const key = sources.find(
-        (s) =>
-          usable(s) &&
-          (s.source === "api_key_env" ||
-            s.source === "api_key_flag" ||
-            s.source === "provider_auth_file"),
-      );
-      return { route: "managed_api_key", verification: key?.verification ?? "not_run" };
-    }
-    return undefined;
   }
 
   /**

--- a/packages/orchestrator/src/profile-billing-routing.test.ts
+++ b/packages/orchestrator/src/profile-billing-routing.test.ts
@@ -1,0 +1,154 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HarnessAdapter } from "@claudexor/core";
+import { ConformanceReport, HarnessManifest } from "@claudexor/schema";
+import { afterEach, describe, expect, it } from "vitest";
+import { Orchestrator } from "./orchestrator.js";
+
+const scratchDirs: string[] = [];
+
+function scratch(prefix: string): string {
+  const path = mkdtempSync(join(tmpdir(), prefix));
+  scratchDirs.push(path);
+  return path;
+}
+
+afterEach(() => {
+  for (const path of scratchDirs.splice(0)) rmSync(path, { recursive: true, force: true });
+});
+
+function initializedRepo(): string {
+  const repo = scratch("claudexor-profile-billing-repo-");
+  execFileSync("git", ["-C", repo, "init", "-b", "main"]);
+  writeFileSync(join(repo, "README.md"), "# test\n");
+  execFileSync("git", ["-C", repo, "add", "README.md"]);
+  execFileSync("git", [
+    "-C",
+    repo,
+    "-c",
+    "user.email=test@example.com",
+    "-c",
+    "user.name=Test",
+    "commit",
+    "-m",
+    "init",
+  ]);
+  return repo;
+}
+
+function profileOnlyCodex(): HarnessAdapter {
+  return {
+    id: "codex",
+    async discover() {
+      return HarnessManifest.parse({
+        id: "codex",
+        display_name: "Codex",
+        kind: "local_cli",
+        provider_family: "openai",
+        capabilities: { read_files: true },
+        access_profiles_supported: ["readonly"],
+      });
+    },
+    async doctor() {
+      return ConformanceReport.parse({
+        harness_id: "codex",
+        status: "unavailable",
+        reasons: ["the default Codex home is not logged in"],
+        auth_sources: [
+          {
+            source: "native_session",
+            availability: "unavailable",
+            verification: "not_run",
+          },
+        ],
+      });
+    },
+    async probeCredentialProfile(profile) {
+      return {
+        profile_id: profile.profile_id,
+        harness_id: profile.harness_id,
+        availability: "available",
+        verification: "passed",
+        verification_source: "local_store",
+        last_verified_at: new Date().toISOString(),
+      };
+    },
+    async *run(spec) {
+      const ts = new Date().toISOString();
+      yield {
+        type: "started",
+        session_id: spec.session_id,
+        ts,
+        credential_route: "vendor_native",
+        credential_profile_id: "work-primary",
+      } as const;
+      yield { type: "message", session_id: spec.session_id, ts, text: "ok" } as const;
+      yield { type: "completed", session_id: spec.session_id, ts } as const;
+    },
+  };
+}
+
+describe("profile-backed subscription routing", () => {
+  it("keeps a vendor-verified Codex profile eligible when paid fallback is never", async () => {
+    const configDir = scratch("claudexor-profile-billing-config-");
+    const profileHome = join(configDir, "profiles", "work-primary");
+    mkdirSync(profileHome, { recursive: true });
+    writeFileSync(
+      join(configDir, "config.yaml"),
+      [
+        "routing:",
+        "  paid_fallback: never",
+        "credential_profiles:",
+        "  - profile_id: work-primary",
+        "    harness_id: codex",
+        "    display_name: Work (Primary)",
+        "    credential_kind: config_dir_login",
+        `    isolation_locator: ${profileHome}`,
+        "    secret_ref: null",
+        "    enabled: true",
+        "    created_at: 2026-09-01T07:05:45.812Z",
+        "",
+      ].join("\n"),
+    );
+    const previousConfigDir = process.env.CLAUDEXOR_CONFIG_DIR;
+    process.env.CLAUDEXOR_CONFIG_DIR = configDir;
+    try {
+      const observedAt = new Date().toISOString();
+      const result = await new Orchestrator({
+        registry: new Map([["codex", profileOnlyCodex()]]),
+        reviewers: [],
+        quotaSnapshots: () => [
+          {
+            subject: {
+              harness: "codex",
+              credential_route: "vendor_native",
+              plan_label: "pro",
+              subject_id: "work-primary",
+            },
+            constraints: [],
+            source: "codex_app_server",
+            observed_at: observedAt,
+            freshness: "fresh",
+          },
+        ],
+      }).run({
+        repoRoot: initializedRepo(),
+        prompt: "hello",
+        mode: "ask",
+        harnesses: ["codex"],
+        credentialProfileId: "work-primary",
+        web: "auto",
+      });
+
+      expect(result.lifecycle, result.summary).toBe("succeeded");
+      expect(result.candidates).toEqual([
+        expect.objectContaining({ harnessId: "codex", status: "success" }),
+      ]);
+    } finally {
+      if (previousConfigDir === undefined) delete process.env.CLAUDEXOR_CONFIG_DIR;
+      else process.env.CLAUDEXOR_CONFIG_DIR = previousConfigDir;
+    }
+  });
+});


### PR DESCRIPTION
## What & why

Closes #260

Quota admission already selects an exact credential profile, but budget routing previously classified the resulting native route using aggregate doctor auth sources.

For a named Codex profile, those sources describe the default credential store. If the default store was logged out, a vendor-verified subscription profile inherited `verification: not_run` and was removed when `paid_fallback` was `never`.

This change:

- obtains billing verification for the exact profile selected during quota admission;
- upgrades it only from vendor-backed evidence, preserving INV-060's evidence boundary;
- carries that verification through the frozen quota-admission result;
- uses it when constructing native-route billing evidence;
- keeps default doctor evidence as the fallback for profile-less routes;
- adds an orchestrator regression covering a vendor-verified named Codex profile with an unavailable default store.

The existing auth-route projection was moved into `auth-route-classification.ts` to keep `orchestrator.ts` within the INV-124 complexity ratchet. No reviewer policy or reviewer-free behavior is changed.

## Checks

- [x] `pnpm build && pnpm typecheck && pnpm typecheck:tests && pnpm test` pass
- [x] Existing documentation already specifies exact selected-account authority; no schema, surface, or documented behavior changed
- [x] `CLAUDEXOR_BIBLE.md` is unchanged
- [x] No secrets, tokens, or machine-local paths in the diff
- [x] `git diff --check`
- [x] Full TypeScript test suite: 4601 passed, 11 skipped
- [x] Complexity ratchet
- [x] Schema generation and validation
- [x] Docs truth, concept, invariant, sensitive-resource, and retired-key gates
- [x] Codex model-hints freshness against the pinned Codex CLI 0.144.1
- [x] Canary suite: 42 passed
- [x] End-to-end red/green smoke: clean upstream failed during billing routing; the patched branch succeeded with the same isolated profile and quota state

Local full-release verification could not complete two environment-dependent gates:

- strict fixture freshness also requires matching local Claude, Agy, and Cursor CLIs;
- Swift tests cannot import the `Testing` module from the installed Command Line Tools.

These failures occur outside the changed TypeScript packages and should be exercised by upstream CI.
