### PR TITLE
Diagnose Windows ConPTY acceptance timeouts before cleanup

### DIFF
--- a/packages/harness-agy/src/win32-print-acceptance.test.ts
+++ b/packages/harness-agy/src/win32-print-acceptance.test.ts
@@ -37,6 +37,17 @@ interface AcceptanceSummary {
   workerPid: number;
   observedPids: number[];
   error?: string;
+  inAppDiagnostics?: {
+    runnerPid: number;
+    workerPid?: number;
+    helperPid?: number;
+    vendorPid?: number;
+    runnerExit?: { code: number | null; signal: NodeJS.Signals | null };
+    runnerClosed?: boolean;
+    stdoutBytes?: number;
+    stderrBytes?: number;
+    codeEchoObserved?: boolean;
+  };
   paths: {
     config: string;
     evidenceB: string;
@@ -134,7 +145,11 @@ describe.skipIf(process.platform !== "win32")("Win32 agy acceptance", () => {
           summary = JSON.parse(readFileSync(resultPath, "utf8")) as AcceptanceSummary;
         }
         const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`${message}; stage=${summary?.stage ?? "not_started"}`);
+        // Capture typed facts before finally kills the tree and deletes its
+        // sidecars. Never include the pasted input, OAuth URL, or raw output.
+        throw new Error(
+          `${message}; stage=${summary?.stage ?? "not_started"}; inApp=${JSON.stringify(inAppTimeoutDiagnostics(root, summary))}`,
+        );
       }
       if (existsSync(resultPath)) {
         summary = JSON.parse(readFileSync(resultPath, "utf8")) as AcceptanceSummary;
@@ -298,6 +313,43 @@ interface CollectedChild {
   signal: NodeJS.Signals | null;
   stdout: string;
   stderr: string;
+}
+
+function inAppTimeoutDiagnostics(root: string, summary: AcceptanceSummary | null) {
+  const diagnostics = summary?.inAppDiagnostics;
+  const [input, state, receipt] = [
+    "runner-input.json",
+    "runner-state.json",
+    "runner-result.json",
+  ].map((name) => {
+    const path = join(root, "in-app-job", name);
+    try {
+      return { exists: true, value: JSON.parse(readFileSync(path, "utf8")) };
+    } catch {
+      return { exists: existsSync(path), value: null };
+    }
+  });
+  return {
+    ...diagnostics,
+    processes: (["runnerPid", "workerPid", "helperPid", "vendorPid"] as const).map((role) => {
+      const pid = diagnostics?.[role];
+      return { role, pid: pid ?? null, alive: pid ? pidAlive(pid) : null };
+    }),
+    input: {
+      exists: input!.exists,
+      readable: input!.value !== null,
+      consumed: input!.value?.consumed === true,
+    },
+    state: { exists: state!.exists, stage: state!.value?.stage ?? null },
+    receipt: {
+      exists: receipt!.exists,
+      readable: receipt!.value !== null,
+      commandStarted: receipt!.value?.commandStarted ?? null,
+      exitCode: receipt!.value?.exitCode ?? null,
+      signal: receipt!.value?.signal ?? null,
+      errorCode: receipt!.value?.errorCode ?? null,
+    },
+  };
 }
 
 async function collect(child: ChildProcess): Promise<CollectedChild> {

--- a/scripts/win32-agy-print-acceptance-worker.mjs
+++ b/scripts/win32-agy-print-acceptance-worker.mjs
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   readFileSync,
   realpathSync,
+  renameSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -36,14 +37,16 @@ for (const key of PROVIDER_KEYS) process.env[key] = "must-be-scrubbed";
 
 const observedPids = new Set([process.pid]);
 let stage = "starting";
+let inAppDiagnostics;
 let summary = { ok: false, stage, workerPid: process.pid, observedPids: [...observedPids] };
 const checkpoint = (next) => {
   stage = next;
   writeFileSync(
-    resultPath,
-    `${JSON.stringify({ ok: false, stage, workerPid: process.pid, observedPids: [...observedPids] })}\n`,
+    `${resultPath}.tmp`,
+    `${JSON.stringify({ ok: false, stage, workerPid: process.pid, observedPids: [...observedPids], inAppDiagnostics })}\n`,
     "utf8",
   );
+  renameSync(`${resultPath}.tmp`, resultPath);
 };
 checkpoint(stage);
 try {
@@ -269,10 +272,24 @@ try {
     });
     if (!inAppRunner.pid) throw new Error("in-app runner PID was not assigned");
     const inAppRunnerPid = inAppRunner.pid;
+    inAppDiagnostics = {
+      runnerPid: inAppRunnerPid,
+      runnerClosed: false,
+      stdoutBytes: 0,
+      stderrBytes: 0,
+      codeEchoObserved: false,
+    };
     inAppPids.add(inAppRunnerPid);
     observedPids.add(inAppRunnerPid);
     checkpoint("in_app_runner_started");
-    const inAppFinished = collectChild(inAppRunner);
+    const inAppFinished = collectChild(inAppRunner, (observation) => {
+      Object.assign(inAppDiagnostics, observation);
+      try {
+        checkpoint(stage);
+      } catch {
+        // Diagnostic I/O must not interrupt child output or lifecycle events.
+      }
+    });
     let awaitingPermit;
     await Promise.race([
       waitFor(
@@ -292,6 +309,7 @@ try {
       }),
     ]);
     const inAppWorkerPid = awaitingPermit?.processGroup?.pgid ?? 0;
+    inAppDiagnostics.workerPid = inAppWorkerPid;
     assert(inAppWorkerPid > 0, "in-app worker state omitted its exact PID");
     assert(
       awaitingPermit?.processGroup?.leader?.pid === inAppWorkerPid,
@@ -362,6 +380,7 @@ try {
     );
     const inAppHelperPid = helperProcess.pid;
     const inAppVendorPid = vendorProcess.pid;
+    Object.assign(inAppDiagnostics, { helperPid: inAppHelperPid, vendorPid: inAppVendorPid });
     for (const processRow of descendantProcesses(processSnapshot.rows, inAppWorkerPid)) {
       inAppPids.add(processRow.pid);
       observedPids.add(processRow.pid);
@@ -486,6 +505,7 @@ try {
     workerPid: process.pid,
     observedPids: [...observedPids],
     error: error instanceof Error ? error.message : String(error),
+    inAppDiagnostics,
   };
   process.exitCode = 1;
 } finally {
@@ -694,18 +714,24 @@ function waitForChild(child) {
   });
 }
 
-function collectChild(child) {
+function collectChild(child, observe) {
   if (!child.stdout || !child.stderr) throw new Error("child output pipes were not created");
   let stdout = "";
   let stderr = "";
   child.stdout.on("data", (chunk) => {
     stdout += chunk.toString("utf8");
+    observe({ stdoutBytes: Buffer.byteLength(stdout), codeEchoObserved: stdout.includes("CODE:") });
   });
   child.stderr.on("data", (chunk) => {
     stderr += chunk.toString("utf8");
+    observe({ stderrBytes: Buffer.byteLength(stderr) });
   });
   return new Promise((resolveChild, rejectChild) => {
     child.once("error", rejectChild);
-    child.once("close", (code, signal) => resolveChild({ code, signal, stdout, stderr }));
+    child.once("exit", (code, signal) => observe({ runnerExit: { code, signal } }));
+    child.once("close", (code, signal) => {
+      observe({ runnerClosed: true });
+      resolveChild({ code, signal, stdout, stderr });
+    });
   });
 }


### PR DESCRIPTION
Adds process and input-delivery facts to Windows acceptance failure output. Production login paths, timeouts, assertions and cleanup are unchanged. This investigates both Windows CI failures after #274; it does not claim to fix the underlying hang.

The diagnostic change is isolated from the pending #273 and 3.10.0 release candidate. Native Windows evidence will come from this CI run.

Ouroboros